### PR TITLE
Update Brewfile package tables to match projectbluefin/common

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -29,14 +29,20 @@ The following AI-focused command-line tools are available via homebrew, install 
 | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [aichat](https://formulae.brew.sh/formula/aichat)                   | All-in-one AI-Powered CLI Chat & Copilot                         |
 | [block-goose-cli](https://formulae.brew.sh/formula/block-goose-cli) | Block Protocol AI agent CLI                                      |
+| [claude-code](https://formulae.brew.sh/cask/claude-code)            | Claude coding agent with desktop integration                     |
 | [clio](https://github.com/gptscript-ai/clio)                        | AI assistant for the command line powered by GPTScript           |
 | [codex](https://formulae.brew.sh/cask/codex)                        | Code editor for OpenAI's coding agent that runs in your terminal |
+| [copilot-cli](https://formulae.brew.sh/cask/copilot-cli)            | GitHub Copilot CLI for terminal assistance                       |
 | [crush](https://github.com/charmbracelet/crush)                     | AI coding agent for the terminal, from charm.sh                  |
 | [gemini-cli](https://formulae.brew.sh/formula/gemini-cli)           | Command-line interface for Google's Gemini API                   |
+| [kimi-cli](https://formulae.brew.sh/formula/kimi-cli)               | CLI for Moonshot AI's Kimi models                                |
 | [llm](https://formulae.brew.sh/formula/llm)                         | Access large language models from the command line               |
+| [lm-studio](https://formulae.brew.sh/cask/lm-studio)                | Desktop app for running local LLMs                               |
+| [mistral-vibe](https://formulae.brew.sh/formula/mistral-vibe)       | CLI for Mistral AI models                                        |
 | [mods](https://formulae.brew.sh/formula/mods)                       | AI on the command-line, from charm.sh                            |
 | [opencode](https://formulae.brew.sh/formula/opencode)               | AI coding agent for the terminal                                 |
 | [qwen-code](https://formulae.brew.sh/formula/qwen-code)             | CLI for Qwen3-Coder models                                       |
+| [ramalama](https://formulae.brew.sh/formula/ramalama)               | Manage and run AI models locally with containers                 |
 | [whisper-cpp](https://formulae.brew.sh/formula/whisper-cpp)         | High-performance inference of OpenAI's Whisper model             |
 
 ## Ramalama

--- a/docs/bluefin-dx.md
+++ b/docs/bluefin-dx.md
@@ -191,10 +191,12 @@ For access to the full suite of [Cloud Native Computing Foundation](https://l.cn
 | Name                                                                                      |
 | ----------------------------------------------------------------------------------------- |
 | [CaskaydiaMono Nerd Font](https://formulae.brew.sh/cask/font-caskaydia-mono-nerd-font)    |
+| [Comic Shanns Mono Nerd Font](https://formulae.brew.sh/cask/font-comic-shanns-mono-nerd-font) |
 | [Droid Sans Mono Nerd Font](https://formulae.brew.sh/cask/font-droid-sans-mono-nerd-font) |
 | [Go Mono Nerd Font](https://formulae.brew.sh/cask/font-go-mono-nerd-font)                 |
-| [IBM Plex Mono Nerd Font](https://formulae.brew.sh/cask/font-ibm-plex-mono-nerd-font)     |
+| [Blex Mono Nerd Font](https://formulae.brew.sh/cask/font-blex-mono-nerd-font)             |
 | [Sauce Code Pro Nerd Font](https://formulae.brew.sh/cask/font-sauce-code-pro-nerd-font)   |
 | [Source Code Pro](https://formulae.brew.sh/cask/font-source-code-pro)                     |
 | [Ubuntu Nerd Font](https://formulae.brew.sh/cask/font-ubuntu-nerd-font)                   |
 | [FiraCode Nerd Font](https://formulae.brew.sh/cask/font-fira-code-nerd-font)              |
+| [0xProto Nerd Font](https://formulae.brew.sh/cask/font-0xproto-nerd-font)                 |


### PR DESCRIPTION
Updates package tables in documentation to accurately reflect the packages defined in projectbluefin/common Brewfiles.

## Changes

### AI Tools (docs/ai.md)
- Added missing packages: claude-code, copilot-cli, kimi-cli, lm-studio, mistral-vibe, ramalama
- All packages now match ai-tools.Brewfile

### Fonts (docs/bluefin-dx.md)
- Replaced IBM Plex Mono Nerd Font with Blex Mono Nerd Font (actual package)
- Added Comic Shanns Mono Nerd Font
- Added 0xProto Nerd Font
- All fonts now match fonts.Brewfile

These tables are now synchronized with the actual Brewfiles in projectbluefin/common repository.