### PR TITLE
feat: alphabetize donations page by first name

### DIFF
--- a/docs/donations.mdx
+++ b/docs/donations.mdx
@@ -21,28 +21,28 @@ Bluefin focuses on sustainability, the project focuses on efficiency and long te
 >
   <GitHubProfileCard username="ahmedadan" />
   <GitHubProfileCard username="befanyt" />
-  <GitHubProfileCard
-    username="castrojo"
-    title="Product Development and Dinosaur Guy"
-    sponsorUrl="https://github.com/sponsors/castrojo/"
-  />
-  <GitHubProfileCard username="daegalus" />
+  <GitHubProfileCard username="inffy" />
   <GitHubProfileCard
     username="hanthor"
     title="LTS Specialist and shameless AI enjoyer"
     sponsorUrl="https://github.com/sponsors/hanthor"
   />
-  <GitHubProfileCard username="inffy" />
+  <GitHubProfileCard
+    username="castrojo"
+    title="Product Development and Dinosaur Guy"
+    sponsorUrl="https://github.com/sponsors/castrojo/"
+  />
+  <GitHubProfileCard username="renner0e" />
   <GitHubProfileCard
     username="p5"
     title='"Hold onto your butts" guy and Lead DevOps'
   />
-  <GitHubProfileCard username="renner0e" />
   <GitHubProfileCard
     username="tulilirockz"
     title="Large Maniraptoran Specialist and co-maintainer"
     sponsorUrl="https://github.com/sponsors/tulilirockz"
   />
+  <GitHubProfileCard username="daegalus" />
 </div>
 
 # Artists
@@ -73,13 +73,13 @@ Bluefin focuses on sustainability, the project focuses on efficiency and long te
     marginBottom: "2rem",
   }}
 >
+  <GitHubProfileCard username="bsherman" title="CTO" />
   <GitHubProfileCard
     username="bketelsen"
     title="Lead Developer Experience, Architect of The Final Shape"
   />
-  <GitHubProfileCard username="bsherman" title="CTO" />
-  <GitHubProfileCard username="m2Giles" title="Lead Architect" />
   <GitHubProfileCard username="rothgar" />
+  <GitHubProfileCard username="m2Giles" title="Lead Architect" />
 </div>
 
 ## Special Guests
@@ -92,12 +92,12 @@ Bluefin focuses on sustainability, the project focuses on efficiency and long te
     marginBottom: "2rem",
   }}
 >
-  <GitHubProfileCard username="alatiera" />
   <GitHubProfileCard
     username="kolunmi"
     title="App store experience (Bazaar)"
     sponsorUrl="https://ko-fi.com/kolunmi"
   />
+  <GitHubProfileCard username="alatiera" />
   <GitHubProfileCard
     username="madonuko"
     title="Readymade installation experience (Fyra Labs)"
@@ -121,41 +121,41 @@ The following individuals have made a lasting impact on Bluefin's design, either
   }}
 >
   <GitHubProfileCard username="abbycabs" />
+  <GitHubProfileCard username="popey" />
   <GitHubProfileCard username="ahrkrak" />
-  <GitHubProfileCard username="angellk" />
   <GitHubProfileCard username="ashleymcnamara" />
-  <GitHubProfileCard username="caniszczyk" />
+  <GitHubProfileCard username="funnelfiasco" />
+  <GitHubProfileCard username="mrbobbytables" />
   <GitHubProfileCard username="carlwgeorge" />
+  <GitHubProfileCard username="caniszczyk" />
   <GitHubProfileCard username="cblecker" />
+  <GitHubProfileCard username="liljenstolpe" />
   <GitHubProfileCard username="cgwalters" />
   <GitHubProfileCard username="colindean" />
   <GitHubProfileCard username="craigmcl" />
-  <GitHubProfileCard username="ctsdownloads" />
+  <GitHubProfileCard username="rhatdan" />
   <GitHubProfileCard username="dustinkirkland" />
   <GitHubProfileCard username="ericcurtin" />
-  <GitHubProfileCard username="funnelfiasco" />
   <GitHubProfileCard username="idvoretskyi" />
-  <GitHubProfileCard username="jbeda" />
-  <GitHubProfileCard username="jberkus" />
   <GitHubProfileCard username="jeefy" />
+  <GitHubProfileCard username="jbeda" />
   <GitHubProfileCard username="jonobacon" />
+  <GitHubProfileCard username="jberkus" />
   <GitHubProfileCard username="karasowles" />
+  <GitHubProfileCard username="angellk" />
   <GitHubProfileCard username="kenvandine" />
+  <GitHubProfileCard username="nimbinatus" />
   <GitHubProfileCard username="lhawthorn" />
-  <GitHubProfileCard username="liljenstolpe" />
   <GitHubProfileCard username="marcoceppi" />
+  <GitHubProfileCard username="mfahlandt" />
   <GitHubProfileCard username="marrusl" />
+  <GitHubProfileCard username="ctsdownloads" />
   <GitHubProfileCard username="mattfarina" />
   <GitHubProfileCard username="mattray" />
-  <GitHubProfileCard username="mfahlandt" />
   <GitHubProfileCard username="michaeltunnell" />
-  <GitHubProfileCard username="mrbobbytables" />
-  <GitHubProfileCard username="nimbinatus" />
   <GitHubProfileCard username="parispittman" />
-  <GitHubProfileCard username="popey" />
   <GitHubProfileCard username="puja108" />
   <GitHubProfileCard username="ramcq" />
-  <GitHubProfileCard username="rhatdan" />
   <GitHubProfileCard username="sarahnovotny" />
   <GitHubProfileCard username="thockin" />
   <GitHubProfileCard username="travier" />


### PR DESCRIPTION
## Changes

Reorder all contributor sections on the donations page alphabetically by **first name** instead of GitHub username. This makes it easier to find specific people when you know their real name.

## Sections Reordered

### Current Maintainers
**Before:** ahmedadan, befanyt, castrojo, daegalus, hanthor, inffy, p5, renner0e, tulilirockz  
**After:** Ahmed, befanyt, inffy, James (hanthor), Jorge (castrojo), renner, Robert (p5), Tulip, Yulian (daegalus)

### Artists
✅ Already correct: Chandler, M.

### Bluefin Maintainers (Emeritus)
**Before:** bketelsen, bsherman, m2Giles, rothgar  
**After:** Benjamin (bsherman), Brian (bketelsen), Justin (rothgar), m2 (m2Giles)

### Special Guests
**Before:** alatiera, kolunmi, madonuko  
**After:** Adam (kolunmi), Jordan (alatiera), madomado (madonuko)

### Legendary Supporters (40 people)
**Before:** Alphabetical by username (abbycabs → wwitzel3)  
**After:** Alphabetical by first name (Abby → Wayne)

Notable changes:
- popey moved up (Alan)
- funnelfiasco moved up (Ben)
- mrbobbytables moved up (Bob)
- Multiple people with same first name kept in order (3 Matts, 2 Colins)

### Universal Blue Team
✅ Already correct: Antheas, dreamyuki, HikariKnight, Kyle, Noel

## Benefits

✅ **Easier to find people** - Search by real name instead of username  
✅ **More intuitive** - Most people know contributors by their names  
✅ **Consistent** - All sections use same alphabetization method  
✅ **Handles duplicates** - Multiple people with same first name preserved  

## Testing

- ✅ TypeScript compilation passes
- ✅ Production build succeeds
- ✅ All profile cards render correctly
- ✅ No broken links or missing profiles

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot CLI