### PR TITLE
feat: dark mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 
+# fix for error https://github.com/ffi/ffi/issues/1103:
+#   ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is
+gem "ffi", "< 1.17"
+
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ description: > # this means to ignore newlines until "baseurl:"
   The next generation Linux workstation, designed for reliability, performance, and sustainability. Built for the love of the game. Welcome to indie Cloud Native.
 
 # Add your baseurl here (your repository) but DO NOT CHANGE THE LINE NUMBER without editing .circleci/circle_urls.sh
-baseurl: "/" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 
 # This is mostly for testing
 url: "https://docs.projectbluefin.io" # the base hostname & protocol for your site

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,12 @@
   <div class="container-fluid mx-sm-5">
     <div class="row">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
-        <ul class="list-inline mb-0">  
+        <ul class="list-inline mb-0">
+          <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
+            <a class="text-white" target="_blank" href="{{ site.repo }}">
+              <i class="fab fa-github"></i>
+            </a>
+          </li>
           {% if site.twitter %}
             <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Twitter" data-original-title="Twitter">
               <a class="text-white" target="_blank" href="https://twitter.com/{{ site.twitter }}">
@@ -20,17 +25,69 @@
         </ul>
       </div>
       <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
-        <ul class="list-inline mb-0">  
-          <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
-            <a class="text-white" target="_blank" href="{{ site.repo }}">
-              <i class="fab fa-github"></i>
-            </a>
+        <ul class="list-inline mb-0">
+          <li class="list-inline-item mr-0" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Light Theme" data-original-title="Toggle Light Theme">
+
+            <button
+              type="button"
+              class="btn td-border-none p-0"
+              aria-label="Light Theme"
+              data-theme-toggle="light"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class=""
+              >
+                <circle cx="12" cy="12" r="4"></circle>
+                <path d="M12 2v2"></path>
+                <path d="M12 20v2"></path>
+                <path d="m4.93 4.93 1.41 1.41"></path>
+                <path d="m17.66 17.66 1.41 1.41"></path>
+                <path d="M2 12h2"></path>
+                <path d="M20 12h2"></path>
+                <path d="m6.34 17.66-1.41 1.41"></path>
+                <path d="m19.07 4.93-1.41 1.41"></path>
+              </svg>
+            </button>
+          </li>
+          <li class="list-inline-item" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Dark Theme" data-original-title="Toggle Dark Theme">
+
+            <button
+              type="button"
+              class="btn td-border-none p-0"
+              aria-label="Dark Theme"
+              data-theme-toggle="dark"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class=""
+              >
+                <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+              </svg>
+            </button>
+
           </li>
         </ul>
       </div>
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
         <small class="text-white">© {{ 'now' | date: "%Y" }} {{ site.author }} All Rights Reserved</small>
-        <p class="text-white">Bluefin is built with <a href=https://universal-blue.org">Universal Blue</a>. Evolve.</p>	
+        <p class="text-white">Bluefin is built with <a href=https://universal-blue.org">Universal Blue</a>. Evolve.</p>
       </div>
     </div>
   </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,62 +26,15 @@
       </div>
       <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
         <ul class="list-inline mb-0">
-          <li class="list-inline-item mr-0" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Light Theme" data-original-title="Toggle Light Theme">
-
-            <button
-              type="button"
-              class="btn td-border-none p-0"
-              aria-label="Light Theme"
-              data-theme-toggle="light"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class=""
-              >
-                <circle cx="12" cy="12" r="4"></circle>
-                <path d="M12 2v2"></path>
-                <path d="M12 20v2"></path>
-                <path d="m4.93 4.93 1.41 1.41"></path>
-                <path d="m17.66 17.66 1.41 1.41"></path>
-                <path d="M2 12h2"></path>
-                <path d="M20 12h2"></path>
-                <path d="m6.34 17.66-1.41 1.41"></path>
-                <path d="m19.07 4.93-1.41 1.41"></path>
-              </svg>
-            </button>
+          <li class="list-inline-item h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Light Theme" data-original-title="Toggle Light Theme">
+            <a class="text-white" href="#" data-theme-toggle="light">
+              <i class="fas fa-sun"></i>
+            </a>
           </li>
