### PR TITLE
feat: add abbycabs and ashleymcnamara to legendary supporters

### DIFF
--- a/docs/donations.mdx
+++ b/docs/donations.mdx
@@ -117,8 +117,10 @@ Sustainability is a key focus of Universal Blue, the project focuses on efficien
     marginBottom: "2rem",
   }}
 >
+  <GitHubProfileCard username="abbycabs" />
   <GitHubProfileCard username="ahrkrak" />
   <GitHubProfileCard username="angellk" />
+  <GitHubProfileCard username="ashleymcnamara" />
   <GitHubProfileCard username="caniszczyk" />
   <GitHubProfileCard username="carlwgeorge" />
   <GitHubProfileCard username="cblecker" />


### PR DESCRIPTION
## Summary
Add two more contributors to the Legendary Supporters section on the donations page.

## New Legendary Supporters
- **abbycabs** - Added alphabetically first
- **ashleymcnamara** - Added alphabetically fourth

## Updated Totals
- Legendary Supporters: 40 people (up from 38)
- Total contributors: 64 people with GitHub profile cards

## Changes
- Both contributors added in correct alphabetical order
- All sections remain properly sorted

## Related
- Separate PR from #485 as requested
- Based on merged PR #484

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot CLI