### PR TITLE
Update ai to include mention of straight ollama and not just alpaca

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -9,6 +9,13 @@ GPU Acceleration for both Nvidia and AMD are included out of the box and usually
 
 ### Desktop integration
 
-[Install alpaca](https://flathub.org/apps/com.jeffser.Alpaca) to use a native desktop application. Alpaca supports Nvidia and AMD acceleration natively and includes ollama. If you prefer an all-GUI solution just use Alpaca and manage your models from within the application.
+[Install alpaca](https://flathub.org/apps/com.jeffser.Alpaca) to use a native desktop application. If you prefer an all-GUI solution just use Alpaca and manage your models from within the application. Alpaca supports Nvidia and AMD acceleration natively and _includes ollama_. 
 
 ![image](https://github.com/user-attachments/assets/9fd38164-e2a9-4da1-9bcd-29e0e7add071)
+
+
+### Ollama CLI
+
+If you prefer a CLI or to interact with the ollama server from your scripts, then you can install ollama with either 
+- `brew install ollama` (recommended) with [Homebrew](https://formulae.brew.sh/formula/ollama)
+- The installation script from the [ollama website](https://ollama.com, but will require some manual tweaks in their docs to get it in your path.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -13,9 +13,9 @@ GPU Acceleration for both Nvidia and AMD are included out of the box and usually
 
 ![image](https://github.com/user-attachments/assets/9fd38164-e2a9-4da1-9bcd-29e0e7add071)
 
-
 ### Ollama CLI
 
 If you prefer a CLI or to interact with the ollama server from your scripts, then you can install ollama with either 
+
 - `brew install ollama` (recommended) with [Homebrew](https://formulae.brew.sh/formula/ollama)
-- The installation script from the [ollama website](https://ollama.com, but will require some manual tweaks in their docs to get it in your path.
+- The installation script from the [ollama website](https://ollama.com), but will require some manual tweaks in their docs to get it in your path.


### PR DESCRIPTION
While I prefer Alpaca, now people are confused if this is the _only_ way to run ai, etc. Might as well mention brew install ollama since it's there and works well. https://universal-blue.discourse.group/t/has-ujust-ollama-web-been-removed/4336/18