### PR TITLE
docs(donations): add @krisnova to advisors and mentors

### DIFF
--- a/docs/donations/contributors.mdx
+++ b/docs/donations/contributors.mdx
@@ -170,6 +170,7 @@ The following individuals have made a lasting impact on Bluefin's design, either
   <GitHubProfileCard username="jbeda" />
   <GitHubProfileCard username="jonobacon" />
   <GitHubProfileCard username="jberkus" />
+  <GitHubProfileCard username="krisnova" />
   <GitHubProfileCard username="rochaporto" />
 </div>
 


### PR DESCRIPTION
Add krisnova to the Advisors and Mentors section of the contributors donation page to recognize their impact on the project.

Assisted-by: Claude Sonnet 4.5 via GitHub Copilot