### PR TITLE
docs(agents): remove non-existent communication.md reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ Common documentation areas include:
 - Developer experience (`docs/bluefin-dx.md`, `docs/bluefin-gdx.md`, `docs/devcontainers.md`)
 - FAQ and troubleshooting (`docs/FAQ.md`)
 - Hardware-specific guides (`docs/t2-mac.md`)
-- Community information (`docs/communication.md`, `docs/code-of-conduct.md`, `docs/values.md`, `docs/mission.md`, `docs/donations/`)
+- Community information (`docs/code-of-conduct.md`, `docs/values.md`, `docs/mission.md`, `docs/donations/`)
   - Donations section split into: `docs/donations/index.mdx`, `docs/donations/contributors.mdx`, `docs/donations/projects.mdx`
 - Gaming support (`docs/gaming.md`)
 - LTS information (`docs/lts.md`)


### PR DESCRIPTION
## Summary

Removes outdated reference to `docs/communication.md` from AGENTS.md documentation list. This file does not exist in the repository.

## Changes
- Removed `docs/communication.md` from the community information documentation list in AGENTS.md
- Verified no other references to this non-existent file exist in the codebase

## Testing
- [x] Verified file doesn't exist: `ls docs/communication.md`
- [x] Checked for other references: `rg communication.md`
- [x] Only found outdated reference in AGENTS.md

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

Closes #N/A (maintenance/cleanup task)