### PR TITLE
docs: update fedora media writer link on installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ This page is a short [runbook](https://www.pagerduty.com/resources/learn/what-is
 
 Review the [Fedora Silverblue installation instructions](https://docs.fedoraproject.org/en-US/fedora-silverblue/installation/). Some differences to consider:
 
-- Use the [Fedora Media Writer](https://flathub.org/apps/org.fedoraproject.MediaWriter) to create installation media. Other creation methods may not work properly
+- Use the [Fedora Media Writer](https://docs.fedoraproject.org/en-US/fedora/latest/preparing-boot-media/#_fedora_media_writer) to create installation media. Other creation methods may not work properly
   - Use of Ventoy is **unsupported**
 - Older BIOS-based systems are **unsupported**; only UEFI systems are supported
 - Dual booting off of the same disk is **unsupported**; use a dedicated drive for another operating system and use your BIOS to choose another OS to boot off of


### PR DESCRIPTION
On the installation page (https://docs.projectbluefin.io/installation) there is the following text: 

> Use the [Fedora Media Writer](https://flathub.org/apps/org.fedoraproject.MediaWriter) to create installation media

The Fedora Media Writer link currently leads to the flathub page for Fedora Media Writer. I don't think this is ideal because of 3 reasons:
* Flatpak is not OS agnostic
* The flathub page provides very limited information about Fedora Media Writer
* Usage instructions are lacking

This link should be more appropriate: https://docs.fedoraproject.org/en-US/fedora/latest/preparing-boot-media/#_fedora_media_writer

The link above fixes the above 3 issues as such:
* It provides installation instructions for Linux, Windows and MacOS
* It documents what Fedora Media Writer is and does in a better way
* It contains usage instructions