### PR TITLE
fix(ci): run deployment job on main branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main'
     needs: build
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment


### PR DESCRIPTION
This should stop jobs during PRs from failing when trying to deploy to GitHub Pages.