### PR TITLE
Fix ujust command for installing k8s dev tools

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:    
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -3,23 +3,23 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:    
+  workflow_dispatch:
 jobs:
   pdf:
     runs-on: ubuntu-latest
-    steps: 
-    - name: Install Prince
-      run: |
-        curl https://www.princexml.com/download/prince-15.4.1-linux-generic-x86_64.tar.gz -O
-        tar zxf prince-15.4.1-linux-generic-x86_64.tar.gz
-        cd prince-15.4.1-linux-generic-x86_64
-        yes "" | sudo ./install.sh
-    - name: Build PDF
-      run: npx docusaurus-prince-pdf -u https://docs.projectbluefin.io -o pdf/bluefin.pdf
-    - name: Upload results
-      uses: actions/upload-artifact@v4
-      with:
-        name: bluefin
-        # The output filename can be specified with --output option
-        path: pdf/bluefin.pdf
-        if-no-files-found: error
+    steps:
+      - name: Install Prince
+        run: |
+          curl https://www.princexml.com/download/prince-15.4.1-linux-generic-x86_64.tar.gz -O
+          tar zxf prince-15.4.1-linux-generic-x86_64.tar.gz
+          cd prince-15.4.1-linux-generic-x86_64
+          yes "" | sudo ./install.sh
+      - name: Build PDF
+        run: npx docusaurus-prince-pdf -u https://docs.projectbluefin.io -o pdf/bluefin.pdf
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluefin
+          # The output filename can be specified with --output option
+          path: pdf/bluefin.pdf
+          if-no-files-found: error

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -32,7 +32,7 @@ The [brew](https://brew.sh/) application is the package manager used for install
 - [Homebrew Packages](https://formulae.brew.sh/)
 - [Cheatsheet](https://devhints.io/homebrew)
 
-Note that the cask functionality in homebrew is MacOS specific and non functional in Bluefin, flatpak is used instead. 
+Note that the cask functionality in homebrew is MacOS specific and non functional in Bluefin, flatpak is used instead.
 
 ## System Updates
 
@@ -44,7 +44,7 @@ Machine firmware updates are provided through the standard Software Center:
 
 ### Upgrades and Throttle Settings
 
-Bluefin publishes images based on the current and last stable version of Fedora. This is to give users maximum flexibility by allowing them to rebase to the version they want. You can choose from three rolling tags, or lock to a specific version of Fedora. Check the [release notes](https://github.com/ublue-os/bluefin/releases) for specific version information. 
+Bluefin publishes images based on the current and last stable version of Fedora. This is to give users maximum flexibility by allowing them to rebase to the version they want. You can choose from three rolling tags, or lock to a specific version of Fedora. Check the [release notes](https://github.com/ublue-os/bluefin/releases) for specific version information.
 
 |                      | `gts` (default) | `stable` or `stable-daily` | `latest`       |
 | -------------------- | --------------- | -------------------------- | -------------- |
@@ -68,7 +68,6 @@ The major difference between `latest` and `stable` is the kernel cadence and whe
 One of Bluefin's strengths is being able to atomically adjust versions. All the tags are built from the same repository and are essentially the same, the version numbers will just be different. `gts` for a work machine and `stable` for your hot rod. Additionally the ability to rebase between release cadences lets users repurpose machines for different use cases without needing to reinstall.
 
 :::
-
 
 #### Gated Kernel
 
@@ -171,7 +170,6 @@ skopeo inspect docker://ghcr.io/ublue-os/bluefin
 This will show all the available tags and useful metadata like image and kernel versions.
 
 Check the [Fedora Silverblue User Guide](https://docs.fedoraproject.org/en-US/fedora-silverblue/) for more information.
-
 
 ### Virtual Private Networks (VPN)
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -5,11 +5,11 @@ slug: /ai
 
 # AI and Machine Learning
 
-GPU Acceleration for both Nvidia and AMD are included out of the box and usually do not require any extra setup. 
+GPU Acceleration for both Nvidia and AMD are included out of the box and usually do not require any extra setup.
 
 ### Ollama GUI
 
-[Install Alpaca](https://flathub.org/apps/com.jeffser.Alpaca) to manage and chat with your LLM models from within a native desktop application. Alpaca supports Nvidia and AMD acceleration natively and *includes ollama*. 
+[Install Alpaca](https://flathub.org/apps/com.jeffser.Alpaca) to manage and chat with your LLM models from within a native desktop application. Alpaca supports Nvidia and AMD acceleration natively and _includes ollama_.
 
 ![image](https://github.com/user-attachments/assets/9fd38164-e2a9-4da1-9bcd-29e0e7add071)
 
@@ -18,11 +18,14 @@ GPU Acceleration for both Nvidia and AMD are included out of the box and usually
 Since Alpaca doesn't expose any API, if you need other applications than Alpaca to interact with your ollama instance (for example an IDE) you should consider installing it [in a docker container](https://hub.docker.com/r/ollama/ollama).
 
 To do so, first configure docker to use the nvidia drivers (that come preinstalled with Bluefin) with:
+
 ```bash
 sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 ```
+
 Then, choose a folder where to install the ollama container (for example `~/Containers/ollama`) and inside it create a new file named `docker-compose.yaml` with the following content:
+
 ```yaml
 ---
 services:
@@ -41,11 +44,14 @@ services:
             - capabilities:
                 - gpu
 ```
+
 Finally, open a terminal in the folder containing the file just created and start the container with
+
 ```bash
 docker compose up -d
 ```
+
 and your ollama instance should be up and running at `http://127.0.0.1:11434`!
 
-> **NOTE:** if you still want to use Alpaca as one of the way of interacting with Ollama, you can open the application, then go to *Preferences*, toggle the option *Use the Remote Connection to Ollama*, specify the endpoint above (`http://127.0.0.1:11434`) as *Server URL* (leave *Bearer Token* empty) in the dialog that will pop up and then press *Connect*.
-> This way you should be able to manage the models installed on your ollama container and chat with them from the Alpaca GUI. 
+> **NOTE:** if you still want to use Alpaca as one of the way of interacting with Ollama, you can open the application, then go to _Preferences_, toggle the option _Use the Remote Connection to Ollama_, specify the endpoint above (`http://127.0.0.1:11434`) as _Server URL_ (leave _Bearer Token_ empty) in the dialog that will pop up and then press _Connect_.
+> This way you should be able to manage the models installed on your ollama container and chat with them from the Alpaca GUI.

--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -33,7 +33,7 @@ Homebrew can also be used for installation of development tools. However it is r
 
 # Enabling Developer Mode
 
-Turning on developer mode is a two step process: 
+Turning on developer mode is a two step process:
 
 ## Step 1: Turn it on
 

--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -15,25 +15,25 @@ Bluefin goes "all in" on cloud native development and is used differently than a
 
 - Development is done in [devcontainers](https://containers.dev/)
 - Command line applications are installed using [homebrew](https://brew.sh)
-- Preconfigured ad-hoc containers for Ubuntu, Fedora, and Wolfi. Use whichever distribution you want.
+- Preconfigured ad-hoc containers for Ubuntu, Fedora, and Wolfi are included. Use whichever distribution you want.
 
-This differs from traditional distributions by making the development process operating system agnostic. There is no equivalent to `apt install php` on Bluefin, development is done with `podman` or `docker` directly via an IDE.
+This differs from traditional distributions by making the development process operating system agnostic. There is no equivalent to `apt install php` on Bluefin; development is done with `podman` or `docker` directly via an IDE.
 
 > We picked the cloud native pattern because local development in containers translates to deployment of containers on modern infrastructure.
 
 ![image](https://github.com/user-attachments/assets/51415b6c-b7fe-45e9-af74-c01694b26fbe)
 
-The pattern in `bluefin-dx` (and `aurora-dx`) is centered around [devcontainers](https://containers.dev). Since the devcontainers live in the project's git repository, and they can deployed on any operating system, Linux, MacOS, or Windows (via WSL). This facilitates "distributed by default" development and avoids Linux users being "the odd one out" when working with teammates on other operating systems.
+The pattern in `bluefin-dx` (and `aurora-dx`) is centered around [devcontainers](https://containers.dev). Since devcontainers live in the project's git repository, they can be deployed on any operating system: Linux, MacOS, or Windows (via WSL). This facilitates "distributed by default" development and avoids Linux users being "the odd one out" when working with teammates on other operating systems.
 
-Each project has a declarative environment that is intended to be start the user with a "best practice" cloud-native workflow out of the box. The [Ultimate Guide to Dev Containers](https://www.daytona.io/dotfiles/ultimate-guide-to-dev-containers) has a good write up of the advantages of using devcontainers. This means that the development environment is kept in version control instead of coupled to the host.
+Each project includes a declarative environment intended to start the user with a "best practice" cloud-native workflow out of the box. The [Ultimate Guide to Dev Containers](https://www.daytona.io/dotfiles/ultimate-guide-to-dev-containers) has a good write-up on the advantages of using devcontainers. This means that the development environment is kept in version control instead of coupled to the host.
 
-Homebrew can also be used for installation of development tools. However it is recommended to avoid that and declare the project's dependencies in version control. It's so easy sometimes, [it's okay](https://www.youtube.com/shorts/lKwavoyaaFA).
+Homebrew can also be used to install development tools. However, it is recommended to avoid that and declare the project's dependencies in version control. It's so easy sometimes, [it's okay](https://www.youtube.com/shorts/lKwavoyaaFA).
 
-> You can always use whatever you want, you do not need to use everything in here in order to be productive -- at the end of the day it's your computer, this is just a set of defaults.
+> You can always use whatever you want. You do not need to use everything in here in order to be productive -- at the end of the day it's your computer and this is just a set of defaults.
 
 # Enabling Developer Mode
 
-Turning on developer mode is a two step process:
+Turning on developer mode is a two-step process:
 
 ## Step 1: Turn it on
 
@@ -51,7 +51,7 @@ Like all Universal Blue images, switching is atomic, allowing for clean switchin
 
 ## Visual Studio Code with Docker
 
-[Visual Studio Code](https://code.visualstudio.com/) is included on the image as the default IDE. It comes with the [devcontainers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) already installed. It's the recommended developer experience, start here if you're new to containerized development!
+[Visual Studio Code](https://code.visualstudio.com/) is included in the image as the default IDE. It comes with the [devcontainers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) already installed. It's the recommended developer experience, so start here if you're new to containerized development!
 
 - [Dev Containers Documentation](https://code.visualstudio.com/docs/devcontainers/containers) - you can skip most of the installation instructions and go directly to [the tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial#_install-the-extension)
 - [Dev Containers Specification](https://containers.dev/)
@@ -63,7 +63,7 @@ The most current [Docker Engine](https://docs.docker.com/engine/) is included by
 
 ## Devpod
 
-DevPod is an open source tool used to create reproducible developer environments. Each developer environment runs in a separate container and is specified through a `devcontainer.json`. Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost `docker`.
+DevPod is an open source tool used to create reproducible developer environments. Each developer environment runs in a separate container and is specified through a `devcontainer.json` file. It's like Codespaces but is open-source, client-only, and unopinionated: it works with any IDE and lets you use any cloud, Kubernetes, or even local `docker` environment.
 
 - [Devpod Website](https://devpod.sh/)
 - [Devpod Documentation](https://devpod.sh/docs/what-is-devpod)
@@ -78,11 +78,11 @@ Check out this talk from [Rich Burroughs](https://timeline.richburroughs.dev/):
 
 ![Podman Desktop](https://github.com/user-attachments/assets/69f64ed1-7fcc-4040-9a3d-12b71308da1b)
 
-[Podman Desktop](https://podman-desktop.io/) is included to provide container management. Check out the Podman Desktop [documentation](https://podman-desktop.io/docs/intro) for more information. All the upstream `podman` tools are included. This is the default system container runtime, and is the recommended developer configuration that Fedora ships with.
+[Podman Desktop](https://podman-desktop.io/) is included to provide container management. Check out the Podman Desktop [documentation](https://podman-desktop.io/docs/intro) for more information. All the upstream `podman` tools are included. This is the default system container runtime and is the recommended developer configuration that Fedora ships with.
 
-> Though Bluefin defaults to docker and vscode for development, all of the Fedora upstream tools are included for those that prefer that experience.
+> Though Bluefin defaults to docker and vscode for development, all of the Fedora upstream tools are included for those who prefer that experience.
 
-## Built in Performance Tooling
+## Built-in Performance Tooling
 
 [Sysprof](https://www.sysprof.com/) is included as a systemwide performance profiler. As well as [Brendan Gregg's](https://www.brendangregg.com/) recommended CLI tools:
 
@@ -93,7 +93,7 @@ Thanks to Ubuntu and Canonical for the [detailed specification](https://discours
 ## Quality of Life Improvements
 
 - [Cockpit](https://cockpit-project.org/) for local and remote management
-- A collection of well curated monospace fonts
+- A collection of well-curated monospace fonts
 - [Tailscale](https://universal-blue.discourse.group/t/tailscale-vpn-on-bluefin/290) for VPN
 - [Just](https://github.com/casey/just) task runner for automation tasks
 - `fish` and `zsh` available as optional shells
@@ -111,7 +111,7 @@ Thanks to Ubuntu and Canonical for the [detailed specification](https://discours
 - [fzf](https://github.com/junegunn/fzf) for command line fuzzy finding
 - [ripgrep](https://github.com/BurntSushi/ripgrep) for search
 - [tealdeer](https://github.com/dbrgn/tealdeer) for `tldr`
-- [television](https://github.com/alexpasmantier/television) - a blazing fast general purpose fuzzy finder TUI - (`tv`)
+- [television](https://github.com/alexpasmantier/television) - a blazing fast general-purpose fuzzy finder TUI - (`tv`)
 - [trash-cli](https://github.com/andreafrancia/trash-cli) to manage the system trashcan. (Strongly recommended for new CLI users)
 - [ugrep](https://github.com/Genivia/ugrep) for grep
 - [yq](https://github.com/mikefarah/yq) - for yaml, json, and xml processing
@@ -131,7 +131,7 @@ Use BoxBuddy's interface to create your own pet containers from whichever distri
 
 ![image](https://github.com/user-attachments/assets/79570148-98f9-458f-b46e-2a87cfaa00ed)
 
-For CLI warriors you can manage your containers with the Terminal's built in container support:
+For CLI warriors you can manage your containers with the Terminal's built-in container support:
 
 ![image](https://github.com/user-attachments/assets/2a4dc4b5-f1a8-4781-80a4-92ea4dfeeb97)
 
@@ -153,9 +153,9 @@ The included [Terminal](https://gitlab.gnome.org/chergert/ptyxis) includes a hos
 
 The JetBrains blog also has more information on JetBrains Dev Containers support:
 
-- [Using Dev Containers in JetBrains IDEs](https://blog.jetbrains.com/idea/2024/07/using-dev-containers-in-jetbrains-ides-part-1/) – Part 1
+- [Using Dev Containers in JetBrains IDEs – Part 1](https://blog.jetbrains.com/idea/2024/07/using-dev-containers-in-jetbrains-ides-part-1/)
 
-Devpod also has support for JetBrains
+Devpod also has support for JetBrains:
 
 - [Devpod Quickstart JetBrains](https://devpod.sh/docs/getting-started/quickstart-jetbrains)
 
@@ -178,4 +178,4 @@ Devpod also has support for JetBrains
 
 - [virt-manager](https://virt-manager.org/) and associated tooling (KVM, qemu)
 - [Incus](https://linuxcontainers.org/incus/) provides system containers
-  - [LXC](https://linuxcontainers.org/) and [LXD](https://ubuntu.com/lxd) are also provided for compatibility reasons, however these tools are deprecated and will be removed in Spring 2025
+  - [LXC](https://linuxcontainers.org/) and [LXD](https://ubuntu.com/lxd) are also provided for compatibility reasons, however, these tools are deprecated and will be removed in Spring 2025

--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -61,13 +61,13 @@ Like all Universal Blue images, switching is atomic, allowing for clean switchin
 
 The most current [Docker Engine](https://docs.docker.com/engine/) is included by default and is set up to be the default container runtime for vscode. Using [docker compose](https://danielquinn.org/blog/developing-with-docker/) is also a great way to get started in container development and is an option if devcontainers don't fit your style.
 
-## Devpod
+## DevPod
 
 DevPod is an open source tool used to create reproducible developer environments. Each developer environment runs in a separate container and is specified through a `devcontainer.json` file. It's like Codespaces but is open-source, client-only, and unopinionated: it works with any IDE and lets you use any cloud, Kubernetes, or even local `docker` environment.
 
-- [Devpod Website](https://devpod.sh/)
-- [Devpod Documentation](https://devpod.sh/docs/what-is-devpod)
-- [Devpod Quickstart VS Code](https://devpod.sh/docs/getting-started/quickstart-vscode)
+- [DevPod Website](https://devpod.sh/)
+- [DevPod Documentation](https://devpod.sh/docs/what-is-devpod)
+- [DevPod Quickstart VS Code](https://devpod.sh/docs/getting-started/quickstart-vscode)
 - [Loft.sh](https://www.loft.sh/)
 
 Check out this talk from [Rich Burroughs](https://timeline.richburroughs.dev/):
@@ -155,16 +155,16 @@ The JetBrains blog also has more information on JetBrains Dev Containers support
 
 - [Using Dev Containers in JetBrains IDEs – Part 1](https://blog.jetbrains.com/idea/2024/07/using-dev-containers-in-jetbrains-ides-part-1/)
 
-Devpod also has support for JetBrains:
+DevPod also has support for JetBrains:
 
-- [Devpod Quickstart JetBrains](https://devpod.sh/docs/getting-started/quickstart-jetbrains)
+- [DevPod Quickstart JetBrains](https://devpod.sh/docs/getting-started/quickstart-jetbrains)
 
 ## Neovim
 
 `brew install neovim devcontainer` then follow these directions for a devcontainer setup:
 
 - [Running Neovim with Devcontainers](https://cadu.dev/running-neovim-on-devcontainers/)
-- [Devpod Quickstart for Neovim](https://devpod.sh/docs/getting-started/quickstart-vim)
+- [DevPod Quickstart for Neovim](https://devpod.sh/docs/getting-started/quickstart-vim)
 
 ## Kubernetes and other Cloud Native Tooling
 

--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -168,7 +168,7 @@ Devpod also has support for JetBrains
 
 ## Kubernetes and other Cloud Native Tooling
 
-`ujust k8s-dev-tools` to get started:
+`ujust install-k8s-dev-tools` to get started:
 
 - [kind](https://kind.sigs.k8s.io/) - Run a Kubernetes cluster on your machine. Run `kind create cluster` on the host to get started!
   - [kubectl](https://kubernetes.io/docs/reference/kubectl/) - Administer Kubernetes Clusters

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -129,7 +129,7 @@ If you come to the Discord you might be asked to report an issue or start a disc
 
 ### How to test incoming changes
 
-One of the nice things about the image model is that we can generate an entire OS image for every change we want to commit, so this makes testing way easier than in the past. 
+One of the nice things about the image model is that we can generate an entire OS image for every change we want to commit, so this makes testing way easier than in the past.
 You can rebase to it, see if it works, and then move back.
 This also means we can increase the amount of testers!
 

--- a/docs/donations.md
+++ b/docs/donations.md
@@ -7,19 +7,19 @@ slug: /donations
      <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 
-
 # Donations
 
-Sustainability is a key focus of Universal Blue, the project focuses on efficiency and long term health. Donations are appreciated, especially those that benefit the Linux application ecosystem. Donations cover the cost of the GitHub runners, sponsoring Paleoart for the OS, and hardware expenses. 
+Sustainability is a key focus of Universal Blue, the project focuses on efficiency and long term health. Donations are appreciated, especially those that benefit the Linux application ecosystem. Donations cover the cost of the GitHub runners, sponsoring Paleoart for the OS, and hardware expenses.
 
 # Bluefin Team
-Complete with actual job titles: 
+
+Complete with actual job titles:
 
 - [Brian Ketelsen](https://github.com/bketelsen) - Lead Developer Experience, Architect of The Final Shape (Emeritus)
 - [Benjamin Sherman](https://github.com/bsherman) - CTO
 - [m2Giles](https://github.com/m2Giles) - Lead Architect
-- <a class="github-button" href="https://github.com/sponsors/castrojo" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor @castrojo">Sponsor</a>    [Jorge Castro](https://github.com/castrojo/) - Product Development and co-maintainer 
-- <a class="github-button" href="https://github.com/sponsors/tulilirockz" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor tulilirockz">Sponsor</a>    [Tulip Blossom](https://github.com/tulilirockz)  Large Maniraptoran Specialist and co-maintainer
+- <a class="github-button" href="https://github.com/sponsors/castrojo" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor @castrojo">Sponsor</a> [Jorge Castro](https://github.com/castrojo/) - Product Development and co-maintainer
+- <a class="github-button" href="https://github.com/sponsors/tulilirockz" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor tulilirockz">Sponsor</a> [Tulip Blossom](https://github.com/tulilirockz) Large Maniraptoran Specialist and co-maintainer
 - [Robert Sturla](https://github.com/p5) - "Hold onto your butts" guy and Lead DevOps
 - ... this could be you! ...
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Bluefin is:
 - **Optimized for the 96%** - Not the 4% - Bluefin takes a "stronger together" approach towards features. You can always do what you want, but the value is to share best practices, the team doesn't spend much time on edge cases.
 - **Cloud Native** (For Developers) - The developer experience is focused around containers and exposing new Linux users to the [tools used in cloud native](https://www.cncf.io/). See Universal Blue's [mission statement](https://universal-blue.org/mission.html) for more information.
 
-If your requirements are outside of this scope, then **Bluefin might not be the best fit for you**. We recognize that in order to make a better desktop that many parts of the traditional Linux desktop experience will not be coming with us. [Here's a video](https://www.youtube.com/watch?v=4CyWH6jx2pE) on why we take such a focused approach to the desktop. The video is about [Bazzite.gg](https://bazzite.gg), which is a sister project, but the same applies. 
+If your requirements are outside of this scope, then **Bluefin might not be the best fit for you**. We recognize that in order to make a better desktop that many parts of the traditional Linux desktop experience will not be coming with us. [Here's a video](https://www.youtube.com/watch?v=4CyWH6jx2pE) on why we take such a focused approach to the desktop. The video is about [Bazzite.gg](https://bazzite.gg), which is a sister project, but the same applies.
 
 :::note[Begin your journey...]
 
@@ -36,7 +36,6 @@ If this appeals to you, then Bluefin is for you!
 > "Evolution is a process of constant branching and expansion."
 >
 > - Stephen Jay Gould
-
 
 ## Introductory Videos and Podcasts
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -59,7 +59,7 @@ Review the [Fedora Silverblue installation instructions](https://docs.fedoraproj
 
 - Use the [Fedora Media Writer](https://flathub.org/apps/org.fedoraproject.MediaWriter) to create installation media. Other creation methods may not work properly.
 - Dual booting off of the same disk is **unsupported**, use a dedicated drive for another operating system and use your BIOS to choose another OS to boot off of.
-  - Bluefin supports a [installation on an external drive](/tips/#bluefin-to-go-using-an-external-drive) if you want to try it on bare metal before committing. 
+  - Bluefin supports a [installation on an external drive](/tips/#bluefin-to-go-using-an-external-drive) if you want to try it on bare metal before committing.
 - We **strongly recommend** using automated partitioning during installation, there are [known issues](https://docs.fedoraproject.org/en-US/fedora-silverblue/installation/) with manual partition on Atomic systems and is unnecessary to set up unless you are on a multi-disk system.
 - A stock Bluefin installation is 11GB. Bluefin with developer mode enabled (`bluefin-dx`) is 19GB.
 - Read the installation runbook below to ensure your device and use case are supported by Bluefin!
@@ -82,7 +82,7 @@ Most pain points can be addressed directly by planning ahead of time.
   - Does the software you use require an out of tree kernel module?
     - VirtualBox and VMWare are not supported
     - Nvidia, Xbox One Controller Support, wl drivers, and v4l2loopback are supported. (These are "best effort", in certain cases we cannot control third party software that breaks with newer versions of the Linux kernel)
-    - [openzfs](https://github.com/openzfs/zfs) is included out of the box. It is used by maintainers regularly and has not yet fallen behind the kernels Bluefin ships. However, we still cannot guarantee this as it is an out of tree kernel module. 
+    - [openzfs](https://github.com/openzfs/zfs) is included out of the box. It is used by maintainers regularly and has not yet fallen behind the kernels Bluefin ships. However, we still cannot guarantee this as it is an out of tree kernel module.
   - Is your wireless card supported by Linux?
     - Poorly supported cards include Broadcom
     - Check [USB-Wifi](https://github.com/morrownr/USB-WiFi) if you are not sure
@@ -145,7 +145,7 @@ Bluefin strives to make maintenance as easy as possible, however many of the aut
   - `ujust changelogs` will show incoming changes and updates coming from Fedora
   - `ujust bios` will reboot the machine and enter the BIOS/UEFI menu. This is useful for booting into a Windows drive
 - Subscribe to the [announcements tag](https://universal-blue.discourse.group/tag/announcements) on the Universal Blue forums
-- Subscribe to the [release notes](https://github.com/ublue-os/bluefin/releases) 
+- Subscribe to the [release notes](https://github.com/ublue-os/bluefin/releases)
 - Understand [rebase and rollback procedures](/administration.md#switching-between-streams)
 - Use the [Warehouse application](https://github.com/flattool/warehouse) to manage Flatpak lifecycle:
   - Pin to an old version or rollback

--- a/docs/local.md
+++ b/docs/local.md
@@ -13,12 +13,12 @@ First clone the repo:
 
 The `Justfile` at the root of the repo is used to build the images and ISOs, here's some examples:
 
-| Command                                  | Description                                  |
-| ---------------------------------------- | -------------------------------------------- |
-| `just build bluefin`                     | Defaults to `latest` main                    |
-| `just build bluefin-dx gts`              | Builds `gts` only Bluefin DX                 |
-| `just build bluefin-dx beta nvidia`      | Builds `beta` `nvidia` version of Bluefin DX |
-| `just build bluefin stable nvidia`       | Builds `nvidia` version of the Bluefin stable branch |
+| Command                             | Description                                          |
+| ----------------------------------- | ---------------------------------------------------- |
+| `just build bluefin`                | Defaults to `latest` main                            |
+| `just build bluefin-dx gts`         | Builds `gts` only Bluefin DX                         |
+| `just build bluefin-dx beta nvidia` | Builds `beta` `nvidia` version of Bluefin DX         |
+| `just build bluefin stable nvidia`  | Builds `nvidia` version of the Bluefin stable branch |
 
 The general pattern is `just build/run image tag flavor`
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -37,11 +37,11 @@ Use Cases:
 - Great way to try Linux, if you like it, move the drive into your main machine without needing to reinstall.
   - Or if you want to commit, buy a new drive for your PC and then put your existing OS in an external case so you have a backup. Over time you may even put it in a drawer. 😈
 - Temporarily repurposing a machine.
-- Sharing a PC with a partner and you don't want to argue about Linux. 
+- Sharing a PC with a partner and you don't want to argue about Linux.
 - Trying out hardware before purchasing.
 - "Hot desking" and existing machine in an office.
 - Great for the homelab! Put all your favorite tools on there!
-- From @mikes-tech-tips: Add a Bluefin DX drive to your docked [Bazzite powered](https://bazzite.gg) handheld. Party in the front, business in the back. 
+- From @mikes-tech-tips: Add a Bluefin DX drive to your docked [Bazzite powered](https://bazzite.gg) handheld. Party in the front, business in the back.
 
 ### Windows to Go
 
@@ -52,7 +52,7 @@ Use cases are keeping Windows around for:
 - Hardware that may need Windows to update firmware.
 - Critical applications that have no equivalent in Linux, but you don't use it that often. Tax software, for example.
 - Your relatives are visiting and you don't want to argue about Linux.
-- You play Destiny 2. 
+- You play Destiny 2.
 
 ## Building Your Own Bluefin
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -56,11 +56,11 @@ const config: Config = {
       searchPagePath: "search",
     },
     announcementBar: {
-      id: 'announcement',
+      id: "announcement",
       content:
         'Keep up with the latest by <a href="https://universal-blue.discourse.group/tag/bluefin-news">following the announcements feed!</a>',
-      backgroundColor: '#fafbfc',
-      textColor: '#091E42',
+      backgroundColor: "#fafbfc",
+      textColor: "#091E42",
       isCloseable: true,
     },
     metadata: [

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
# Summary
My primary goal is to fix the instructions for installing k8s dev tools, but I figured I'd take a pass at the grammar and style of the `Developer Mode` docs while I was in there.

## k8s Dev Tools Issue
- Running `ujust k8s-dev-tools` does not work since the recipe is called `install-k8s-dev-tools`:
![image](https://github.com/user-attachments/assets/01a6e2c9-5a74-4baa-a85f-8860400bd9c4)

## Full List of changes

* `docs/bluefin-dx.md` 
  * Fix command to install k8s dev tools
  * In-depth review for grammar and style adjustments
* Format with prettier.

If needed, I am happy to either split up or revert any of the changes.