### PR TITLE
Add IME setup instructions to FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -129,6 +129,25 @@ Your layout may be already included with Fedora, but you need to list extended k
 10. There are only two to pick from, "English (United States)" and "Spanish (United States)". Pick one, probably "English (United States)" is what you want.
 11. You get another sub-selection and can now pick "EurKEY (US)"
 
+## How do I set up an Input Method Editor (IME)?
+
+1. Install [Fcitx5](https://flathub.org/en/apps/org.fcitx.Fcitx5):
+ ```bash
+ flatpak install org.fcitx.Fcitx5
+ ```
+2. Install the [kimpanel](https://extensions.gnome.org/extension/261/kimpanel/) Gnome extension (required on Gnome/Wayland).
+3. Install the Flatpak Add-on for the language you want to use.
+   - For example, for Chinese:
+ ```bash
+ flatpak install org.fcitx.Fcitx5.Addon.ChineseAddons
+ ```
+4. In Fcitx5 settings, add the input method you want to use.
+   - For example, for Chinese: Add 'Pinyin' to the list under Current Input Method.
+
+Use `Ctrl+Space` to change the input method. Optionally, add Fcitx5 to list of start up apps in [Ignition](https://flathub.org/apps/io.github.flattool.Ignition).
+
+For additional information, see [Fcitx wiki](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland#GNOME).
+
 ## How do I install Microsoft fonts?
 
 Follow [these instructions](https://github.com/colindean/homebrew-fonts-nonfree) to install them via homebrew. (Skip the homebrew installation instructions). 


### PR DESCRIPTION
Added instructions for setting up an Input Method Editor (IME) using Fcitx5, including installation steps and configuration details.

Consider closing: https://github.com/ublue-os/bluefin/issues/1896

Users who need to use an IME can add the functionality using Fcitx5 Flatpak as described in this FAQ question, so probably don't need to add any packages to the base image.