### PR TITLE
feat: add Images page with automated updates

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,0 +1,42 @@
+name: Update Images Page
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/update-images.yml'
+      - 'scripts/update-images.sh'
+
+permissions:
+  contents: write
+
+jobs:
+  update-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch image data and update page
+        run: |
+          chmod +x scripts/update-images.sh
+          ./scripts/update-images.sh
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/images.md
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update images page"
+            git push
+          fi

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,60 @@
+# Images
+
+This page shows the latest published container images for Bluefin OS.
+
+## Latest Images
+
+### Stable Release
+
+| Image Name | Publication Date | Package Link |
+|------------|------------------|--------------|
+<!-- STABLE_IMAGES_START -->
+| `stable-20251024` | 2025-10-24 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20251021` | 2025-10-21 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20251019` | 2025-10-19 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20251012` | 2025-10-12 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20251005` | 2025-10-05 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20250928` | 2025-09-28 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20250921` | 2025-09-21 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20250914` | 2025-09-14 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20250907` | 2025-09-07 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `stable-20250831` | 2025-08-31 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+<!-- STABLE_IMAGES_END -->
+
+### GTS Release
+
+| Image Name | Publication Date | Package Link |
+|------------|------------------|--------------|
+<!-- GTS_IMAGES_START -->
+| `gts-20251028` | 2025-10-28 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20251024` | 2025-10-24 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20251021` | 2025-10-21 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20251019` | 2025-10-19 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20251012` | 2025-10-12 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20251005` | 2025-10-05 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20250928` | 2025-09-28 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20250921` | 2025-09-21 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20250914` | 2025-09-14 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+| `gts-20250907` | 2025-09-07 | [View Package](https://github.com/ublue-os/bluefin/pkgs/container/bluefin) |
+<!-- GTS_IMAGES_END -->
+
+### LTS Release
+
+| Image Name | Publication Date | Package Link |
+|------------|------------------|--------------|
+<!-- LTS_IMAGES_START -->
+| `lts.20251027` | 2025-10-27 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20251006` | 2025-10-06 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20251003` | 2025-10-06 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250930` | 2025-09-30 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250916` | 2025-09-16 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250910` | 2025-09-10 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250909` | 2025-09-09 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250908` | 2025-09-08 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250907` | 2025-09-07 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+| `lts.20250905` | 2025-09-05 | [View Package](https://github.com/ublue-os/bluefin-lts/pkgs/container/bluefin-lts) |
+<!-- LTS_IMAGES_END -->
+
+---
+
+*This page is automatically updated via GitHub Actions. Last updated: 2025-10-30 19:14:12 UTC*

--- a/scripts/update-images.sh
+++ b/scripts/update-images.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -e
+
+# Function to fetch release tags from GitHub releases
+fetch_images() {
+    local repo=$1
+    local tag_pattern=$2
+    local limit=$3
+    
+    # Fetch releases from GitHub API (public, no auth needed)
+    curl -s "https://api.github.com/repos/ublue-os/${repo}/releases?per_page=100" \
+        | jq -r '.[].tag_name' \
+        | grep -E "^${tag_pattern}" \
+        | head -n "$limit"
+}
+
+# Function to get release date
+get_release_date() {
+    local repo=$1
+    local tag=$2
+    
+    curl -s "https://api.github.com/repos/ublue-os/${repo}/releases/tags/${tag}" \
+        | jq -r '.published_at' \
+        | cut -d'T' -f1
+}
+
+# Function to format image data as markdown table rows
+format_table_rows() {
+    local repo=$1
+    local package=$2
+    local tags=$3
+    
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        
+        # Get release date
+        formatted_date=$(get_release_date "$repo" "$tag")
+        
+        # Create package URL - point to GHCR package page
+        package_url="https://github.com/ublue-os/${repo}/pkgs/container/${package}"
+        
+        # Output markdown row
+        echo "| \`${tag}\` | ${formatted_date} | [View Package](${package_url}) |"
+    done <<< "$tags"
+}
+
+# Temporary file for the new content
+temp_file=$(mktemp)
+
+# Fetch images for each release type
+echo "Fetching stable images..."
+stable_tags=$(fetch_images "bluefin" "stable" 10)
+stable_images=$(format_table_rows "bluefin" "bluefin" "$stable_tags")
+
+echo "Fetching GTS images..."
+gts_tags=$(fetch_images "bluefin" "gts" 10)
+gts_images=$(format_table_rows "bluefin" "bluefin" "$gts_tags")
+
+echo "Fetching LTS images..."
+lts_tags=$(fetch_images "bluefin-lts" "lts" 10)
+lts_images=$(format_table_rows "bluefin-lts" "bluefin-lts" "$lts_tags")
+
+# Get current timestamp
+current_date=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+# Read the original file and replace sections
+{
+    while IFS= read -r line; do
+        if [[ "$line" == *"<!-- STABLE_IMAGES_START -->"* ]]; then
+            echo "$line"
+            echo "$stable_images"
+            # Skip until end marker
+            while IFS= read -r line && [[ "$line" != *"<!-- STABLE_IMAGES_END -->"* ]]; do
+                :
+            done
+            echo "$line"
+        elif [[ "$line" == *"<!-- GTS_IMAGES_START -->"* ]]; then
+            echo "$line"
+            echo "$gts_images"
+            while IFS= read -r line && [[ "$line" != *"<!-- GTS_IMAGES_END -->"* ]]; do
+                :
+            done
+            echo "$line"
+        elif [[ "$line" == *"<!-- LTS_IMAGES_START -->"* ]]; then
+            echo "$line"
+            echo "$lts_images"
+            while IFS= read -r line && [[ "$line" != *"<!-- LTS_IMAGES_END -->"* ]]; do
+                :
+            done
+            echo "$line"
+        elif [[ "$line" == *"<!-- LAST_UPDATE -->"* ]]; then
+            echo "*This page is automatically updated via GitHub Actions. Last updated: $current_date*"
+            # Skip any trailing timestamps
+            break
+        else
+            echo "$line"
+        fi
+    done < docs/images.md
+} > "$temp_file"
+
+# Replace the original file
+mv "$temp_file" docs/images.md
+
+echo "Images page updated successfully!"

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -40,6 +40,7 @@ const sidebars: SidebarsConfig = {
         "dinosaurs",
         "downloads",
         "FAQ",
+        "images",
         "mission",
         "press-kit",
         "tips",


### PR DESCRIPTION
## Summary

This PR adds a new **Images** page under the Project Information section that displays the last 10 published container images for Bluefin OS, organized by release type (stable, gts, and lts).

## Changes

- ✨ **New Images page** () displaying latest images with:
  - Image tag names
  - Publication dates
  - Links to GitHub Container Registry packages
- 🤖 **Automated updates** via GitHub Action that runs daily at 6 AM UTC
- 📜 **Update script** (Fetching stable images...
Fetching GTS images...
Fetching LTS images...
Images page updated successfully!) that fetches data from GitHub releases API
- 📚 **Sidebar integration** - added Images to Project Information section

## Features

- **Efficient**: Uses GitHub's public releases API (no authentication required)
- **Simple**: Fetches from GitHub releases rather than scraping GHCR.io
- **Automatic**: Daily updates via GitHub Actions with workflow_dispatch option
- **Organized**: Separate tables for stable, gts, and lts releases
- **Traceable**: Shows last update timestamp

## Testing

- ✅ Build passes successfully
- ✅ Script tested locally and generates correct markdown
- ✅ Data fetches from ublue-os/bluefin and ublue-os/bluefin-lts repositories
- ✅ Page renders correctly in Docusaurus

## Related

Addresses the need for a centralized view of published container images across different release channels.