### PR TITLE
fix: update link to Bootc docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -93,7 +93,7 @@ Most pain points can be addressed directly by planning ahead of time.
 - Read this documentation in its entirety, here's some associated upstream documentation:
   - [Homebrew](https://docs.brew.sh/)
   - [Flathub](https://docs.flathub.org/)
-  - [bootc](https://containers.github.io/bootc/)
+  - [bootc](https://bootc-dev.github.io/bootc/)
     - [rpm-ostree](https://coreos.github.io/rpm-ostree/) - this tool is deprecated in Bluefin but still available on the image, it will be removed in Spring 2025
 
 #### Developers


### PR DESCRIPTION
They have moved their docs over to a different org