### PR TITLE
fix: make GNOME extensions grid responsive for mobile

### DIFF
--- a/docs/tips.mdx
+++ b/docs/tips.mdx
@@ -4,6 +4,7 @@ slug: /tips
 ---
 
 import GnomeExtensions from '@site/src/components/GnomeExtensions';
+import styles from '@site/src/components/ExtensionsGrid.module.css';
 
 This section contains miscellaneous tips and tricks that may not be core documentation.
 
@@ -11,13 +12,7 @@ This section contains miscellaneous tips and tricks that may not be core documen
 
 Here are some GNOME extensions that the maintainers recommend to round out your experience. Remember to support extension authors by donating to the ones you love! Talk to a maintainer before PRing something here as this is an opinionated list. :)
 
-<div style={{
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: '1.5rem',
-  marginTop: '2rem',
-  marginBottom: '2rem'
-}}>
+<div className={styles.extensionsGrid}>
 
 <GnomeExtensions extensionId={5724} />
 <GnomeExtensions extensionId={6670} />

--- a/src/components/ExtensionsGrid.module.css
+++ b/src/components/ExtensionsGrid.module.css
@@ -1,0 +1,23 @@
+.extensionsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+/* Tablet: 2 columns */
+@media (max-width: 996px) {
+  .extensionsGrid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+  }
+}
+
+/* Mobile: 1 column for better readability */
+@media (max-width: 576px) {
+  .extensionsGrid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Problem

The GNOME extensions thumbnails on the Tips page appeared "smooshed" or squashed on mobile devices due to a fixed 3-column grid layout. On small screens (~375px wide phones), each column was only ~100px wide, making the extension cards difficult to read and use.

## Solution

Replaced the inline grid styles with a responsive CSS module that adapts to different screen sizes:

- **Desktop** (997px+): 3 columns - optimal for wide screens
- **Tablet** (577-996px): 2 columns - balanced layout
- **Mobile** (≤576px): 1 column - full width for readability

## Changes

1. **Created** `src/components/ExtensionsGrid.module.css`
   - Responsive grid with Docusaurus-aligned breakpoints
   - Progressive gap sizing (1.5rem → 1.25rem → 1rem)

2. **Updated** `docs/tips.mdx`
   - Replaced inline styles with CSS module
   - Cleaner, more maintainable code

## Testing Recommendations

Test on the following screen sizes:
- ✅ Desktop (1920x1080, 1440x900)
- ✅ Tablet (768x1024)
- ✅ Mobile (375x667 iPhone SE, 393x851 Pixel 5)

You can use browser dev tools (F12 → Device Toolbar) to test responsive behavior.

## Before/After

### Before (Mobile)
- 3 tiny columns (~100px each)
- Text unreadable
- Images appear squashed
- Poor touch targets

### After (Mobile)
- Single full-width column
- Readable text and titles
- Properly proportioned thumbnails
- Easy to tap and interact

## Benefits

- ✅ Better mobile UX
- ✅ Maintains desktop experience
- ✅ Follows Docusaurus breakpoint conventions
- ✅ More maintainable (CSS module vs inline styles)
- ✅ Consistent with modern responsive design patterns

## Related

This fix specifically addresses the Tips page extension grid. The `GnomeExtensions.module.css` already had good responsive styles for individual cards - this PR fixes the container grid layout.