### PR TITLE
Add changelog entries for multiple Bluefin releases

### DIFF
--- a/changelog/2025-07-20-stable-20250720.2.md
+++ b/changelog/2025-07-20-stable-20250720.2.md
@@ -1,0 +1,98 @@
+---
+title: "Bluefin Stable stable-20250720.2"
+slug: bluefin-stable-20250720.2
+authors: [bluefin-release-bot]
+tags: [release, bluefin, stable]
+---
+
+Bluefin Stable release stable-20250720.2 is now available.
+
+<!--truncate-->
+
+This is an automatically generated changelog for release `stable-20250720.2`.
+
+From previous `stable` version `stable-20250714.2` there have been the following changes. **One package per new version shown.**
+
+### Major packages
+| Name | Version |
+| --- | --- |
+| **Kernel** | 6.14.11-300 |
+| **Gnome** | 48.3-1 |
+| **Mesa** | 25.1.4-1 |
+| **Podman** | 5.5.2-1 |
+| **Nvidia** | 575.64.03-1 |
+
+### Major DX packages
+| Name | Version |
+| --- | --- |
+| **Incus** | 6.12-1 |
+| **Docker** | 28.3.2-1 |
+
+### Commits
+| Hash | Subject |
+| --- | --- |
+| **[1728dd5](https://github.com/ublue-os/bluefin/commit/1728dd534b689d21102f3bfe58a024b9dbfbe22b)** | fix(pin): downgrade libdex to 0.9.1 (#2794) |
+| **[191cc21](https://github.com/ublue-os/bluefin/commit/191cc2195386711de6091f0247b2867103737a0e)** | feat(bazaar): add Constrict (#2774) |
+
+### All Images
+| | Name | Previous | New |
+| --- | --- | --- | --- |
+| 🔄 | argyllcms | 3.3.0-2 | 3.4.0-1 |
+| 🔄 | bazaar | 0.0.git.954.103092a0.8af418b-3 | 0.0.git.972.3fa6ddb7.7bca83c-4 |
+| 🔄 | bluefin-schemas | 0.2.8-1 | 0.2.10-1 |
+| 🔄 | cosign | 2.5.2-1 | 2.5.3-1 |
+| 🔄 | fwupd | 2.0.7-100.ublue | 2.0.12-100.ublue |
+| 🔄 | gnome-desktop3 | 44.1-3 | 44.3-1 |
+| 🔄 | ibus-typing-booster | 2.27.68-1 | 2.27.69-1 |
+| 🔄 | iwd | 3.6-1 | 3.9-1 |
+| 🔄 | kernel-tools | 6.15.5-200 | 6.15.6-200 |
+| 🔄 | libell | 0.75-1 | 0.78-1 |
+| 🔄 | libinput | 1.28.901-1 | 1.28.901-2 |
+| 🔄 | libsolv | 0.7.33-1 | 0.7.34-1 |
+| 🔄 | ostree | 2025.2-2 | 2025.3-2 |
+| 🔄 | pcp-conf | 6.3.7-7 | 6.3.7-8 |
+| 🔄 | python3-boto3 | 1.38.46-1 | 1.39.6-1 |
+| 🔄 | ublue-bling | 0.1.6-1 | 0.1.7-1 |
+| 🔄 | vim-common | 9.1.1537-1 | 9.1.1552-1 |
+| 🔄 | yelp-xsl | 42.1-7 | 42.4-1 |
+
+### [Dev Experience Images](https://docs.projectbluefin.io/bluefin-dx)
+| | Name | Previous | New |
+| --- | --- | --- | --- |
+| 🔄 | cockpit-bridge | 341-1 | 342-1 |
+| 🔄 | cockpit-machines | 334-1 | 335-1 |
+| 🔄 | cockpit-podman | 108-1 | 109-1 |
+| 🔄 | code | 1.102.0-1752099924.el8 | 1.102.1-1752598767.el8 |
+| 🔄 | cowsql | 1.15.8-1 | 1.15.9-1 |
+| 🔄 | edk2-aarch64 | 20250523-6 | 20250523-11 |
+| 🔄 | kcli | 99.0.0.git.202507140611.acc9dff-0 | 99.0.0.git.202507170819.c6f1c4c-0 |
+| 🔄 | osbuild | 153-1 | 156-1 |
+| 🔄 | podman-tui | 1.6.1-1 | 1.7.0-1 |
+
+
+
+### How to rebase
+For current users, type the following to rebase to this version:
+```bash
+# Get Image Name
+IMAGE_NAME=$(jq -r '.["image-name"]' < /usr/share/ublue-os/image-info.json)
+
+# For this Stream
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable
+
+# For this Specific Image:
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable-20250720.2
+```
+
+### Documentation
+Be sure to read the [documentation](https://docs.projectbluefin.io/) for more information
+on how to use your cloud native system.
+
+---
+
+**Release Information:**
+- **Release:** [stable-20250720.2](https://github.com/ublue-os/bluefin/releases/tag/stable-20250720.2)
+- **Type:** Stable
+- **Date:** 2025-07-20
+
+For installation instructions and more information, visit the [Bluefin documentation](https://docs.projectbluefin.io/).

--- a/changelog/2025-07-27-gts-20250727.md
+++ b/changelog/2025-07-27-gts-20250727.md
@@ -1,0 +1,86 @@
+---
+title: "Bluefin GTS 20250727"
+slug: bluefin-gts-20250727
+authors: [bluefin-release-bot]
+tags: [release, bluefin, gts]
+---
+
+Bluefin GTS release 20250727 is now available.
+
+<!--truncate-->
+
+This is an automatically generated changelog for release `gts-20250727`.
+
+From previous `gts` version `gts-20250720` there have been the following changes. **One package per new version shown.**
+
+### Major packages
+| Name | Version |
+| --- | --- |
+| **Kernel** | 6.14.11-200 |
+| **Gnome** | 47.5-1 |
+| **Podman** | 5.5.2-1 |
+| **Nvidia** | 575.64.03-1 ➡️ 575.64.05-1 |
+
+### Major DX packages
+| Name | Version |
+| --- | --- |
+| **Incus** | 6.14-0.1 |
+| **Docker** | 28.3.2-1 |
+
+### Commits
+| Hash | Subject |
+| --- | --- |
+| **[1f78a71](https://github.com/ublue-os/bluefin/commit/1f78a71e0e880430a8ee704098caace2e67727df)** | revert: "chore(ci): test out storage action revisions" (#2813) |
+| **[e705dfd](https://github.com/ublue-os/bluefin/commit/e705dfd59f53cc6694c15a65e92e34fcb44a180e)** | fix(build): use GITHUB_TOKEN for curl when needed (#2808) |
+| **[74272a1](https://github.com/ublue-os/bluefin/commit/74272a14cc07b5fb1b56b563e24abe14c0ddda72)** | feat: add dialout to dx-group recipe (#2807) |
+
+### All Images
+| | Name | Previous | New |
+| --- | --- | --- | --- |
+| 🔄 | gnome-classic-session | 47.4-2 | 47.6-1 |
+| 🔄 | gnome-shell-extension-gsconnect | 66-1 | 66-2 |
+| 🔄 | ibus-typing-booster | 2.27.69-1 | 2.27.70-1 |
+| 🔄 | kernel-tools | 6.15.6-100 | 6.15.7-100 |
+| 🔄 | langtable | 0.0.68-2 | 0.0.69-1 |
+| 🔄 | pcp-conf | 6.3.7-7 | 6.3.7-8 |
+| 🔄 | python3-boto3 | 1.39.8-1 | 1.39.11-1 |
+| 🔄 | python3-s3transfer | 0.13.0-1 | 0.13.1-1 |
+| 🔄 | tailscale | 1.84.0-1 | 1.86.0-1 |
+
+### [Dev Experience Images](https://docs.projectbluefin.io/bluefin-dx)
+| | Name | Previous | New |
+| --- | --- | --- | --- |
+| ✨ | ramalama | | 0.11.0-1 |
+| 🔄 | code | 1.102.1-1752598767.el8 | 1.102.2-1753187859.el8 |
+| 🔄 | kcli | 99.0.0.git.202507170819.c6f1c4c-0 | 99.0.0.git.202507232001.b28a395-0 |
+| 🔄 | lxc | 6.0.4-1 | 6.0.4-3 |
+| 🔄 | nbdkit | 1.40.6-1 | 1.40.7-1 |
+| ❌ | python3-ramalama | 0.10.1-1 | |
+
+
+
+### How to rebase
+For current users, type the following to rebase to this version:
+```bash
+# Get Image Name
+IMAGE_NAME=$(jq -r '.["image-name"]' < /usr/share/ublue-os/image-info.json)
+
+# For this Stream
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:gts
+
+# For this Specific Image:
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:gts-20250727
+```
+
+### Documentation
+Be sure to read the [documentation](https://docs.projectbluefin.io/) for more information
+on how to use your cloud native system.
+
+---
+
+**Release Information:**
+- **Release:** [gts-20250727](https://github.com/ublue-os/bluefin/releases/tag/gts-20250727)
+- **Type:** GTS
+- **Date:** 2025-07-27
+
+For installation instructions and more information, visit the [Bluefin documentation](https://docs.projectbluefin.io/).


### PR DESCRIPTION
Automatically generated changelog entries for 2 release(s):
- changelog/2025-07-20-stable-20250720.2.md
- changelog/2025-07-27-gts-20250727.md