### PR TITLE
Remove Chromium mention from lts.md

### DIFF
--- a/docs/lts.md
+++ b/docs/lts.md
@@ -119,8 +119,6 @@ If there are other ways to set this up on MacOS please considering sending a pul
 
 - [Pixi](https://github.com/prefix-dev/pixi) package manager is used instead
   - Homebrew doesn't have ARM Linux builds
-- Chromium as the browser
-  - Firefox doesn't have ARM Linux builds
 
 ## Building Locally 
 


### PR DESCRIPTION
Bluefin LTS now has Firefox, as Firefox publishes Linux ARM builds. Remove reference in docs that states otherwise. Homebrew is next! :) 