### PR TITLE
chore(devcontainer): install legacy npm deps, add just, and configure port forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:3-22-bookworm",
   "features": {
-    "ghcr.io/devcontainers-community/npm-features/prettier:1": {}
+    "ghcr.io/devcontainers-community/npm-features/prettier:1": {},
+    "ghcr.io/guiyomh/features/just:0": {}
   },
-  "postCreateCommand": "npm install"
+  "postCreateCommand": "npm install --legacy-peer-deps",
+  "forwardPorts": [3000]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "npm run fetch-data && docusaurus start",
+    "start": "npm run fetch-data && docusaurus start --host 0.0.0.0",
     "build": "npm run fetch-data && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
The devcontainer is throwing an error on the _postCreateCommand_ of `npm install` due to legacy dependencies. As stated in the [AGENTS.md](https://github.com/projectbluefin/documentation/blob/main/AGENTS.md) I added the `--legacy-peer-deps` flag.

Also `just` was not present in the devcontainer, so I added it via a devcontainer feature.

Running `just serve` from the devcontainer did not work due to no port forwarding and `docusaurus start` not listening on all interfaces.