### PR TITLE
Corrected spelling error

### DIFF
--- a/_docs/administration.md
+++ b/_docs/administration.md
@@ -200,7 +200,7 @@ Bluefin and Aurora include Cockpit for machine management. We're hoping to inclu
 
 > Note that the Bluefin team lacks expertise in both fish and zsh, contributions to help us reach feature parity would be welcome and appreciated!
 
-Bluefin ships [pytxis](https://devsuite.app/ptyxis/) as the default terminal. It shows up as `Terminal` in the menu. It is **strongly recommended** that you [change your shell via the terminal emulator instead of system-wide](https://tim.siosm.fr/blog/2023/12/22/dont-change-defaut-login-shell/). Click on the Terminal settings and edit your profile:
+Bluefin ships [Ptyxis](https://devsuite.app/ptyxis/) as the default terminal. It shows up as `Terminal` in the menu. It is **strongly recommended** that you [change your shell via the terminal emulator instead of system-wide](https://tim.siosm.fr/blog/2023/12/22/dont-change-defaut-login-shell/). Click on the Terminal settings and edit your profile:
 
 ![image](https://github.com/user-attachments/assets/2c122205-dbd8-41e6-8b7b-4f536c3b69e9)
 


### PR DESCRIPTION
this was mentioned in the bazzite discord since this part of the documentation was copied into bazzite's docs and we all missed the spelling error of the terminal we ship.  i'm glad fedora now ships it and simply calls it terminal.