### PR TITLE
Replace Cayo link with uCore link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -170,8 +170,8 @@ const config: Config = {
               href: "https://bazzite.gg/",
             },
             {
-              label: "Cayo",
-              href: "https://projectcayo.org/",
+              label: "uCore",
+              href: "https://github.com/ublue-os/ucore",
             },
           ],
         },


### PR DESCRIPTION
The Cayo project was archived last month (https://github.com/ublue-os/cayo/pull/125). This replaces link in footer to direct people to uCore instead.