### PR TITLE
Navbar reorganization and clickable titles

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -14,12 +14,12 @@
     - title: "Press Kit"
       url: press-kit
 - title: Contributing
-  url: ""
+  url: "contributing"
   links:
-    - title: "Building Locally"
-      url: local
     - title: "Contributor's Guide"
       url: contributing
+    - title: "Building Locally"
+      url: local
 - title: Framework Laptops
   url: "framework"
   links:
@@ -29,8 +29,11 @@
       url: framework-16
 - title: "T2 Macs (2018-2020)"
   url: "t2-mac"
+  links:
+    - title: "T2 Macs on Bluefin"
+      url: "t2-mac"
 - title: Supporting the Project
-  url: ""
+  url: "Donations"
   links:
     - title: "Donations"
       url: donations


### PR DESCRIPTION
Minor edits to the navigation for the documentation.  Titles now go to the first link (instead of back to the intro documentation) and some minor edits like moving contributing guide above building locally and a subsection for T2 (which goes to the same place) for consistency.