### PR TITLE
docs(tips): add donation URLs for GNOME extensions

### DIFF
--- a/static/data/gnome-extensions.json
+++ b/static/data/gnome-extensions.json
@@ -62,7 +62,7 @@
     "screenshot": "/img/extensions/3843.png",
     "remoteScreenshot": "https://extensions.gnome.org/extension-data/screenshots/screenshot_3843_C95rsxm.png",
     "icon": "https://extensions.gnome.org/extension-data/icons/icon_3843_fQsImoF.png",
-    "donateUrl": null
+    "donateUrl": "https://www.buymeacoffee.com/justperfection"
   },
   {
     "id": 2236,
@@ -114,6 +114,6 @@
     "screenshot": "/img/extensions/7065.jpg",
     "remoteScreenshot": "https://extensions.gnome.org/extension-data/screenshots/screenshot_7065_c1v2s78.jpg",
     "icon": "https://extensions.gnome.org/extension-data/icons/icon_7065.png",
-    "donateUrl": null
+    "donateUrl": "https://ko-fi.com/domferr"
   }
 ]


### PR DESCRIPTION
Add donation links for GNOME extensions that have publicly available sponsor/donation pages.

## Changes
- **Just Perfection**: Add Buy Me a Coffee donation link (buymeacoffee.com/justperfection)
- **Tiling Shell**: Add Ko-fi donation link (ko-fi.com/domferr)

## Research Notes
The following extensions were researched but do not have publicly advertised donation URLs:
- Battery Health Charging (maniacx)
- Bluetooth Battery Meter (maniacx)
- Control monitor brightness with ddcutil (Nei/daitj)
- Copyous (boerdereinar)
- Night Theme Switcher (Romain Vigier - hosted on GitLab)
- Quick Settings Audio Devices Hider (marcinjahn)
- Quick Settings Audio Devices Renamer (marcinjahn)

These donation URLs are displayed on the Tips page (/tips) to encourage users to support extension developers.

Closes #