-          <li class="list-inline-item" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Dark Theme" data-original-title="Toggle Dark Theme">
-
-            <button
-              type="button"
-              class="btn td-border-none p-0"
-              aria-label="Dark Theme"
-              data-theme-toggle="dark"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class=""
-              >
-                <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
-              </svg>
-            </button>
-
+          <li class="list-inline-item h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Toggle Dark Theme" data-original-title="Toggle Dark Theme">
+            <a class="text-white" href="#" data-theme-toggle="dark">
+              <i class="fas fa-moon"></i>
+            </a>
           </li>
         </ul>
       </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,6 +36,7 @@
 
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/palette.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/palette-dark.css">
 <script
   src="{{ site.baseurl }}/assets/js/jquery-3.3.1/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha256-T+aPohYXbm0fRYDpJLr+zJ9RmYTswGsahAoIsNiMld4="

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en" class="no-js dark">
   <!-- Copyright 2019-2021 Vanessa Sochat-->
   {% include head.html %}
   {% include google-analytics.html %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18618,41 +18618,46 @@ footer {
 
 /* Dark mode overrides */
 :root {
-    --zinc-300: rgb(212 212 216);
-    --zinc-500: rgb(113 113 122);
-    --zinc-700: rgb(63 63 70);
-    --zinc-800: rgb(39 39 42);
-    --zinc-900: rgb(24 24 27);
+    --dark-300: #cbd5e1;
+    --dark-500: #64748b;
+    --dark-700: #334155;
+    --dark-800: #1e293b;
+    --dark-900: #0f172a;
+    --dark-950: #020617;
 }
 
 html.dark body {
-    background-color: var(--zinc-900);
-    color: var(--zinc-500);
+    background-color: var(--dark-900);
+    color: var(--dark-500);
 }
 
 html.dark .td-sidebar-nav__section-title a {
-    color: var(--zinc-500);
+    color: var(--dark-500);
 
     &:hover {
-        color: var(--zinc-300);
+        color: var(--dark-300);
     }
 }
 
 html.dark .td-toc {
-    border-color: var(--zinc-700);
+    border-color: var(--dark-700);
 }
 
-html:not(.dark) [data-theme-toggle=light] {
-    color: var(--zinc-500) !important;
+[data-theme-toggle] {
+    transition: color 300ms ease-in;
 }
 
-html.dark [data-theme-toggle=dark] {
-    color: var(--zinc-500) !important;
+html:not(.dark) [data-theme-toggle=dark] {
+    color: var(--dark-500) !important;
+}
+
+html.dark [data-theme-toggle=light] {
+    color: var(--dark-500) !important;
 }
 
 @media(min-width:768px) {
     html.dark .td-sidebar {
-        background-color: var(--zinc-800);
-        border-color: var(--zinc-700);
+        background-color: var(--dark-800);
+        border-color: var(--dark-700);
     }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18614,5 +18614,37 @@ footer {
         margin-top: 30px;
         margin-bottom: 30px;
     }
-    
+}
+
+/* Dark mode overrides */
+html.dark {
+    --zinc-300: rgb(212 212 216);
+    --zinc-500: rgb(113 113 122);
+    --zinc-700: rgb(63 63 70);
+    --zinc-800: rgb(39 39 42);
+    --zinc-900: rgb(24 24 27);
+}
+
+html.dark body {
+    background-color: var(--zinc-900);
+    color: var(--zinc-500);
+}
+
+html.dark .td-sidebar-nav__section-title a {
+    color: var(--zinc-500);
+
+    &:hover {
+        color: var(--zinc-300);
+    }
+}
+
+html.dark .td-toc {
+    border-color: var(--zinc-700);
+}
+
+@media(min-width:768px) {
+    html.dark .td-sidebar {
+        background-color: var(--zinc-800);
+        border-color: var(--zinc-700);
+    }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18617,7 +18617,7 @@ footer {
 }
 
 /* Dark mode overrides */
-html.dark {
+:root {
     --zinc-300: rgb(212 212 216);
     --zinc-500: rgb(113 113 122);
     --zinc-700: rgb(63 63 70);
@@ -18640,6 +18640,14 @@ html.dark .td-sidebar-nav__section-title a {
 
 html.dark .td-toc {
     border-color: var(--zinc-700);
+}
+
+html:not(.dark) [data-theme-toggle=light] {
+    color: var(--zinc-500) !important;
+}
+
+html.dark [data-theme-toggle=dark] {
+    color: var(--zinc-500) !important;
 }
 
 @media(min-width:768px) {

--- a/assets/css/palette-dark.css
+++ b/assets/css/palette-dark.css
@@ -1,0 +1,85 @@
+html.dark {
+
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #f8f8f2;
+  background-color: #272822;
+}
+.highlight .err {
+  color: #272822;
+  background-color: #f92672;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #75715e;
+}
+.highlight .cp {
+  color: #f4bf75;
+}
+.highlight .nt {
+  color: #f4bf75;
+}
+.highlight .o, .highlight .ow {
+  color: #f8f8f2;
+}
+.highlight .p, .highlight .pi {
+  color: #f8f8f2;
+}
+.highlight .gi {
+  color: #a6e22e;
+}
+.highlight .gd {
+  color: #f92672;
+}
+.highlight .gh {
+  color: #66d9ef;
+  background-color: #272822;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
+  color: #ae81ff;
+}
+.highlight .kc {
+  color: #fd971f;
+}
+.highlight .kt {
+  color: #fd971f;
+}
+.highlight .kd {
+  color: #fd971f;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+  color: #a6e22e;
+}
+.highlight .sa {
+  color: #ae81ff;
+}
+.highlight .sr {
+  color: #a1efe4;
+}
+.highlight .si {
+  color: #cc6633;
+}
+.highlight .se {
+  color: #cc6633;
+}
+.highlight .nn {
+  color: #f4bf75;
+}
+.highlight .nc {
+  color: #f4bf75;
+}
+.highlight .no {
+  color: #f4bf75;
+}
+.highlight .na {
+  color: #66d9ef;
+}
+.highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #a6e22e;
+}
+.highlight .ss {
+  color: #a6e22e;
+}
+
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -63,20 +63,23 @@ layout: null
     var Theme = {
         init: function () {
             const htmlClasses = document.documentElement.classList;
-            const savedTheme = localStorage.getItem("theme");
+            const savedTheme = localStorage.theme;
             const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-
-            if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
-                htmlClasses.add("dark");
+            const klass = "dark";
+            
+            if (savedTheme === klass || (!savedTheme && prefersDark)) {
+                htmlClasses.add(klass);
+            } else {
+                htmlClasses.remove(klass);
             }
 
             $(document).ready(function () {
                 $(document).on("click", "[data-theme-toggle]", function (e) {
                     const mode = e.currentTarget.dataset.themeToggle;
-                    htmlClasses.remove("light", "dark");
+                    htmlClasses.remove(klass);
                     htmlClasses.toggle(mode);
 
-                    localStorage.setItem("theme", mode);
+                    localStorage.theme = mode;
                 });
             });
         },

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -61,7 +61,7 @@ layout: null
 (function ($) {
     'use strict';
     var Theme = {
-        init: function () {
+        init: function() {
             const htmlClasses = document.documentElement.classList;
             const savedTheme = localStorage.theme;
             const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -73,8 +73,11 @@ layout: null
                 htmlClasses.remove(klass);
             }
 
-            $(document).ready(function () {
+            $(document).ready(function() {
                 $(document).on("click", "[data-theme-toggle]", function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
                     const mode = e.currentTarget.dataset.themeToggle;
                     htmlClasses.remove(klass);
                     htmlClasses.toggle(mode);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -58,3 +58,28 @@ layout: null
     };
     Search.init();
 }(jQuery));
+(function ($) {
+    'use strict';
+    var Theme = {
+        init: function () {
+            const htmlClasses = document.documentElement.classList;
+            const savedTheme = localStorage.getItem("theme");
+            const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+            if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+                htmlClasses.add("dark");
+            }
+
+            $(document).ready(function () {
+                $(document).on("click", "[data-theme-toggle]", function (e) {
+                    const mode = e.currentTarget.dataset.themeToggle;
+                    htmlClasses.remove("light", "dark");
+                    htmlClasses.toggle(mode);
+
+                    localStorage.setItem("theme", mode);
+                });
+            });
+        },
+    };
+    Theme.init();
+}(jQuery));

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   site:
     container_name: docsy

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,6 @@ excluded_in_search: true
 ---
 
 <input class="form-control td-search-input" type="search" name="q" id="search-input" placeholder="&#xf002 Search this site…"  style="margin-top:5px" autofocus>
-<i style="color:white; margin-right:8px; margin-left:5px" class="fa fa-search"></i>
 
 <p><span id="search-process">Loading</span> results <span id="search-query-container" style="display: none;">for "<strong id="search-query"></strong>"</span></p>
 


### PR DESCRIPTION
closes #1

This makes minimal changes to implement a dark mode (I also found myself wanting it :sweat_smile:)

* rearrange the footer to make room for light/dark icons
* theme function that defaults to dark mode if user's system set to dark
* color palette heavily borrowing from Tailwind's [slate scheme](https://tailwindcss.com/docs/customizing-colors) (in the spirit of "blue")
* syntax highlighting dark variant based on rouge's `base16.monokai.dark`

(It also required fixing a couple minor issues to get Jekyll working in development) 

---


https://github.com/user-attachments/assets/65bd4313-a6f7-4669-9baa-d63dd37dd782

