### PR TITLE
docs(gdx): convert donation links to GitHubProfileCard components

### DIFF
--- a/docs/bluefin-gdx.mdx
+++ b/docs/bluefin-gdx.mdx
@@ -3,6 +3,8 @@ title: Bluefin GDX
 slug: /gdx
 ---
 
+import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
+
 ![achillobator_smol](https://github.com/user-attachments/assets/76d1a3ee-92e7-4d2e-88b6-0aebdb0b447d)
 
 :::tip[Run faster...]
@@ -55,5 +57,22 @@ Check the [downloads page](./downloads.md) for more information. Follow the [Blu
 
 The team appreciates your support!
 
-- [James Reilly](https://github.com/sponsors/hanthor) - LTS Specialist and shameless AI enjoyer
-- <a class="github-button" href="https://github.com/sponsors/tulilirockz" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-heart" data-size="large" aria-label="Sponsor tulilirockz">Sponsor</a> [Tulip Blossom](https://github.com/tulilirockz)- Lead Raptor Wrangler
+<div
+  style={{
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+    gap: "1.5rem",
+    marginBottom: "2rem",
+  }}
+>
+  <GitHubProfileCard
+    username="hanthor"
+    title="LTS Specialist and shameless AI enjoyer"
+    sponsorUrl="https://github.com/sponsors/hanthor"
+  />
+  <GitHubProfileCard
+    username="tulilirockz"
+    title="Lead Raptor Wrangler"
+    sponsorUrl="https://github.com/sponsors/tulilirockz"
+  />
+</div>


### PR DESCRIPTION
- Convert bluefin-gdx.md to bluefin-gdx.mdx to support React components
- Replace text-based donation links with GitHubProfileCard components
- Match the style and layout used in the LTS page (#511)
- Maintain all existing caching behavior (build-time data, localStorage fallback)
- Profile data for hanthor and tulilirockz already fetched during build process

This applies the same changes from #511 to the GDX page.