### PR TITLE
fix: update bluefin-dx.md: s/Jetbrains/JetBrains

### DIFF
--- a/_docs/bluefin-dx.md
+++ b/_docs/bluefin-dx.md
@@ -148,17 +148,17 @@ You can add packages and call init hooks from this file, ensuring that your dist
 
 ## JetBrains
 
-`ujust jetbrains-toolbox` will fetch and install the [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app) application, which will manage the installation of the JetBrains set of tools. This application will handle installation, removal, and upgrade of the JetBrains products, and is handled completely in your home directory, independent of the operating system image. We do not recommend using the Jetbrains flatpaks. 
+`ujust jetbrains-toolbox` will fetch and install the [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app) application, which will manage the installation of the JetBrains set of tools. This application will handle installation, removal, and upgrade of the JetBrains products, and is handled completely in your home directory, independent of the operating system image. We do not recommend using the JetBrains flatpaks. 
 
-- Check the [Jetbrains documentation](https://www.jetbrains.com/help/idea/podman.html) for integrating those tools with the podman runtime. 
-- Check out how to [setup Jetbrains with devcontainers](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html)
+- Check the [JetBrains documentation](https://www.jetbrains.com/help/idea/podman.html) for integrating those tools with the podman runtime. 
+- Check out how to [setup JetBrains with devcontainers](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html)
 - [Uninstallation instructions](https://toolbox-support.jetbrains.com/hc/en-us/articles/115001313270-How-to-uninstall-Toolbox-App-)
 
-The Jetbrains blog also has more information on Jetbrains Dev Containers support:
+The JetBrains blog also has more information on JetBrains Dev Containers support:
 
 - [Using Dev Containers in JetBrains IDEs](https://blog.jetbrains.com/idea/2024/07/using-dev-containers-in-jetbrains-ides-part-1/) – Part 1
 
-Devpod also has support for Jetbrains
+Devpod also has support for JetBrains
 
 - [Devpod Quickstart JetBrains](https://devpod.sh/docs/getting-started/quickstart-jetbrains)
 


### PR DESCRIPTION
The company name is spelled as "JetBrains", not "Jetbrains".