### PR TITLE
feat(docs): add hidden troubleshooting page

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,41 @@
+---
+title: Troubleshooting
+slug: /troubleshooting
+unlisted: true
+---
+
+# Troubleshooting
+
+This page provides solutions to common issues you may encounter with Bluefin.
+
+:::info
+This is a work in progress. More troubleshooting guides will be added over time.
+:::
+
+## Common Issues
+
+### Issue Category 1
+
+Description and solution to be added.
+
+### Issue Category 2
+
+Description and solution to be added.
+
+## Getting Help
+
+If you're experiencing an issue not covered here:
+
+1. Check the [FAQ](/FAQ) for common questions
+2. Visit our [community support channels](https://universal-blue.discourse.group/)
+3. Search existing [GitHub issues](https://github.com/ublue-os/bluefin/issues)
+4. Create a new issue if your problem hasn't been reported
+
+## Reporting Bugs
+
+When reporting bugs, include:
+
+- Your Bluefin version (`rpm-ostree status`)
+- Hardware specifications
+- Steps to reproduce the issue
+- Any relevant error messages or logs

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         "bluefin-dx",
         "devcontainers",
         "command-line",
+        "troubleshooting",
       ],
     },
     {


### PR DESCRIPTION
## Summary

Adds a new troubleshooting page to the Documentation section, positioned after the command-line page.

## Changes

- Created `docs/troubleshooting.md` with placeholder content
- Added page to `sidebars.ts` in the Documentation category after command-line
- Set page as hidden using `unlisted: true` frontmatter property

## Behavior

The troubleshooting page is:
- Hidden from navigation and search by default
- Accessible via direct URL: `/troubleshooting`
- Positioned in the sidebar configuration for future visibility

## Purpose

Provides a foundation for future troubleshooting guides. The page can be populated with content and made visible by removing the `unlisted: true` property when ready.

## Testing

- TypeScript compilation: Will be validated by CI
- Build: Will be validated by CI  
- Manual verification: Page is hidden but accessible via direct link

---

**Note**: The page currently contains placeholder content and is intentionally hidden until more comprehensive troubleshooting content is added.