### PR TITLE
fix: set rolling release for PDFs

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -27,4 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{github.event.release.tag_name}} pdf/bluefin.pdf
+          gh release upload --clobber 0.1 pdf/bluefin.pdf


### PR DESCRIPTION

Just sets the workflow to a single, rolling release, so we can get this into the images