### PR TITLE
feat(footer): add Contribute column with issues, PRs, and guide links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -236,6 +236,23 @@ const config: Config = {
           ],
         },
         {
+          title: "Contribute",
+          items: [
+            {
+              label: "Open Issues",
+              href: "https://issues.projectbluefin.io",
+            },
+            {
+              label: "Open Pull Requests",
+              href: "https://pullrequests.projectbluefin.io",
+            },
+            {
+              label: "Contributor's Guide",
+              href: "https://contribute.projectbluefin.io",
+            },
+          ],
+        },
+        {
           title: "GitHub",
           items: [
             {


### PR DESCRIPTION
Add a new 'Contribute' column to the footer as the 4th column, positioned before the 'GitHub' column. The column includes three links in order:
- Open Issues (issues.projectbluefin.io)
- Open Pull Requests (pullrequests.projectbluefin.io)
- Contributor's Guide (contribute.projectbluefin.io)

This makes it easier for community members to find ways to contribute to the project.

Assisted-by: Claude Sonnet 4 via GitHub Copilot