### PR TITLE
docs(lts): convert donation links to GitHubProfileCard components

### DIFF
--- a/docs/lts.mdx
+++ b/docs/lts.mdx
@@ -3,6 +3,8 @@ title: Introduction to Bluefin LTS
 slug: /lts
 ---
 
+import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
+
 _Achillobator giganticus_
 
 ![achillosmall](https://github.com/user-attachments/assets/b6945e80-34e4-44bb-8518-91ad31fed56d)
@@ -121,5 +123,22 @@ Note that secureboot and hibernation are mutually exclusive. We do not yet offer
 
 The team appreciates your support!
 
-- [James Reilly](https://github.com/sponsors/hanthor) - LTS Specialist and shameless AI enjoyer
-- <a class="github-button" href="https://github.com/sponsors/tulilirockz" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor tulilirockz">Sponsor</a> [Tulip Blossom](https://github.com/tulilirockz)- Lead Raptor Wrangler
+<div
+  style={{
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+    gap: "1.5rem",
+    marginBottom: "2rem",
+  }}
+>
+  <GitHubProfileCard
+    username="hanthor"
+    title="LTS Specialist and shameless AI enjoyer"
+    sponsorUrl="https://github.com/sponsors/hanthor"
+  />
+  <GitHubProfileCard
+    username="tulilirockz"
+    title="Lead Raptor Wrangler"
+    sponsorUrl="https://github.com/sponsors/tulilirockz"
+  />
+</div>

--- a/static/data/github-profiles.json
+++ b/static/data/github-profiles.json
@@ -77,8 +77,8 @@
     "avatar_url": "https://avatars.githubusercontent.com/u/120808662?v=4",
     "bio": "Big Linux fan :)",
     "html_url": "https://github.com/tulilirockz",
-    "public_repos": 151,
-    "followers": 137
+    "public_repos": 152,
+    "followers": 138
   },
   "chandeleer1698": {
     "login": "chandeleer1698",
@@ -105,7 +105,7 @@
     "bio": null,
     "html_url": "https://github.com/bketelsen",
     "public_repos": 468,
-    "followers": 1364
+    "followers": 1363
   },
   "bsherman": {
     "login": "bsherman",
@@ -239,7 +239,7 @@
     "avatar_url": "https://avatars.githubusercontent.com/u/197224?v=4",
     "bio": "Scholar, bon vivant, champion of the oppressed.",
     "html_url": "https://github.com/colindean",
-    "public_repos": 300,
+    "public_repos": 301,
     "followers": 246
   },
   "craigmcl": {
@@ -275,8 +275,8 @@
     "avatar_url": "https://avatars.githubusercontent.com/u/1694275?v=4",
     "bio": "https://gitlab.com/ecurtin\r\nhttps://gitlab.freedesktop.org/ecurtin\r\n\r\n    \r\n",
     "html_url": "https://github.com/ericcurtin",
-    "public_repos": 223,
-    "followers": 186
+    "public_repos": 225,
+    "followers": 187
   },
   "funnelfiasco": {
     "login": "funnelfiasco",
@@ -520,5 +520,23 @@
     "html_url": "https://github.com/travier",
     "public_repos": 140,
     "followers": 305
+  },
+  "wwitzel3": {
+    "login": "wwitzel3",
+    "name": "Wayne Witzel III",
+    "avatar_url": "https://avatars.githubusercontent.com/u/27317?v=4",
+    "bio": "Software engineer and electrician.",
+    "html_url": "https://github.com/wwitzel3",
+    "public_repos": 124,
+    "followers": 72
+  },
+  "antheas": {
+    "login": "antheas",
+    "name": "Antheas Kapenekakis",
+    "avatar_url": "https://avatars.githubusercontent.com/u/5252246?v=4",
+    "bio": "Comp. Sci. PhD Fellow @ Aalborg University, Denmark",
+    "html_url": "https://github.com/antheas",
+    "public_repos": 37,
+    "followers": 51
   }
 }


### PR DESCRIPTION
## Changes

Converts the LTS documentation page donation section to use the same styled GitHubProfileCard components as the main donations page.

### What Changed
- Converted `docs/lts.md` → `docs/lts.mdx` to support React components
- Replaced text-based donation links with GitHubProfileCard components
- Maintains consistent styling with the main donations page
- All existing caching behavior preserved:
  - Build-time data fetching
  - localStorage fallback with 30-day expiration
  - API fallback with rate limiting protection

### Cards Added
- **James Reilly (hanthor)**: LTS Specialist and shameless AI enjoyer
- **Tulip Blossom (tulilirockz)**: Lead Raptor Wrangler

Both cards include sponsor buttons linking to their GitHub Sponsors pages.

### Validation
- ✅ TypeScript check passed (expected warnings)
- ✅ Build completed successfully
- ✅ Manual testing verified card rendering
- ✅ Conventional commits format followed

---

Assisted-by: Claude 3.7 Sonnet via GitHub Copilot