### PR TITLE
Resize fonts to be more accessible

### DIFF
--- a/src/components/FeedItems.module.css
+++ b/src/components/FeedItems.module.css
@@ -66,25 +66,25 @@
 
 .feedItemTitle {
   margin: 0;
-  font-size: 1rem;
+  font-size: 1.25rem;
   font-weight: 500;
   color: var(--ifm-color-primary);
 }
 
 .feedItemDate {
-  font-size: 0.875rem;
+  font-size: 0.95rem;
   color: var(--ifm-color-emphasis-600);
   font-style: italic;
 }
 
 .feedItemAuthor {
-  font-size: 0.875rem;
+  font-size: 0.95rem;
   color: var(--ifm-color-emphasis-700);
   font-weight: 500;
 }
 
 .feedItemDescription {
-  font-size: 0.875rem;
+  font-size: 0.95rem;
   color: var(--ifm-color-emphasis-700);
   line-height: 1.4;
   margin-top: 0.5rem;

--- a/src/components/PackageSummary.tsx
+++ b/src/components/PackageSummary.tsx
@@ -128,7 +128,7 @@ export default function PackageSummary({ feedKey, title }: PackageSummaryProps) 
         paddingBottom: '0.5rem'
       }}>{title} - Latest Versions</Heading>
       <div style={{ 
-        fontSize: '0.95em',
+        fontSize: '0.95rem',
         fontFamily: 'monospace',
         lineHeight: '1.6'
       }}>


### PR DESCRIPTION
This resizes the changelogs page fonts to be more legible and consistent.

Before:

<img width="1920" height="1047" alt="image" src="https://github.com/user-attachments/assets/6c6d2a61-8e76-448b-8fb6-0d9e2d2a4ce7" />

After:

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c5f90965-05bc-48d2-ae40-855c9f522f81" />
