### PR TITLE
chore(ci): add harden-runner action for improved security

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,14 +10,21 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
+
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,14 +15,23 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+
       - name: Install dependencies
         run: bun install --frozen-lockfile --production
+
       - name: Build website
         run: bun run build
+
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
@@ -45,6 +54,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -10,6 +10,11 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Install Prince
@@ -18,8 +23,10 @@ jobs:
           tar zxf prince-15.4.1-linux-generic-x86_64.tar.gz
           cd prince-15.4.1-linux-generic-x86_64
           yes "" | sudo ./install.sh
+
       - name: Build PDF
         run: npx docusaurus-prince-pdf --toc -u https://docs.projectbluefin.io -o pdf/bluefin.pdf
+
       - name: Upload results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -28,6 +35,7 @@ jobs:
           path: pdf/bluefin.pdf
           if-no-files-found: error
           overwrite: true
+
       - name: Upload Release Artifact
         if: github.event_name != 'pull_request'
         env:

--- a/.github/workflows/renovate-validate.yml
+++ b/.github/workflows/renovate-validate.yml
@@ -10,6 +10,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 


### PR DESCRIPTION
Enables harden-runner in audit mode for a while to monitor which public endpoints we require in our builds.

Will shortly be changed to block mode with the specific domains allowlisted to protect against the various supply chain attacks going on in NPM land.