### PR TITLE
Add instructions to rebase from Silverblue, although unsupported.

### DIFF
--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -185,3 +185,9 @@ DevPod also has support for JetBrains:
 - [virt-manager](https://virt-manager.org/) and associated tooling (KVM, qemu)
 - [Incus](https://linuxcontainers.org/incus/) provides system containers
   - [LXC](https://linuxcontainers.org/) and [LXD](https://ubuntu.com/lxd) are also provided for compatibility reasons, however, these tools are deprecated and will be removed in Spring 2025
+  - 
+
+# Rebasing from Fedora Silverblue / Kinoite (unsupported, not recommended)
+
+- `rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bluefin-dx:latest`
+- and then `rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:latest` after a reboot.


### PR DESCRIPTION
I know this isn't officially supported, but I nevertheless sometimes need to do it, and end up always googling around and referring to [this Reddit thread](https://www.reddit.com/r/Fedora/comments/1cem6um/help_with_rebasing_to_bluefin_from_silverblue/). 

Just a suggestion to add the magical incantations to the official docs instead, with some warnings? Or if you'd prefer to recommend a re-install, I'll close! Thank you!