### PR TITLE
Mention official support for Bazzite

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -9,7 +9,7 @@ Fedora is an officially supported option for the [Framework](https://frame.work)
 
 ![83a08fa741add9e31b4762bf601337e4b506db8d](https://github.com/user-attachments/assets/3dd48f0f-f839-47ca-96f3-8e230e11e47e)
 
-Bluefin and it's sister images [Aurora](https://getaurora.dev) and [Bazzite](https://bazzite.gg) are community supported options on Framework hardware.
+Bluefin and its sister images [Aurora](https://getaurora.dev) and [Bazzite](https://bazzite.gg) are community supported options on Framework hardware.
 
 ![e7f719d97dee2083907dda5d06171608f6384bea](https://github.com/user-attachments/assets/3091108c-3228-400c-883d-16d6b734b47d)
 


### PR DESCRIPTION
I noticed that Aurora and Bazzite are listed as community supported, but Bazzite is now even officially supported:
<img width="1207" height="795" alt="image" src="https://github.com/user-attachments/assets/e8e2fb02-0f79-47e5-b8a0-6058b027718e" />

Even if this doc is for Bluefin, I think the close relation to Bazzite still makes it worth mentioning.