### PR TITLE
docs: add @mairin to Special Guests section

### DIFF
--- a/docs/donations/contributors.mdx
+++ b/docs/donations/contributors.mdx
@@ -119,6 +119,7 @@ import GitHubProfileCard from "@site/src/components/GitHubProfileCard";
     sponsorUrl="https://github.com/sponsors/xe"
   />
   <GitHubProfileCard username="sramkrishna" />
+  <GitHubProfileCard username="mairin" />
 </div>
 
 ## Advisors and Mentors


### PR DESCRIPTION
Add @mairin to the Special Guests section of the contributors page.

The GitHubProfileCard component will automatically fetch their profile information at build time.