### PR TITLE
feat(reports): adopt Hyperlight-style formatting and simplify bot activity table

### DIFF
--- a/reports/2025-12-31-report.mdx
+++ b/reports/2025-12-31-report.mdx
@@ -25,15 +25,15 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#90 feat: disable atuin shell integration by default](https://github.com/projectbluefin/common/pull/90) by @​castrojo
-- [#87 fix(motd): use full terminal width](https://github.com/projectbluefin/common/pull/87) by @​renner0e
-- [#68 feat: update tips in 10-tips.md](https://github.com/projectbluefin/common/pull/68) by @​castrojo
-- [#67 feat(ublue-bling): clean up script considerably and allow for overrides](https://github.com/projectbluefin/common/pull/67) by @​tulilirockz
-- [#52 feat: add ublue-motd but better since we just use envsubst here](https://github.com/projectbluefin/common/pull/52) by @​tulilirockz
-- [#44 feat: move everything from `ublue-fastfetch` to here instead](https://github.com/projectbluefin/common/pull/44) by @​tulilirockz
-- [#43 feat: add ublue-bling](https://github.com/projectbluefin/common/pull/43) by @​renner0e
-- [#32 feat: add full-desktop Brewfile with GNOME Circle apps](https://github.com/projectbluefin/common/pull/32) by @​castrojo
-- [#31 feat: add bluefin-faces and fastfetch](https://github.com/projectbluefin/common/pull/31) by @​renner0e
+- feat: disable atuin shell integration by default by [@​castrojo](https://github.com/castrojo) in [#90](https://github.com/projectbluefin/common/pull/90)
+- fix(motd): use full terminal width by [@​renner0e](https://github.com/renner0e) in [#87](https://github.com/projectbluefin/common/pull/87)
+- feat: update tips in 10-tips.md by [@​castrojo](https://github.com/castrojo) in [#68](https://github.com/projectbluefin/common/pull/68)
+- feat(ublue-bling): clean up script considerably and allow for overrides by [@​tulilirockz](https://github.com/tulilirockz) in [#67](https://github.com/projectbluefin/common/pull/67)
+- feat: add ublue-motd but better since we just use envsubst here by [@​tulilirockz](https://github.com/tulilirockz) in [#52](https://github.com/projectbluefin/common/pull/52)
+- feat: move everything from `ublue-fastfetch` to here instead by [@​tulilirockz](https://github.com/tulilirockz) in [#44](https://github.com/projectbluefin/common/pull/44)
+- feat: add ublue-bling by [@​renner0e](https://github.com/renner0e) in [#43](https://github.com/projectbluefin/common/pull/43)
+- feat: add full-desktop Brewfile with GNOME Circle apps by [@​castrojo](https://github.com/castrojo) in [#32](https://github.com/projectbluefin/common/pull/32)
+- feat: add bluefin-faces and fastfetch by [@​renner0e](https://github.com/renner0e) in [#31](https://github.com/projectbluefin/common/pull/31)
 
 #### ⚡ Opportunistic Work
 
@@ -45,8 +45,8 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#88 feat: add nvim, micro, and helix to the ide list](https://github.com/projectbluefin/common/pull/88) by @​castrojo
-- [#72 feat(dx): add Swift development environment](https://github.com/projectbluefin/common/pull/72) by @​joshyorko
+- feat: add nvim, micro, and helix to the ide list by [@​castrojo](https://github.com/castrojo) in [#88](https://github.com/projectbluefin/common/pull/88)
+- feat(dx): add Swift development environment by [@​joshyorko](https://github.com/joshyorko) in [#72](https://github.com/projectbluefin/common/pull/72)
 
 #### ⚡ Opportunistic Work
 
@@ -58,14 +58,14 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#76 chore(tools): move swift Brewfile to shared](https://github.com/projectbluefin/common/pull/76) by @​ahmedadan
-- [#64 Brewfile fixup](https://github.com/projectbluefin/common/pull/64) by @​hanthor
-- [#38 fix: Change copilot-cli from brew to cask installation](https://github.com/projectbluefin/common/pull/38) by @​inffy
-- [#37 feat: add Claude Code, Mistral Vibe & Kimi CLI](https://github.com/projectbluefin/common/pull/37) by @​KiKaraage
-- [#29 Add font-comic-shanns-mono-nerd-font to Brewfile](https://github.com/projectbluefin/common/pull/29) by @​theMimolet
-- [#25 feat: update ai-tools.Brewfile](https://github.com/projectbluefin/common/pull/25) by @​castrojo
-- [#24 feat: add LM Studio to AI tools Brewfile](https://github.com/projectbluefin/common/pull/24) by @​castrojo
-- [#23 feat: add IDE Brewfile with VSCode, VSCodium, and JetBrains](https://github.com/projectbluefin/common/pull/23) by @​castrojo
+- chore(tools): move swift Brewfile to shared by [@​ahmedadan](https://github.com/ahmedadan) in [#76](https://github.com/projectbluefin/common/pull/76)
+- Brewfile fixup by [@​hanthor](https://github.com/hanthor) in [#64](https://github.com/projectbluefin/common/pull/64)
+- fix: Change copilot-cli from brew to cask installation by [@​inffy](https://github.com/inffy) in [#38](https://github.com/projectbluefin/common/pull/38)
+- feat: add Claude Code, Mistral Vibe & Kimi CLI by [@​KiKaraage](https://github.com/KiKaraage) in [#37](https://github.com/projectbluefin/common/pull/37)
+- Add font-comic-shanns-mono-nerd-font to Brewfile by [@​theMimolet](https://github.com/theMimolet) in [#29](https://github.com/projectbluefin/common/pull/29)
+- feat: update ai-tools.Brewfile by [@​castrojo](https://github.com/castrojo) in [#25](https://github.com/projectbluefin/common/pull/25)
+- feat: add LM Studio to AI tools Brewfile by [@​castrojo](https://github.com/castrojo) in [#24](https://github.com/projectbluefin/common/pull/24)
+- feat: add IDE Brewfile with VSCode, VSCodium, and JetBrains by [@​castrojo](https://github.com/castrojo) in [#23](https://github.com/projectbluefin/common/pull/23)
 
 #### ⚡ Opportunistic Work
 
@@ -77,13 +77,13 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#74 fix: re-include zsa udev rules](https://github.com/projectbluefin/common/pull/74) by @​tulilirockz
-- [#61 fix: togge-tpm2 recipe when NO pin is used](https://github.com/projectbluefin/common/pull/61) by @​inffy
-- [#49 feat: move `ublue-setup-services` to here](https://github.com/projectbluefin/common/pull/49) by @​tulilirockz
-- [#45 feat: add most of `ublue-polkit-rules`](https://github.com/projectbluefin/common/pull/45) by @​tulilirockz
-- [#42 feat: add contents of `ublue-os-udev-rules` + documentation for each udev rule](https://github.com/projectbluefin/common/pull/42) by @​tulilirockz
-- [#41 feat: add contents of `ublue-os-singing` to common](https://github.com/projectbluefin/common/pull/41) by @​tulilirockz
-- [#40 feat: rewrite luks autounlock script with new instructions from gnomeOS](https://github.com/projectbluefin/common/pull/40) by @​tulilirockz
+- fix: re-include zsa udev rules by [@​tulilirockz](https://github.com/tulilirockz) in [#74](https://github.com/projectbluefin/common/pull/74)
+- fix: togge-tpm2 recipe when NO pin is used by [@​inffy](https://github.com/inffy) in [#61](https://github.com/projectbluefin/common/pull/61)
+- feat: move `ublue-setup-services` to here by [@​tulilirockz](https://github.com/tulilirockz) in [#49](https://github.com/projectbluefin/common/pull/49)
+- feat: add most of `ublue-polkit-rules` by [@​tulilirockz](https://github.com/tulilirockz) in [#45](https://github.com/projectbluefin/common/pull/45)
+- feat: add contents of `ublue-os-udev-rules` + documentation for each udev rule by [@​tulilirockz](https://github.com/tulilirockz) in [#42](https://github.com/projectbluefin/common/pull/42)
+- feat: add contents of `ublue-os-singing` to common by [@​tulilirockz](https://github.com/tulilirockz) in [#41](https://github.com/projectbluefin/common/pull/41)
+- feat: rewrite luks autounlock script with new instructions from gnomeOS by [@​tulilirockz](https://github.com/tulilirockz) in [#40](https://github.com/projectbluefin/common/pull/40)
 
 #### ⚡ Opportunistic Work
 
@@ -101,19 +101,19 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#97 feat: add loading message to ujust bbrew command](https://github.com/projectbluefin/common/pull/97) by @​castrojo
-- [#94 feat(ci): add justfile validation](https://github.com/projectbluefin/common/pull/94) by @​renner0e
-- [#92 chore(ujust, bluefin): do not run rollback helper on centos](https://github.com/projectbluefin/common/pull/92) by @​tulilirockz
-- [#84 feat(just):  add a generic shared just recipe](https://github.com/projectbluefin/common/pull/84) by @​inffy
-- [#75 feat: add ujust powerwash command for factory reset](https://github.com/projectbluefin/common/pull/75) by @​castrojo
-- [#69 fix: also install cli.Brewfile for bluefin-cli](https://github.com/projectbluefin/common/pull/69) by @​renner0e
-- [#66 feat(just): add clean-system back](https://github.com/projectbluefin/common/pull/66) by @​renner0e
-- [#56 feat: refactor opentabletdriver just recipe](https://github.com/projectbluefin/common/pull/56) by @​inffy
-- [#54 fix: use ujust and remove urrllink function](https://github.com/projectbluefin/common/pull/54) by @​renner0e
-- [#51 fix(ujust, update): always use bootc upgrade unless packages are being layered (for legacy `rpm-ostree` systems)](https://github.com/projectbluefin/common/pull/51) by @​tulilirockz
-- [#50 ujust: don't hardcode to `/usr/bin/just` so we can use homebrew just for `ujust`!](https://github.com/projectbluefin/common/pull/50) by @​tulilirockz
-- [#47 fix: remove resolve ujust recipe](https://github.com/projectbluefin/common/pull/47) by @​castrojo
-- [#22 chore(just): optionally include custom just recipes](https://github.com/projectbluefin/common/pull/22) by @​tunix
+- feat: add loading message to ujust bbrew command by [@​castrojo](https://github.com/castrojo) in [#97](https://github.com/projectbluefin/common/pull/97)
+- feat(ci): add justfile validation by [@​renner0e](https://github.com/renner0e) in [#94](https://github.com/projectbluefin/common/pull/94)
+- chore(ujust, bluefin): do not run rollback helper on centos by [@​tulilirockz](https://github.com/tulilirockz) in [#92](https://github.com/projectbluefin/common/pull/92)
+- feat(just):  add a generic shared just recipe by [@​inffy](https://github.com/inffy) in [#84](https://github.com/projectbluefin/common/pull/84)
+- feat: add ujust powerwash command for factory reset by [@​castrojo](https://github.com/castrojo) in [#75](https://github.com/projectbluefin/common/pull/75)
+- fix: also install cli.Brewfile for bluefin-cli by [@​renner0e](https://github.com/renner0e) in [#69](https://github.com/projectbluefin/common/pull/69)
+- feat(just): add clean-system back by [@​renner0e](https://github.com/renner0e) in [#66](https://github.com/projectbluefin/common/pull/66)
+- feat: refactor opentabletdriver just recipe by [@​inffy](https://github.com/inffy) in [#56](https://github.com/projectbluefin/common/pull/56)
+- fix: use ujust and remove urrllink function by [@​renner0e](https://github.com/renner0e) in [#54](https://github.com/projectbluefin/common/pull/54)
+- fix(ujust, update): always use bootc upgrade unless packages are being layered (for legacy `rpm-ostree` systems) by [@​tulilirockz](https://github.com/tulilirockz) in [#51](https://github.com/projectbluefin/common/pull/51)
+- ujust: don't hardcode to `/usr/bin/just` so we can use homebrew just for `ujust`! by [@​tulilirockz](https://github.com/tulilirockz) in [#50](https://github.com/projectbluefin/common/pull/50)
+- fix: remove resolve ujust recipe by [@​castrojo](https://github.com/castrojo) in [#47](https://github.com/projectbluefin/common/pull/47)
+- chore(just): optionally include custom just recipes by [@​tunix](https://github.com/tunix) in [#22](https://github.com/projectbluefin/common/pull/22)
 
 #### ⚡ Opportunistic Work
 
@@ -127,13 +127,13 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#39 fix: set wallpaper metadata path to /usr/share](https://github.com/projectbluefin/common/pull/39) by @​renner0e
-- [#59 fix: centralize bluefin bazaar config](https://github.com/projectbluefin/common/pull/59) by @​renner0e
+- fix: set wallpaper metadata path to /usr/share by [@​renner0e](https://github.com/renner0e) in [#39](https://github.com/projectbluefin/common/pull/39)
+- fix: centralize bluefin bazaar config by [@​renner0e](https://github.com/renner0e) in [#59](https://github.com/projectbluefin/common/pull/59)
 
 #### ⚡ Opportunistic Work
 
-- [#943 fix(ci): remove unconsumed build arg](https://github.com/ublue-os/bluefin-lts/pull/943) by @​renner0e
-- [#942 fix: motd printing variables](https://github.com/ublue-os/bluefin-lts/pull/942) by @​renner0e
+- fix(ci): remove unconsumed build arg by [@​renner0e](https://github.com/renner0e) in [#943](https://github.com/ublue-os/bluefin-lts/pull/943)
+- fix: motd printing variables by [@​renner0e](https://github.com/renner0e) in [#942](https://github.com/ublue-os/bluefin-lts/pull/942)
 
 ### Enhancements
 
@@ -141,12 +141,12 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#34 feat: add wallpapers](https://github.com/projectbluefin/common/pull/34) by @​renner0e
-- [#33 feat: move bazaar config to common repo](https://github.com/projectbluefin/common/pull/33) by @​dreamyukii
-- [#99 feat: add Jan to Bazaar curated section](https://github.com/projectbluefin/common/pull/99) by @​coxde
-- [#95 feat: add Cryptomator to utilities list](https://github.com/projectbluefin/common/pull/95) by @​sebjag
-- [#89 feat(bazaar): add brief, remove rewaita](https://github.com/projectbluefin/common/pull/89) by @​castrojo
-- [#46 feat: enable merge queue in build workflow](https://github.com/projectbluefin/common/pull/46) by @​castrojo
+- feat: add wallpapers by [@​renner0e](https://github.com/renner0e) in [#34](https://github.com/projectbluefin/common/pull/34)
+- feat: move bazaar config to common repo by [@​dreamyukii](https://github.com/dreamyukii) in [#33](https://github.com/projectbluefin/common/pull/33)
+- feat: add Jan to Bazaar curated section by [@​coxde](https://github.com/coxde) in [#99](https://github.com/projectbluefin/common/pull/99)
+- feat: add Cryptomator to utilities list by [@​sebjag](https://github.com/sebjag) in [#95](https://github.com/projectbluefin/common/pull/95)
+- feat(bazaar): add brief, remove rewaita by [@​castrojo](https://github.com/castrojo) in [#89](https://github.com/projectbluefin/common/pull/89)
+- feat: enable merge queue in build workflow by [@​castrojo](https://github.com/castrojo) in [#46](https://github.com/projectbluefin/common/pull/46)
 
 #### ⚡ Opportunistic Work
 
@@ -164,7 +164,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#48 chore: move ublue-bling to `/usr/bin` instead of `/usr/libexec`](https://github.com/projectbluefin/common/pull/48) by @​tulilirockz
+- chore: move ublue-bling to `/usr/bin` instead of `/usr/libexec` by [@​tulilirockz](https://github.com/tulilirockz) in [#48](https://github.com/projectbluefin/common/pull/48)
 
 #### ⚡ Opportunistic Work
 
@@ -176,7 +176,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#26 Add regex manager for ublue-os artwork releases](https://github.com/projectbluefin/common/pull/26) by @​inffy
+- Add regex manager for ublue-os artwork releases by [@​inffy](https://github.com/inffy) in [#26](https://github.com/projectbluefin/common/pull/26)
 
 #### ⚡ Opportunistic Work
 
@@ -184,106 +184,105 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 ## 📋 Other
 
-- [#941 chore: fix local builds; check for yq; update bib recipe](https://github.com/ublue-os/bluefin-lts/pull/941) by @​hanthor
-- [#938 refactor: migrate GNOME extensions from COPR to git submodules](https://github.com/ublue-os/bluefin-lts/pull/938) by @​ahmedadan
-- [#922 chore: get bazaar config from common](https://github.com/ublue-os/bluefin-lts/pull/922) by @​renner0e
-- [#1534 fix(ci): use intermediate environment variables](https://github.com/ublue-os/aurora/pull/1534) by @​renner0e
-- [#1526 fix(ci): use just action](https://github.com/ublue-os/aurora/pull/1526) by @​renner0e
-- [#543 End of Year Update](https://github.com/projectbluefin/documentation/pull/543) by @​castrojo
-- [#552 chore(devcontainer): install legacy npm deps, add just, and configure port forwarding](https://github.com/projectbluefin/documentation/pull/552) by @​eltorrero
-- [#549 Add title to GitHubProfileCard for user 'inffy'](https://github.com/projectbluefin/documentation/pull/549) by @​inffy
-- [#551 docs: fix link for projectbluefin/common](https://github.com/projectbluefin/documentation/pull/551) by @​coxde
-- [#553 Enhance 2025 wrap-up with video and content updates](https://github.com/projectbluefin/documentation/pull/553) by @​castrojo
-- [#548 feat(footer): add Contribute column with issues, PRs, and guide links](https://github.com/projectbluefin/documentation/pull/548) by @​castrojo
-- [#546 Update pages to reference upcoming changes to release streams](https://github.com/projectbluefin/documentation/pull/546) by @​fizzyizzy05
-- [#545 Add page contributors section to docs and blog](https://github.com/projectbluefin/documentation/pull/545) by @​castrojo
-- [#544 Move communication channels to footer](https://github.com/projectbluefin/documentation/pull/544) by @​castrojo
-- [#542 Add blog post on upcoming Homebrew CLI changes](https://github.com/projectbluefin/documentation/pull/542) by @​castrojo
-- [#536 docs(donations): add @krisnova to advisors and mentors](https://github.com/projectbluefin/documentation/pull/536) by @​castrojo
-- [#535 feat: update contributor guide](https://github.com/projectbluefin/documentation/pull/535) by @​castrojo
-- [#533 chore: remove unused changelogs folder](https://github.com/projectbluefin/documentation/pull/533) by @​castrojo
-- [#531 docs(tips): add donation URLs for GNOME extensions](https://github.com/projectbluefin/documentation/pull/531) by @​castrojo
-- [#530 ci: enable automerge for driver version PRs](https://github.com/projectbluefin/documentation/pull/530) by @​castrojo
-- [#529 feat(prompts): add conventional commit prompt and guidelines](https://github.com/projectbluefin/documentation/pull/529) by @​castrojo
-- [#528 docs: fix incorrect ujust commands](https://github.com/projectbluefin/documentation/pull/528) by @​castrojo
-- [#527 docs: update brew package lists to match source of truth](https://github.com/projectbluefin/documentation/pull/527) by @​castrojo
-- [#525 Add Discussions section to blog post on Homebrew](https://github.com/projectbluefin/documentation/pull/525) by @​castrojo
-- [#523 Update Brewfile package tables to match projectbluefin/common](https://github.com/projectbluefin/documentation/pull/523) by @​castrojo
-- [#522 feat: add brew post](https://github.com/projectbluefin/documentation/pull/522) by @​castrojo
-- [#521 docs: remove ujust install-resolve command](https://github.com/projectbluefin/documentation/pull/521) by @​castrojo
-- [#520 feat: add huntress and holiday wallpapers blog post](https://github.com/projectbluefin/documentation/pull/520) by @​castrojo
-- [#519 fix: remove duplicate driver version entries and prevent future duplicates](https://github.com/projectbluefin/documentation/pull/519) by @​castrojo
-- [#517 ci: change driver versions workflow to open PR instead of direct push](https://github.com/projectbluefin/documentation/pull/517) by @​castrojo
-- [#514 add Tailscale systray recommendation](https://github.com/projectbluefin/documentation/pull/514) by @​bronson
-- [#516 docs: add @mairin to Special Guests section](https://github.com/projectbluefin/documentation/pull/516) by @​castrojo
-- [#513 feat: split donations page into contributors and projects](https://github.com/projectbluefin/documentation/pull/513) by @​castrojo
-- [#512 docs(gdx): convert donation links to GitHubProfileCard components](https://github.com/projectbluefin/documentation/pull/512) by @​castrojo
-- [#511 docs(lts): convert donation links to GitHubProfileCard components](https://github.com/projectbluefin/documentation/pull/511) by @​castrojo
-- [#510 feat: improve footer navigation and fix links](https://github.com/projectbluefin/documentation/pull/510) by @​castrojo
-- [#509 fix: update footer links and add Bluefin website](https://github.com/projectbluefin/documentation/pull/509) by @​castrojo
-- [#508 fix: make GNOME extensions grid responsive for mobile](https://github.com/projectbluefin/documentation/pull/508) by @​castrojo
-- [#507 feat: add Giscus comments to blog posts](https://github.com/projectbluefin/documentation/pull/507) by @​castrojo
-- [#506 Create 2025-12-07-documentation-updates.md](https://github.com/projectbluefin/documentation/pull/506) by @​castrojo
-- [#505 docs: improve tagging and cleanup driver-versions page](https://github.com/projectbluefin/documentation/pull/505) by @​castrojo
-- [#504 feat: add driver versions page with automated updates](https://github.com/projectbluefin/documentation/pull/504) by @​castrojo
-- [#503 feat(tips): Add GNOME extensions thumbnail gallery](https://github.com/projectbluefin/documentation/pull/503) by @​castrojo
-- [#500 Correct minor typos and grammar errors across documentation](https://github.com/projectbluefin/documentation/pull/500) by @​AnthonyStainer
-- [#498 Fix reference links](https://github.com/projectbluefin/documentation/pull/498) by @​wommy
-- [#501 feat: add the interview with michael](https://github.com/projectbluefin/documentation/pull/501) by @​castrojo
-- [#497 feat: brewfile blog post](https://github.com/projectbluefin/documentation/pull/497) by @​castrojo
-- [#1 feat: add bazaar pictures](https://github.com/projectbluefin/branding/pull/1) by @​renner0e
-- [#20 Add some default branding](https://github.com/projectbluefin/dakota/pull/20) by @​jumpyvi
-- [#21 feat: Switch to ublue-os brew container](https://github.com/projectbluefin/dakota/pull/21) by @​castrojo
-- [#17 Deduplicate .gitmodules](https://github.com/projectbluefin/dakota/pull/17) by @​sideeffffect
-- [#18 feat: add QoL features to Justfile](https://github.com/projectbluefin/dakota/pull/18) by @​ahmedadan
-- [#16 feat: remove logos use common](https://github.com/projectbluefin/dakota/pull/16) by @​renner0e
-- [#15 fix: make vm respect change in resolution in gnome](https://github.com/projectbluefin/dakota/pull/15) by @​ahmedadan
-- [#13 fix: properly use common](https://github.com/projectbluefin/dakota/pull/13) by @​renner0e
-- [#14 fix: add git submodule init to Justfile](https://github.com/projectbluefin/dakota/pull/14) by @​ahmedadan
-- [#12 feat: add show-me-the-future command](https://github.com/projectbluefin/dakota/pull/12) by @​castrojo
-- [#11 feat: add just run-vm to simplify testing](https://github.com/projectbluefin/dakota/pull/11) by @​ahmedadan
-- [#9 fix: add with recursive to build.yml](https://github.com/projectbluefin/dakota/pull/9) by @​ahmedadan
-- [#8 fix: update upstream image url](https://github.com/projectbluefin/dakota/pull/8) by @​castrojo
-- [#20 Add some default branding](https://github.com/projectbluefin/dakota/pull/20) by @​jumpyvi
-- [#21 feat: Switch to ublue-os brew container](https://github.com/projectbluefin/dakota/pull/21) by @​castrojo
-- [#17 Deduplicate .gitmodules](https://github.com/projectbluefin/dakota/pull/17) by @​sideeffffect
-- [#18 feat: add QoL features to Justfile](https://github.com/projectbluefin/dakota/pull/18) by @​ahmedadan
-- [#16 feat: remove logos use common](https://github.com/projectbluefin/dakota/pull/16) by @​renner0e
-- [#15 fix: make vm respect change in resolution in gnome](https://github.com/projectbluefin/dakota/pull/15) by @​ahmedadan
-- [#13 fix: properly use common](https://github.com/projectbluefin/dakota/pull/13) by @​renner0e
-- [#14 fix: add git submodule init to Justfile](https://github.com/projectbluefin/dakota/pull/14) by @​ahmedadan
-- [#12 feat: add show-me-the-future command](https://github.com/projectbluefin/dakota/pull/12) by @​castrojo
-- [#11 feat: add just run-vm to simplify testing](https://github.com/projectbluefin/dakota/pull/11) by @​ahmedadan
-- [#9 fix: add with recursive to build.yml](https://github.com/projectbluefin/dakota/pull/9) by @​ahmedadan
-- [#8 fix: update upstream image url](https://github.com/projectbluefin/dakota/pull/8) by @​castrojo
+- chore: fix local builds; check for yq; update bib recipe by [@​hanthor](https://github.com/hanthor) in [#941](https://github.com/ublue-os/bluefin-lts/pull/941)
+- refactor: migrate GNOME extensions from COPR to git submodules by [@​ahmedadan](https://github.com/ahmedadan) in [#938](https://github.com/ublue-os/bluefin-lts/pull/938)
+- chore: get bazaar config from common by [@​renner0e](https://github.com/renner0e) in [#922](https://github.com/ublue-os/bluefin-lts/pull/922)
+- fix(ci): use intermediate environment variables by [@​renner0e](https://github.com/renner0e) in [#1534](https://github.com/ublue-os/aurora/pull/1534)
+- fix(ci): use just action by [@​renner0e](https://github.com/renner0e) in [#1526](https://github.com/ublue-os/aurora/pull/1526)
+- End of Year Update by [@​castrojo](https://github.com/castrojo) in [#543](https://github.com/projectbluefin/documentation/pull/543)
+- chore(devcontainer): install legacy npm deps, add just, and configure port forwarding by [@​eltorrero](https://github.com/eltorrero) in [#552](https://github.com/projectbluefin/documentation/pull/552)
+- Add title to GitHubProfileCard for user 'inffy' by [@​inffy](https://github.com/inffy) in [#549](https://github.com/projectbluefin/documentation/pull/549)
+- docs: fix link for projectbluefin/common by [@​coxde](https://github.com/coxde) in [#551](https://github.com/projectbluefin/documentation/pull/551)
+- Enhance 2025 wrap-up with video and content updates by [@​castrojo](https://github.com/castrojo) in [#553](https://github.com/projectbluefin/documentation/pull/553)
+- feat(footer): add Contribute column with issues, PRs, and guide links by [@​castrojo](https://github.com/castrojo) in [#548](https://github.com/projectbluefin/documentation/pull/548)
+- Update pages to reference upcoming changes to release streams by [@​fizzyizzy05](https://github.com/fizzyizzy05) in [#546](https://github.com/projectbluefin/documentation/pull/546)
+- Add page contributors section to docs and blog by [@​castrojo](https://github.com/castrojo) in [#545](https://github.com/projectbluefin/documentation/pull/545)
+- Move communication channels to footer by [@​castrojo](https://github.com/castrojo) in [#544](https://github.com/projectbluefin/documentation/pull/544)
+- Add blog post on upcoming Homebrew CLI changes by [@​castrojo](https://github.com/castrojo) in [#542](https://github.com/projectbluefin/documentation/pull/542)
+- docs(donations): add @krisnova to advisors and mentors by [@​castrojo](https://github.com/castrojo) in [#536](https://github.com/projectbluefin/documentation/pull/536)
+- feat: update contributor guide by [@​castrojo](https://github.com/castrojo) in [#535](https://github.com/projectbluefin/documentation/pull/535)
+- chore: remove unused changelogs folder by [@​castrojo](https://github.com/castrojo) in [#533](https://github.com/projectbluefin/documentation/pull/533)
+- docs(tips): add donation URLs for GNOME extensions by [@​castrojo](https://github.com/castrojo) in [#531](https://github.com/projectbluefin/documentation/pull/531)
+- ci: enable automerge for driver version PRs by [@​castrojo](https://github.com/castrojo) in [#530](https://github.com/projectbluefin/documentation/pull/530)
+- feat(prompts): add conventional commit prompt and guidelines by [@​castrojo](https://github.com/castrojo) in [#529](https://github.com/projectbluefin/documentation/pull/529)
+- docs: fix incorrect ujust commands by [@​castrojo](https://github.com/castrojo) in [#528](https://github.com/projectbluefin/documentation/pull/528)
+- docs: update brew package lists to match source of truth by [@​castrojo](https://github.com/castrojo) in [#527](https://github.com/projectbluefin/documentation/pull/527)
+- Add Discussions section to blog post on Homebrew by [@​castrojo](https://github.com/castrojo) in [#525](https://github.com/projectbluefin/documentation/pull/525)
+- Update Brewfile package tables to match projectbluefin/common by [@​castrojo](https://github.com/castrojo) in [#523](https://github.com/projectbluefin/documentation/pull/523)
+- feat: add brew post by [@​castrojo](https://github.com/castrojo) in [#522](https://github.com/projectbluefin/documentation/pull/522)
+- docs: remove ujust install-resolve command by [@​castrojo](https://github.com/castrojo) in [#521](https://github.com/projectbluefin/documentation/pull/521)
+- feat: add huntress and holiday wallpapers blog post by [@​castrojo](https://github.com/castrojo) in [#520](https://github.com/projectbluefin/documentation/pull/520)
+- fix: remove duplicate driver version entries and prevent future duplicates by [@​castrojo](https://github.com/castrojo) in [#519](https://github.com/projectbluefin/documentation/pull/519)
+- ci: change driver versions workflow to open PR instead of direct push by [@​castrojo](https://github.com/castrojo) in [#517](https://github.com/projectbluefin/documentation/pull/517)
+- add Tailscale systray recommendation by [@​bronson](https://github.com/bronson) in [#514](https://github.com/projectbluefin/documentation/pull/514)
+- docs: add @mairin to Special Guests section by [@​castrojo](https://github.com/castrojo) in [#516](https://github.com/projectbluefin/documentation/pull/516)
+- feat: split donations page into contributors and projects by [@​castrojo](https://github.com/castrojo) in [#513](https://github.com/projectbluefin/documentation/pull/513)
+- docs(gdx): convert donation links to GitHubProfileCard components by [@​castrojo](https://github.com/castrojo) in [#512](https://github.com/projectbluefin/documentation/pull/512)
+- docs(lts): convert donation links to GitHubProfileCard components by [@​castrojo](https://github.com/castrojo) in [#511](https://github.com/projectbluefin/documentation/pull/511)
+- feat: improve footer navigation and fix links by [@​castrojo](https://github.com/castrojo) in [#510](https://github.com/projectbluefin/documentation/pull/510)
+- fix: update footer links and add Bluefin website by [@​castrojo](https://github.com/castrojo) in [#509](https://github.com/projectbluefin/documentation/pull/509)
+- fix: make GNOME extensions grid responsive for mobile by [@​castrojo](https://github.com/castrojo) in [#508](https://github.com/projectbluefin/documentation/pull/508)
+- feat: add Giscus comments to blog posts by [@​castrojo](https://github.com/castrojo) in [#507](https://github.com/projectbluefin/documentation/pull/507)
+- Create 2025-12-07-documentation-updates.md by [@​castrojo](https://github.com/castrojo) in [#506](https://github.com/projectbluefin/documentation/pull/506)
+- docs: improve tagging and cleanup driver-versions page by [@​castrojo](https://github.com/castrojo) in [#505](https://github.com/projectbluefin/documentation/pull/505)
+- feat: add driver versions page with automated updates by [@​castrojo](https://github.com/castrojo) in [#504](https://github.com/projectbluefin/documentation/pull/504)
+- feat(tips): Add GNOME extensions thumbnail gallery by [@​castrojo](https://github.com/castrojo) in [#503](https://github.com/projectbluefin/documentation/pull/503)
+- Correct minor typos and grammar errors across documentation by [@​AnthonyStainer](https://github.com/AnthonyStainer) in [#500](https://github.com/projectbluefin/documentation/pull/500)
+- Fix reference links by [@​wommy](https://github.com/wommy) in [#498](https://github.com/projectbluefin/documentation/pull/498)
+- feat: add the interview with michael by [@​castrojo](https://github.com/castrojo) in [#501](https://github.com/projectbluefin/documentation/pull/501)
+- feat: brewfile blog post by [@​castrojo](https://github.com/castrojo) in [#497](https://github.com/projectbluefin/documentation/pull/497)
+- feat: add bazaar pictures by [@​renner0e](https://github.com/renner0e) in [#1](https://github.com/projectbluefin/branding/pull/1)
+- Add some default branding by [@​jumpyvi](https://github.com/jumpyvi) in [#20](https://github.com/projectbluefin/dakota/pull/20)
+- feat: Switch to ublue-os brew container by [@​castrojo](https://github.com/castrojo) in [#21](https://github.com/projectbluefin/dakota/pull/21)
+- Deduplicate .gitmodules by [@​sideeffffect](https://github.com/sideeffffect) in [#17](https://github.com/projectbluefin/dakota/pull/17)
+- feat: add QoL features to Justfile by [@​ahmedadan](https://github.com/ahmedadan) in [#18](https://github.com/projectbluefin/dakota/pull/18)
+- feat: remove logos use common by [@​renner0e](https://github.com/renner0e) in [#16](https://github.com/projectbluefin/dakota/pull/16)
+- fix: make vm respect change in resolution in gnome by [@​ahmedadan](https://github.com/ahmedadan) in [#15](https://github.com/projectbluefin/dakota/pull/15)
+- fix: properly use common by [@​renner0e](https://github.com/renner0e) in [#13](https://github.com/projectbluefin/dakota/pull/13)
+- fix: add git submodule init to Justfile by [@​ahmedadan](https://github.com/ahmedadan) in [#14](https://github.com/projectbluefin/dakota/pull/14)
+- feat: add show-me-the-future command by [@​castrojo](https://github.com/castrojo) in [#12](https://github.com/projectbluefin/dakota/pull/12)
+- feat: add just run-vm to simplify testing by [@​ahmedadan](https://github.com/ahmedadan) in [#11](https://github.com/projectbluefin/dakota/pull/11)
+- fix: add with recursive to build.yml by [@​ahmedadan](https://github.com/ahmedadan) in [#9](https://github.com/projectbluefin/dakota/pull/9)
+- fix: update upstream image url by [@​castrojo](https://github.com/castrojo) in [#8](https://github.com/projectbluefin/dakota/pull/8)
+- Add some default branding by [@​jumpyvi](https://github.com/jumpyvi) in [#20](https://github.com/projectbluefin/dakota/pull/20)
+- feat: Switch to ublue-os brew container by [@​castrojo](https://github.com/castrojo) in [#21](https://github.com/projectbluefin/dakota/pull/21)
+- Deduplicate .gitmodules by [@​sideeffffect](https://github.com/sideeffffect) in [#17](https://github.com/projectbluefin/dakota/pull/17)
+- feat: add QoL features to Justfile by [@​ahmedadan](https://github.com/ahmedadan) in [#18](https://github.com/projectbluefin/dakota/pull/18)
+- feat: remove logos use common by [@​renner0e](https://github.com/renner0e) in [#16](https://github.com/projectbluefin/dakota/pull/16)
+- fix: make vm respect change in resolution in gnome by [@​ahmedadan](https://github.com/ahmedadan) in [#15](https://github.com/projectbluefin/dakota/pull/15)
+- fix: properly use common by [@​renner0e](https://github.com/renner0e) in [#13](https://github.com/projectbluefin/dakota/pull/13)
+- fix: add git submodule init to Justfile by [@​ahmedadan](https://github.com/ahmedadan) in [#14](https://github.com/projectbluefin/dakota/pull/14)
+- feat: add show-me-the-future command by [@​castrojo](https://github.com/castrojo) in [#12](https://github.com/projectbluefin/dakota/pull/12)
+- feat: add just run-vm to simplify testing by [@​ahmedadan](https://github.com/ahmedadan) in [#11](https://github.com/projectbluefin/dakota/pull/11)
+- fix: add with recursive to build.yml by [@​ahmedadan](https://github.com/ahmedadan) in [#9](https://github.com/projectbluefin/dakota/pull/9)
+- fix: update upstream image url by [@​castrojo](https://github.com/castrojo) in [#8](https://github.com/projectbluefin/dakota/pull/8)
 
 ## 🤖 Bot Activity
 
-| Repository | Bot | PRs |
-|------------|-----|-----|
-| common | copilot-swe-agent | 1 |
-| bluefin-lts | ubot-7274 | 2 |
-| documentation | github-actions | 4 |
-| documentation | copilot-swe-agent | 2 |
-| dakota | dependabot | 2 |
-| distroless | dependabot | 2 |
+| Repository | Bot PRs |
+|------------|---------|
+| documentation | 6 |
+| bluefin-lts | 2 |
+| dakota | 2 |
+| distroless | 2 |
+| common | 1 |
 
 <details>
 <summary>View bot activity details</summary>
 
-- [#36 docs: document Brewfiles and remove non-existent flatpak-extras references](https://github.com/projectbluefin/common/pull/36) in projectbluefin/common
-- [#940 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 48bfc00](https://github.com/ublue-os/bluefin-lts/pull/940) in ublue-os/bluefin-lts
-- [#939 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to d30ad1a](https://github.com/ublue-os/bluefin-lts/pull/939) in ublue-os/bluefin-lts
-- [#550 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/550) in projectbluefin/documentation
-- [#534 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/534) in projectbluefin/documentation
-- [#526 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/526) in projectbluefin/documentation
-- [#518 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/518) in projectbluefin/documentation
-- [#538 feat: implement GitHub data caching to reduce API calls and build times](https://github.com/projectbluefin/documentation/pull/538) in projectbluefin/documentation
-- [#539 Implement gemini-code-assist code review recommendations](https://github.com/projectbluefin/documentation/pull/539) in projectbluefin/documentation
-- [#10 build(deps): bump actions/checkout from 6.0.0 to 6.0.1](https://github.com/projectbluefin/dakota/pull/10) in projectbluefin/dakota
-- [#7 build(deps): bump docker/metadata-action from 5.9.0 to 5.10.0](https://github.com/projectbluefin/dakota/pull/7) in projectbluefin/dakota
-- [#10 build(deps): bump actions/checkout from 6.0.0 to 6.0.1](https://github.com/projectbluefin/dakota/pull/10) in projectbluefin/distroless
-- [#7 build(deps): bump docker/metadata-action from 5.9.0 to 5.10.0](https://github.com/projectbluefin/dakota/pull/7) in projectbluefin/distroless
+- docs: document Brewfiles and remove non-existent flatpak-extras references by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/common#36](https://github.com/projectbluefin/common/pull/36)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 48bfc00 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#940](https://github.com/ublue-os/bluefin-lts/pull/940)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to d30ad1a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#939](https://github.com/ublue-os/bluefin-lts/pull/939)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#550](https://github.com/projectbluefin/documentation/pull/550)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#534](https://github.com/projectbluefin/documentation/pull/534)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#526](https://github.com/projectbluefin/documentation/pull/526)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#518](https://github.com/projectbluefin/documentation/pull/518)
+- feat: implement GitHub data caching to reduce API calls and build times by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#538](https://github.com/projectbluefin/documentation/pull/538)
+- Implement gemini-code-assist code review recommendations by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#539](https://github.com/projectbluefin/documentation/pull/539)
+- build(deps): bump actions/checkout from 6.0.0 to 6.0.1 by [@​dependabot](https://github.com/dependabot) in [projectbluefin/dakota#10](https://github.com/projectbluefin/dakota/pull/10)
+- build(deps): bump docker/metadata-action from 5.9.0 to 5.10.0 by [@​dependabot](https://github.com/dependabot) in [projectbluefin/dakota#7](https://github.com/projectbluefin/dakota/pull/7)
+- build(deps): bump actions/checkout from 6.0.0 to 6.0.1 by [@​dependabot](https://github.com/dependabot) in [projectbluefin/distroless#10](https://github.com/projectbluefin/dakota/pull/10)
+- build(deps): bump docker/metadata-action from 5.9.0 to 5.10.0 by [@​dependabot](https://github.com/dependabot) in [projectbluefin/distroless#7](https://github.com/projectbluefin/dakota/pull/7)
 
 </details>
 

--- a/reports/2026-01-31-report.mdx
+++ b/reports/2026-01-31-report.mdx
@@ -10,9 +10,9 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 # Summary
 
 - **Month:** January 2026
-- **Total items:** 158
+- **Total items:** 159
   - **Planned work:** 35
-  - **Opportunistic work:** 123
+  - **Opportunistic work:** 124
 - **Contributors:** 22
 - **New contributors:** 10
 
@@ -25,13 +25,13 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#183 feat: Add org.gnome.SoundRecorder to system-flatpaks](https://github.com/projectbluefin/common/pull/183) by @​LorbusChris
-- [#161 fix(mise): Auto install and activate mise unless told otherwise](https://github.com/projectbluefin/common/pull/161) by @​rwaltr
-- [#151 fix(fish): trigger ublue-motd from fish by default](https://github.com/projectbluefin/common/pull/151) by @​rwaltr
-- [#124 feat(bluefin, gschemas): specify mutter experimental features directly on gschema](https://github.com/projectbluefin/common/pull/124) by @​tulilirockz
-- [#114 chore(bluefin, motd): documentation should be https instead of http](https://github.com/projectbluefin/common/pull/114) by @​tulilirockz
-- [#109 fix: #3919 add no-op for appimage files](https://github.com/projectbluefin/common/pull/109) by @​sebjag
-- [#101 feat: add everything from bluefin-schemas and bluefin(lts)](https://github.com/projectbluefin/common/pull/101) by @​renner0e
+- feat: Add org.gnome.SoundRecorder to system-flatpaks by [@​LorbusChris](https://github.com/LorbusChris) in [#183](https://github.com/projectbluefin/common/pull/183)
+- fix(mise): Auto install and activate mise unless told otherwise by [@​rwaltr](https://github.com/rwaltr) in [#161](https://github.com/projectbluefin/common/pull/161)
+- fix(fish): trigger ublue-motd from fish by default by [@​rwaltr](https://github.com/rwaltr) in [#151](https://github.com/projectbluefin/common/pull/151)
+- feat(bluefin, gschemas): specify mutter experimental features directly on gschema by [@​tulilirockz](https://github.com/tulilirockz) in [#124](https://github.com/projectbluefin/common/pull/124)
+- chore(bluefin, motd): documentation should be https instead of http by [@​tulilirockz](https://github.com/tulilirockz) in [#114](https://github.com/projectbluefin/common/pull/114)
+- fix: #3919 add no-op for appimage files by [@​sebjag](https://github.com/sebjag) in [#109](https://github.com/projectbluefin/common/pull/109)
+- feat: add everything from bluefin-schemas and bluefin(lts) by [@​renner0e](https://github.com/renner0e) in [#101](https://github.com/projectbluefin/common/pull/101)
 
 #### ⚡ Opportunistic Work
 
@@ -43,19 +43,19 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#190 revert: remove weekly status report automation](https://github.com/projectbluefin/common/pull/190) by @​castrojo
-- [#187 feat: add weekly status report automation](https://github.com/projectbluefin/common/pull/187) by @​castrojo
+- revert: remove weekly status report automation by [@​castrojo](https://github.com/castrojo) in [#190](https://github.com/projectbluefin/common/pull/190)
+- feat: add weekly status report automation by [@​castrojo](https://github.com/castrojo) in [#187](https://github.com/projectbluefin/common/pull/187)
 
 #### ⚡ Opportunistic Work
 
-- [#1007 fix: switch GDX to HWE kernel](https://github.com/ublue-os/bluefin-lts/pull/1007) by @​hanthor
-- [#991 chore: remove a few unnecessary steps on build](https://github.com/ublue-os/bluefin-lts/pull/991) by @​tulilirockz
-- [#985 pull: do rebase instead](https://github.com/ublue-os/bluefin-lts/pull/985) by @​tulilirockz
-- [#917 chore: move `ublue-privileged-setup` invocation to `/usr/bin` instead of `/usr/libexec`](https://github.com/ublue-os/bluefin-lts/pull/917) by @​tulilirockz
-- [#980 ci: add permissions to workflows + DEFAULT_TAG needs to change on `manifest` job](https://github.com/ublue-os/bluefin-lts/pull/980) by @​tulilirockz
-- [#975 chore: clean up a buuunch of vendored things that we dont need anymore](https://github.com/ublue-os/bluefin-lts/pull/975) by @​tulilirockz
-- [#958 fix(dx): identify as dx in imageinfo](https://github.com/ublue-os/bluefin-lts/pull/958) by @​rrenomeron
-- [#948 feat(dx): Add Cockpit packages](https://github.com/ublue-os/bluefin-lts/pull/948) by @​rrenomeron
+- fix: switch GDX to HWE kernel by [@​hanthor](https://github.com/hanthor) in [#1007](https://github.com/ublue-os/bluefin-lts/pull/1007)
+- chore: remove a few unnecessary steps on build by [@​tulilirockz](https://github.com/tulilirockz) in [#991](https://github.com/ublue-os/bluefin-lts/pull/991)
+- pull: do rebase instead by [@​tulilirockz](https://github.com/tulilirockz) in [#985](https://github.com/ublue-os/bluefin-lts/pull/985)
+- chore: move `ublue-privileged-setup` invocation to `/usr/bin` instead of `/usr/libexec` by [@​tulilirockz](https://github.com/tulilirockz) in [#917](https://github.com/ublue-os/bluefin-lts/pull/917)
+- ci: add permissions to workflows + DEFAULT_TAG needs to change on `manifest` job by [@​tulilirockz](https://github.com/tulilirockz) in [#980](https://github.com/ublue-os/bluefin-lts/pull/980)
+- chore: clean up a buuunch of vendored things that we dont need anymore by [@​tulilirockz](https://github.com/tulilirockz) in [#975](https://github.com/ublue-os/bluefin-lts/pull/975)
+- fix(dx): identify as dx in imageinfo by [@​rrenomeron](https://github.com/rrenomeron) in [#958](https://github.com/ublue-os/bluefin-lts/pull/958)
+- feat(dx): Add Cockpit packages by [@​rrenomeron](https://github.com/rrenomeron) in [#948](https://github.com/ublue-os/bluefin-lts/pull/948)
 
 ### Ecosystem
 
@@ -63,14 +63,14 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#178 feat: add Whis to "AI & Machine Learning" Bazaar curation](https://github.com/projectbluefin/common/pull/178) by @​KiKaraage
-- [#177 feat: add jetbrains-mono-nerd-font to font brewfile](https://github.com/projectbluefin/common/pull/177) by @​inffy
-- [#173 fix: update brewfiles with latest homebrew packages](https://github.com/projectbluefin/common/pull/173) by @​hanthor
-- [#168 chore: move opencode from homebrew-core to developer tap](https://github.com/projectbluefin/common/pull/168) by @​ahmedadan
-- [#112 fix: make installed-pill more readable](https://github.com/projectbluefin/common/pull/112) by @​renner0e
-- [#113 feat(bluefin): add system-flatpaks brewfiles on this repository so we dont need them on every repo](https://github.com/projectbluefin/common/pull/113) by @​tulilirockz
-- [#107 feat(ai): add goose-linux gui](https://github.com/projectbluefin/common/pull/107) by @​castrojo
-- [#98 feat: add Jan flatpak to ai-tools Brewfile](https://github.com/projectbluefin/common/pull/98) by @​coxde
+- feat: add Whis to "AI & Machine Learning" Bazaar curation by [@​KiKaraage](https://github.com/KiKaraage) in [#178](https://github.com/projectbluefin/common/pull/178)
+- feat: add jetbrains-mono-nerd-font to font brewfile by [@​inffy](https://github.com/inffy) in [#177](https://github.com/projectbluefin/common/pull/177)
+- fix: update brewfiles with latest homebrew packages by [@​hanthor](https://github.com/hanthor) in [#173](https://github.com/projectbluefin/common/pull/173)
+- chore: move opencode from homebrew-core to developer tap by [@​ahmedadan](https://github.com/ahmedadan) in [#168](https://github.com/projectbluefin/common/pull/168)
+- fix: make installed-pill more readable by [@​renner0e](https://github.com/renner0e) in [#112](https://github.com/projectbluefin/common/pull/112)
+- feat(bluefin): add system-flatpaks brewfiles on this repository so we dont need them on every repo by [@​tulilirockz](https://github.com/tulilirockz) in [#113](https://github.com/projectbluefin/common/pull/113)
+- feat(ai): add goose-linux gui by [@​castrojo](https://github.com/castrojo) in [#107](https://github.com/projectbluefin/common/pull/107)
+- feat: add Jan flatpak to ai-tools Brewfile by [@​coxde](https://github.com/coxde) in [#98](https://github.com/projectbluefin/common/pull/98)
 
 #### ⚡ Opportunistic Work
 
@@ -82,7 +82,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#115 fix(shared, uupd): enable uupd on a preset by default](https://github.com/projectbluefin/common/pull/115) by @​tulilirockz
+- fix(shared, uupd): enable uupd on a preset by default by [@​tulilirockz](https://github.com/tulilirockz) in [#115](https://github.com/projectbluefin/common/pull/115)
 
 #### ⚡ Opportunistic Work
 
@@ -100,19 +100,19 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#170 fix(bluefin, rebase-helper): re-enable rebase helper for bluefin LTS](https://github.com/projectbluefin/common/pull/170) by @​tulilirockz
-- [#157 fix(bluefin, devmode): correctly rebase people to (image)-dx-nvidia-open](https://github.com/projectbluefin/common/pull/157) by @​tulilirockz
-- [#153 fix: move powerwash to bluefin specific justfile](https://github.com/projectbluefin/common/pull/153) by @​inffy
-- [#152 fix: formatting in default.just file](https://github.com/projectbluefin/common/pull/152) by @​inffy
-- [#129 fix(opentabletdriver): add blacklist for wacom drivers](https://github.com/projectbluefin/common/pull/129) by @​tulilirockz
-- [#117 chore: remove libujust and use new opentabletdriver recipe](https://github.com/projectbluefin/common/pull/117) by @​tulilirockz
-- [#108 fix: make grep quiet on a few places](https://github.com/projectbluefin/common/pull/108) by @​tulilirockz
-- [#106 chore: consolidate ujust update with aurora and split changelog + minor fixes](https://github.com/projectbluefin/common/pull/106) by @​tulilirockz
+- fix(bluefin, rebase-helper): re-enable rebase helper for bluefin LTS by [@​tulilirockz](https://github.com/tulilirockz) in [#170](https://github.com/projectbluefin/common/pull/170)
+- fix(bluefin, devmode): correctly rebase people to (image)-dx-nvidia-open by [@​tulilirockz](https://github.com/tulilirockz) in [#157](https://github.com/projectbluefin/common/pull/157)
+- fix: move powerwash to bluefin specific justfile by [@​inffy](https://github.com/inffy) in [#153](https://github.com/projectbluefin/common/pull/153)
+- fix: formatting in default.just file by [@​inffy](https://github.com/inffy) in [#152](https://github.com/projectbluefin/common/pull/152)
+- fix(opentabletdriver): add blacklist for wacom drivers by [@​tulilirockz](https://github.com/tulilirockz) in [#129](https://github.com/projectbluefin/common/pull/129)
+- chore: remove libujust and use new opentabletdriver recipe by [@​tulilirockz](https://github.com/tulilirockz) in [#117](https://github.com/projectbluefin/common/pull/117)
+- fix: make grep quiet on a few places by [@​tulilirockz](https://github.com/tulilirockz) in [#108](https://github.com/projectbluefin/common/pull/108)
+- chore: consolidate ujust update with aurora and split changelog + minor fixes by [@​tulilirockz](https://github.com/tulilirockz) in [#106](https://github.com/projectbluefin/common/pull/106)
 
 #### ⚡ Opportunistic Work
 
-- [#3972 chore(iso): clean up everything related to ISOs here](https://github.com/ublue-os/bluefin/pull/3972) by @​tulilirockz
-- [#3971 chore(flatpak, iso): remove flatpak lists from here](https://github.com/ublue-os/bluefin/pull/3971) by @​tulilirockz
+- chore(iso): clean up everything related to ISOs here by [@​tulilirockz](https://github.com/tulilirockz) in [#3972](https://github.com/ublue-os/bluefin/pull/3972)
+- chore(flatpak, iso): remove flatpak lists from here by [@​tulilirockz](https://github.com/tulilirockz) in [#3971](https://github.com/ublue-os/bluefin/pull/3971)
 
 # Work by Type
 
@@ -122,17 +122,17 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#118 fix(bluefin,dx): remove ssh askpass configuration](https://github.com/projectbluefin/common/pull/118) by @​tulilirockz
-- [#111 fix: reduce hallucination on ghcr.io path](https://github.com/projectbluefin/common/pull/111) by @​KiKaraage
+- fix(bluefin,dx): remove ssh askpass configuration by [@​tulilirockz](https://github.com/tulilirockz) in [#118](https://github.com/projectbluefin/common/pull/118)
+- fix: reduce hallucination on ghcr.io path by [@​KiKaraage](https://github.com/KiKaraage) in [#111](https://github.com/projectbluefin/common/pull/111)
 
 #### ⚡ Opportunistic Work
 
-- [#3986 fix: leftover file in /boot for real](https://github.com/ublue-os/bluefin/pull/3986) by @​renner0e
-- [#3984 fix(nvidia): override gschemas on nvidia using sed since we already have these on common now](https://github.com/ublue-os/bluefin/pull/3984) by @​tulilirockz
-- [#3922 fix: cleanup /\{boot,tmp\}](https://github.com/ublue-os/bluefin/pull/3922) by @​renner0e
-- [#3969 fix: Disable old rpm-ostreed-automatic.timer](https://github.com/ublue-os/bluefin/pull/3969) by @​inffy
-- [#1003 fix: remove merging from the Pull config](https://github.com/ublue-os/bluefin-lts/pull/1003) by @​hanthor
-- [#971 fix: remove minor workaround that broke "Forged On"](https://github.com/ublue-os/bluefin-lts/pull/971) by @​tulilirockz
+- fix: leftover file in /boot for real by [@​renner0e](https://github.com/renner0e) in [#3986](https://github.com/ublue-os/bluefin/pull/3986)
+- fix(nvidia): override gschemas on nvidia using sed since we already have these on common now by [@​tulilirockz](https://github.com/tulilirockz) in [#3984](https://github.com/ublue-os/bluefin/pull/3984)
+- fix: cleanup /\{boot,tmp\} by [@​renner0e](https://github.com/renner0e) in [#3922](https://github.com/ublue-os/bluefin/pull/3922)
+- fix: Disable old rpm-ostreed-automatic.timer by [@​inffy](https://github.com/inffy) in [#3969](https://github.com/ublue-os/bluefin/pull/3969)
+- fix: remove merging from the Pull config by [@​hanthor](https://github.com/hanthor) in [#1003](https://github.com/ublue-os/bluefin-lts/pull/1003)
+- fix: remove minor workaround that broke "Forged On" by [@​tulilirockz](https://github.com/tulilirockz) in [#971](https://github.com/ublue-os/bluefin-lts/pull/971)
 
 ### Enhancements
 
@@ -140,12 +140,12 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#96 feat: add Multiplication Puzzle to Education curation for Bazaar](https://github.com/projectbluefin/common/pull/96) by @​KiKaraage
-- [#143 feat: adds french translation to the desktop files](https://github.com/projectbluefin/common/pull/143) by @​theMimolet
+- feat: add Multiplication Puzzle to Education curation for Bazaar by [@​KiKaraage](https://github.com/KiKaraage) in [#96](https://github.com/projectbluefin/common/pull/96)
+- feat: adds french translation to the desktop files by [@​theMimolet](https://github.com/theMimolet) in [#143](https://github.com/projectbluefin/common/pull/143)
 
 #### ⚡ Opportunistic Work
 
-- [#945 feat: Implement lts-testing on testing branch](https://github.com/ublue-os/bluefin-lts/pull/945) by @​hanthor
+- feat: Implement lts-testing on testing branch by [@​hanthor](https://github.com/hanthor) in [#945](https://github.com/ublue-os/bluefin-lts/pull/945)
 
 ### Documentation
 
@@ -153,7 +153,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#147 docs: update label colors and document directory structure](https://github.com/projectbluefin/common/pull/147) by @​castrojo
+- docs: update label colors and document directory structure by [@​castrojo](https://github.com/castrojo) in [#147](https://github.com/projectbluefin/common/pull/147)
 
 #### ⚡ Opportunistic Work
 
@@ -165,12 +165,12 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#191 chore: remove xdg-terminal-exec hack script](https://github.com/projectbluefin/common/pull/191) by @​tulilirockz
+- chore: remove xdg-terminal-exec hack script by [@​tulilirockz](https://github.com/tulilirockz) in [#191](https://github.com/projectbluefin/common/pull/191)
 
 #### ⚡ Opportunistic Work
 
-- [#3846 chore: move `ublue-privileged-setup` references to `/usr/bin` instead of `/usr/libexec`](https://github.com/ublue-os/bluefin/pull/3846) by @​tulilirockz
-- [#3959 chore: clean up every file referenced by projectbluefin/common already](https://github.com/ublue-os/bluefin/pull/3959) by @​tulilirockz
+- chore: move `ublue-privileged-setup` references to `/usr/bin` instead of `/usr/libexec` by [@​tulilirockz](https://github.com/tulilirockz) in [#3846](https://github.com/ublue-os/bluefin/pull/3846)
+- chore: clean up every file referenced by projectbluefin/common already by [@​tulilirockz](https://github.com/tulilirockz) in [#3959](https://github.com/ublue-os/bluefin/pull/3959)
 
 ### Automation
 
@@ -178,7 +178,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 #### 📋 Planned Work
 
-- [#148 ci: skip container builds for documentation changes](https://github.com/projectbluefin/common/pull/148) by @​castrojo
+- ci: skip container builds for documentation changes by [@​castrojo](https://github.com/castrojo) in [#148](https://github.com/projectbluefin/common/pull/148)
 
 #### ⚡ Opportunistic Work
 
@@ -186,371 +186,368 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 
 ## 📋 Other
 
-- [#175 chore(translation): Add Polish translation to curated.yaml](https://github.com/projectbluefin/common/pull/175) by @​Micro856
-- [#162 fix(rebase-helper): handle bluefin LTS + HWE + GDX + everything possible](https://github.com/projectbluefin/common/pull/162) by @​tulilirockz
-- [#4114 feat: add upstream xdg-terminal-exec](https://github.com/ublue-os/bluefin/pull/4114) by @​tulilirockz
-- [#4072 fix: do not remove fedora-logos](https://github.com/ublue-os/bluefin/pull/4072) by @​tulilirockz
-- [#4044 chore(ci): enable SBOMs](https://github.com/ublue-os/bluefin/pull/4044) by @​renner0e
-- [#3988 chore: remove references to brew timer](https://github.com/ublue-os/bluefin/pull/3988) by @​tulilirockz
-- [#1053 fix: don't pull in centos-logos on downstream images](https://github.com/ublue-os/bluefin-lts/pull/1053) by @​renner0e
-- [#1041 feat: update run-vm-iso to use titanoboa ISOs](https://github.com/ublue-os/bluefin-lts/pull/1041) by @​hanthor
-- [#1045 fix: include pcsc-lite for passkey support on initramfs](https://github.com/ublue-os/bluefin-lts/pull/1045) by @​tulilirockz
-- [#1026 fix(image-info): set 0644 permissions for image-info file so that unprivileged users can read it](https://github.com/ublue-os/bluefin-lts/pull/1026) by @​tulilirockz
-- [#1021 fix(ci): make `10(image)` have suffixes so they dont all fight over the (10) tag](https://github.com/ublue-os/bluefin-lts/pull/1021) by @​tulilirockz
-- [#1020 fix(ci): HWE naming on daily builds](https://github.com/ublue-os/bluefin-lts/pull/1020) by @​tulilirockz
-- [#1018 chore(ci): add `-testing` for real on testing environments](https://github.com/ublue-os/bluefin-lts/pull/1018) by @​tulilirockz
-- [#1017 ci: attempt to handle merge_group events as well](https://github.com/ublue-os/bluefin-lts/pull/1017) by @​tulilirockz
-- [#1016 ci: fix tagging for pull request merging](https://github.com/ublue-os/bluefin-lts/pull/1016) by @​tulilirockz
-- [#1009 fix: testing build name](https://github.com/ublue-os/bluefin-lts/pull/1009) by @​hanthor
-- [#949 chore: remove all files shared with common](https://github.com/ublue-os/bluefin-lts/pull/949) by @​tulilirockz
-- [#989 chore(pull): move to merge instead of rebase](https://github.com/ublue-os/bluefin-lts/pull/989) by @​tulilirockz
-- [#987 chore: clean up a few hooks and dont use rpm-ostree on them](https://github.com/ublue-os/bluefin-lts/pull/987) by @​tulilirockz
-- [#982 chore(pull): do hardreset instead of merging](https://github.com/ublue-os/bluefin-lts/pull/982) by @​tulilirockz
-- [#972 chore(countme): remove countme service](https://github.com/ublue-os/bluefin-lts/pull/972) by @​tulilirockz
-- [#970 fix(gdx): nvidia-specific override for kms-modifiers](https://github.com/ublue-os/bluefin-lts/pull/970) by @​tulilirockz
-- [#960 chore(flatpak, iso): remove all flatpak-related things from here](https://github.com/ublue-os/bluefin-lts/pull/960) by @​tulilirockz
-- [#925 fix: switch to ublue-os/legacy-rechunk](https://github.com/ublue-os/bluefin-lts/pull/925) by @​castrojo
-- [#1670 refactor: split up build.sh](https://github.com/ublue-os/aurora/pull/1670) by @​renner0e
-- [#1615 feat: move to upstream base images](https://github.com/ublue-os/aurora/pull/1615) by @​renner0e
-- [#1665 fix(ci): verify akmods, brew, common with local key](https://github.com/ublue-os/aurora/pull/1665) by @​renner0e
-- [#1666 chore: do not set cap_net_raw=ep for ksysguard](https://github.com/ublue-os/aurora/pull/1666) by @​renner0e
-- [#1604 chore(flatpak,iso): get flatpaks from common](https://github.com/ublue-os/aurora/pull/1604) by @​inffy
-- [#1637 fix: generate ISO checksums after renaming](https://github.com/ublue-os/aurora/pull/1637) by @​inffy
-- [#1649 chore: remove generate-release from beta workflow](https://github.com/ublue-os/aurora/pull/1649) by @​inffy
-- [#1657 fix: logos package conflict on downstream images](https://github.com/ublue-os/aurora/pull/1657) by @​renner0e
-- [#1643 chore: remove ISO files and workflows](https://github.com/ublue-os/aurora/pull/1643) by @​inffy
-- [#1655 chore: remove packages that are already in the base image](https://github.com/ublue-os/aurora/pull/1655) by @​renner0e
-- [#1646 feat: enable KDE 6.6 Beta builds](https://github.com/ublue-os/aurora/pull/1646) by @​renner0e
-- [#1640 fix: add gvfs-fuse](https://github.com/ublue-os/aurora/pull/1640) by @​renner0e
-- [#1639 fix: add gvfs](https://github.com/ublue-os/aurora/pull/1639) by @​renner0e
-- [#1630 chore(ci): strip epoch from versions in changelog](https://github.com/ublue-os/aurora/pull/1630) by @​ledif
-- [#1557 feat(ci): update changelog to use SBOMs](https://github.com/ublue-os/aurora/pull/1557) by @​ledif
-- [#1567 chore: cleanup ublue-guest-user.service](https://github.com/ublue-os/aurora/pull/1567) by @​renner0e
-- [#1568 chore: delete bootc install config](https://github.com/ublue-os/aurora/pull/1568) by @​renner0e
-- [#1595 chore(bling): remove unused aurora-cli directory](https://github.com/ublue-os/aurora/pull/1595) by @​ledif
-- [#1589 chore: generate logos in common](https://github.com/ublue-os/aurora/pull/1589) by @​renner0e
-- [#1591 chore(brew): dont explicitly enable brew-\{update,upgrade\} timers](https://github.com/ublue-os/aurora/pull/1591) by @​tulilirockz
-- [#1587 feat: set default wallpaper in common](https://github.com/ublue-os/aurora/pull/1587) by @​renner0e
-- [#1584 feat: set coneheads wallpaper as default](https://github.com/ublue-os/aurora/pull/1584) by @​renner0e
-- [#1578 fix: disable rpm-ostreed-automatic.timer](https://github.com/ublue-os/aurora/pull/1578) by @​inffy
-- [#1572 chore: remove a few files that got added to projectbluefin/common](https://github.com/ublue-os/aurora/pull/1572) by @​tulilirockz
-- [#1571 chore: remove ublue-os-update-services](https://github.com/ublue-os/aurora/pull/1571) by @​renner0e
-- [#1570 chore: delete ublue-fix-hostname](https://github.com/ublue-os/aurora/pull/1570) by @​renner0e
-- [#589 ci: Configure auto-merge for monthly reports workflow](https://github.com/projectbluefin/documentation/pull/589) by @​castrojo
-- [#588 docs: Add comprehensive GSD agent selection guide](https://github.com/projectbluefin/documentation/pull/588) by @​castrojo
-- [#587 Use projectbluefin/common for planned work tracking](https://github.com/projectbluefin/documentation/pull/587) by @​castrojo
-- [#586 feat(reports): split monthly reports into planned vs opportunistic work](https://github.com/projectbluefin/documentation/pull/586) by @​castrojo
-- [#585 feat(reports): add GitHub profile cards with gold foil effect for new contributors](https://github.com/projectbluefin/documentation/pull/585) by @​castrojo
-- [#584 docs: add git workflow rules and labeling helper scripts](https://github.com/projectbluefin/documentation/pull/584) by @​castrojo
-- [#583 refactor(reports): finalize monthly reports cleanup](https://github.com/projectbluefin/documentation/pull/583) by @​castrojo
-- [#581 feat: Add Monthly Reports System (v1.1)](https://github.com/projectbluefin/documentation/pull/581) by @​castrojo
-- [#582 refactor: simplify to npm-only package management](https://github.com/projectbluefin/documentation/pull/582) by @​castrojo
-- [#580 feat(config): add git workflow configuration](https://github.com/projectbluefin/documentation/pull/580) by @​castrojo
-- [#579 Update most prevalent documentation screenshots](https://github.com/projectbluefin/documentation/pull/579) by @​AlexanderVanhee
-- [#576 docs: update fedora media writer link on installation page](https://github.com/projectbluefin/documentation/pull/576) by @​RaduAvramescu
-- [#577 fix(mise): Mise introduction and upstream links](https://github.com/projectbluefin/documentation/pull/577) by @​rwaltr
-- [#571 Cleanup: Remove GISCUS_SETUP.md and USER_ATTACHMENTS_MIGRATION.md files](https://github.com/projectbluefin/documentation/pull/571) by @​castrojo
-- [#570 feat(docs): add platform tabs to troubleshooting page](https://github.com/projectbluefin/documentation/pull/570) by @​castrojo
-- [#569 Enhance troubleshooting guide with new sections](https://github.com/projectbluefin/documentation/pull/569) by @​castrojo
-- [#568 feat(docs): add hidden troubleshooting page](https://github.com/projectbluefin/documentation/pull/568) by @​castrojo
-- [#567 docs(agents): remove non-existent communication.md reference](https://github.com/projectbluefin/documentation/pull/567) by @​castrojo
-- [#547 Add SELinux options to devcontainer configuration](https://github.com/projectbluefin/documentation/pull/547) by @​leafyoung
-- [#561 Blog/modernizing custom images](https://github.com/projectbluefin/documentation/pull/561) by @​castrojo
-- [#556 feat(agents): convert blog-poster skill to GitHub Copilot agent](https://github.com/projectbluefin/documentation/pull/556) by @​castrojo
-- [#554 docs(administration): add ujust powerwash command documentation](https://github.com/projectbluefin/documentation/pull/554) by @​castrojo
-- [#2 feat: move anaconda branding here instead of on ublue-os/packages](https://github.com/projectbluefin/branding/pull/2) by @​tulilirockz
-- [#17 feat(ci): add ISO promotion workflow from testing to production](https://github.com/projectbluefin/iso/pull/17) by @​castrojo
-- [#15 feat: build latest bootc and revert to f42 anaconda](https://github.com/projectbluefin/iso/pull/15) by @​hanthor
-- [#16 fix: expicilty add anaconda package](https://github.com/projectbluefin/iso/pull/16) by @​hanthor
-- [#14 feat: multi-distro support for local ISO build](https://github.com/projectbluefin/iso/pull/14) by @​hanthor
-- [#13 feat: add local ISO build script](https://github.com/projectbluefin/iso/pull/13) by @​hanthor
-- [#11 feat: "Welcome to Bluefin" on installer desktop icon](https://github.com/projectbluefin/iso/pull/11) by @​tulilirockz
-- [#10 fix: use brewfile app list from common instead of reading old flatpak list files](https://github.com/projectbluefin/iso/pull/10) by @​tulilirockz
-- [#51 (Experimental) Just script for disk install](https://github.com/projectbluefin/dakota/pull/51) by @​jumpyvi
-- [#49 Copy binaries that we need from gnomeos-devel](https://github.com/projectbluefin/dakota/pull/49) by @​hecknt
-- [#48 Set temporary "About" branding](https://github.com/projectbluefin/dakota/pull/48) by @​jumpyvi
-- [#46 Remove ostree support from our end](https://github.com/projectbluefin/dakota/pull/46) by @​hecknt
-- [#44 Modify the initramfs to add OSTree boot support](https://github.com/projectbluefin/dakota/pull/44) by @​hecknt
-- [#42 FIx schema override file](https://github.com/projectbluefin/dakota/pull/42) by @​alatiera
-- [#41 Add support for the flatpak version of qemu](https://github.com/projectbluefin/dakota/pull/41) by @​jumpyvi
-- [#40 Re-add fallocate in `generate-bootable-image`](https://github.com/projectbluefin/dakota/pull/40) by @​hecknt
-- [#29 Add bare metal installation instructions](https://github.com/projectbluefin/dakota/pull/29) by @​hecknt
-- [#28 Rename from `distroless` to `dakota` everywhere](https://github.com/projectbluefin/dakota/pull/28) by @​hecknt
-- [#26 Change the build system around to fix updates](https://github.com/projectbluefin/dakota/pull/26) by @​hecknt
-- [#25 Fix container image labels](https://github.com/projectbluefin/dakota/pull/25) by @​sideeffffect
-- [#22 feat: remove everything](https://github.com/projectbluefin/dakota/pull/22) by @​renner0e
-- [#51 (Experimental) Just script for disk install](https://github.com/projectbluefin/dakota/pull/51) by @​jumpyvi
-- [#49 Copy binaries that we need from gnomeos-devel](https://github.com/projectbluefin/dakota/pull/49) by @​hecknt
-- [#48 Set temporary "About" branding](https://github.com/projectbluefin/dakota/pull/48) by @​jumpyvi
-- [#46 Remove ostree support from our end](https://github.com/projectbluefin/dakota/pull/46) by @​hecknt
-- [#44 Modify the initramfs to add OSTree boot support](https://github.com/projectbluefin/dakota/pull/44) by @​hecknt
-- [#42 FIx schema override file](https://github.com/projectbluefin/dakota/pull/42) by @​alatiera
-- [#41 Add support for the flatpak version of qemu](https://github.com/projectbluefin/dakota/pull/41) by @​jumpyvi
-- [#40 Re-add fallocate in `generate-bootable-image`](https://github.com/projectbluefin/dakota/pull/40) by @​hecknt
-- [#29 Add bare metal installation instructions](https://github.com/projectbluefin/dakota/pull/29) by @​hecknt
-- [#28 Rename from `distroless` to `dakota` everywhere](https://github.com/projectbluefin/dakota/pull/28) by @​hecknt
-- [#26 Change the build system around to fix updates](https://github.com/projectbluefin/dakota/pull/26) by @​hecknt
-- [#25 Fix container image labels](https://github.com/projectbluefin/dakota/pull/25) by @​sideeffffect
-- [#22 feat: remove everything](https://github.com/projectbluefin/dakota/pull/22) by @​renner0e
+- chore(translation): Add Polish translation to curated.yaml by [@​Micro856](https://github.com/Micro856) in [#175](https://github.com/projectbluefin/common/pull/175)
+- fix(rebase-helper): handle bluefin LTS + HWE + GDX + everything possible by [@​tulilirockz](https://github.com/tulilirockz) in [#162](https://github.com/projectbluefin/common/pull/162)
+- feat: add upstream xdg-terminal-exec by [@​tulilirockz](https://github.com/tulilirockz) in [#4114](https://github.com/ublue-os/bluefin/pull/4114)
+- fix: do not remove fedora-logos by [@​tulilirockz](https://github.com/tulilirockz) in [#4072](https://github.com/ublue-os/bluefin/pull/4072)
+- chore(ci): enable SBOMs by [@​renner0e](https://github.com/renner0e) in [#4044](https://github.com/ublue-os/bluefin/pull/4044)
+- chore: remove references to brew timer by [@​tulilirockz](https://github.com/tulilirockz) in [#3988](https://github.com/ublue-os/bluefin/pull/3988)
+- fix: don't pull in centos-logos on downstream images by [@​renner0e](https://github.com/renner0e) in [#1053](https://github.com/ublue-os/bluefin-lts/pull/1053)
+- feat: update run-vm-iso to use titanoboa ISOs by [@​hanthor](https://github.com/hanthor) in [#1041](https://github.com/ublue-os/bluefin-lts/pull/1041)
+- fix: include pcsc-lite for passkey support on initramfs by [@​tulilirockz](https://github.com/tulilirockz) in [#1045](https://github.com/ublue-os/bluefin-lts/pull/1045)
+- fix(image-info): set 0644 permissions for image-info file so that unprivileged users can read it by [@​tulilirockz](https://github.com/tulilirockz) in [#1026](https://github.com/ublue-os/bluefin-lts/pull/1026)
+- fix(ci): make `10(image)` have suffixes so they dont all fight over the (10) tag by [@​tulilirockz](https://github.com/tulilirockz) in [#1021](https://github.com/ublue-os/bluefin-lts/pull/1021)
+- fix(ci): HWE naming on daily builds by [@​tulilirockz](https://github.com/tulilirockz) in [#1020](https://github.com/ublue-os/bluefin-lts/pull/1020)
+- chore(ci): add `-testing` for real on testing environments by [@​tulilirockz](https://github.com/tulilirockz) in [#1018](https://github.com/ublue-os/bluefin-lts/pull/1018)
+- ci: attempt to handle merge_group events as well by [@​tulilirockz](https://github.com/tulilirockz) in [#1017](https://github.com/ublue-os/bluefin-lts/pull/1017)
+- ci: fix tagging for pull request merging by [@​tulilirockz](https://github.com/tulilirockz) in [#1016](https://github.com/ublue-os/bluefin-lts/pull/1016)
+- fix: testing build name by [@​hanthor](https://github.com/hanthor) in [#1009](https://github.com/ublue-os/bluefin-lts/pull/1009)
+- chore: remove all files shared with common by [@​tulilirockz](https://github.com/tulilirockz) in [#949](https://github.com/ublue-os/bluefin-lts/pull/949)
+- chore(pull): move to merge instead of rebase by [@​tulilirockz](https://github.com/tulilirockz) in [#989](https://github.com/ublue-os/bluefin-lts/pull/989)
+- chore: clean up a few hooks and dont use rpm-ostree on them by [@​tulilirockz](https://github.com/tulilirockz) in [#987](https://github.com/ublue-os/bluefin-lts/pull/987)
+- chore(pull): do hardreset instead of merging by [@​tulilirockz](https://github.com/tulilirockz) in [#982](https://github.com/ublue-os/bluefin-lts/pull/982)
+- chore(countme): remove countme service by [@​tulilirockz](https://github.com/tulilirockz) in [#972](https://github.com/ublue-os/bluefin-lts/pull/972)
+- fix(gdx): nvidia-specific override for kms-modifiers by [@​tulilirockz](https://github.com/tulilirockz) in [#970](https://github.com/ublue-os/bluefin-lts/pull/970)
+- chore(flatpak, iso): remove all flatpak-related things from here by [@​tulilirockz](https://github.com/tulilirockz) in [#960](https://github.com/ublue-os/bluefin-lts/pull/960)
+- fix: switch to ublue-os/legacy-rechunk by [@​castrojo](https://github.com/castrojo) in [#925](https://github.com/ublue-os/bluefin-lts/pull/925)
+- refactor: split up build.sh by [@​renner0e](https://github.com/renner0e) in [#1670](https://github.com/ublue-os/aurora/pull/1670)
+- feat: move to upstream base images by [@​renner0e](https://github.com/renner0e) in [#1615](https://github.com/ublue-os/aurora/pull/1615)
+- fix(ci): verify akmods, brew, common with local key by [@​renner0e](https://github.com/renner0e) in [#1665](https://github.com/ublue-os/aurora/pull/1665)
+- chore: do not set cap_net_raw=ep for ksysguard by [@​renner0e](https://github.com/renner0e) in [#1666](https://github.com/ublue-os/aurora/pull/1666)
+- chore(flatpak,iso): get flatpaks from common by [@​inffy](https://github.com/inffy) in [#1604](https://github.com/ublue-os/aurora/pull/1604)
+- fix: generate ISO checksums after renaming by [@​inffy](https://github.com/inffy) in [#1637](https://github.com/ublue-os/aurora/pull/1637)
+- chore: remove generate-release from beta workflow by [@​inffy](https://github.com/inffy) in [#1649](https://github.com/ublue-os/aurora/pull/1649)
+- fix: logos package conflict on downstream images by [@​renner0e](https://github.com/renner0e) in [#1657](https://github.com/ublue-os/aurora/pull/1657)
+- chore: remove ISO files and workflows by [@​inffy](https://github.com/inffy) in [#1643](https://github.com/ublue-os/aurora/pull/1643)
+- chore: remove packages that are already in the base image by [@​renner0e](https://github.com/renner0e) in [#1655](https://github.com/ublue-os/aurora/pull/1655)
+- feat: enable KDE 6.6 Beta builds by [@​renner0e](https://github.com/renner0e) in [#1646](https://github.com/ublue-os/aurora/pull/1646)
+- fix: add gvfs-fuse by [@​renner0e](https://github.com/renner0e) in [#1640](https://github.com/ublue-os/aurora/pull/1640)
+- fix: add gvfs by [@​renner0e](https://github.com/renner0e) in [#1639](https://github.com/ublue-os/aurora/pull/1639)
+- chore(ci): strip epoch from versions in changelog by [@​ledif](https://github.com/ledif) in [#1630](https://github.com/ublue-os/aurora/pull/1630)
+- feat(ci): update changelog to use SBOMs by [@​ledif](https://github.com/ledif) in [#1557](https://github.com/ublue-os/aurora/pull/1557)
+- chore: cleanup ublue-guest-user.service by [@​renner0e](https://github.com/renner0e) in [#1567](https://github.com/ublue-os/aurora/pull/1567)
+- chore: delete bootc install config by [@​renner0e](https://github.com/renner0e) in [#1568](https://github.com/ublue-os/aurora/pull/1568)
+- chore(bling): remove unused aurora-cli directory by [@​ledif](https://github.com/ledif) in [#1595](https://github.com/ublue-os/aurora/pull/1595)
+- chore: generate logos in common by [@​renner0e](https://github.com/renner0e) in [#1589](https://github.com/ublue-os/aurora/pull/1589)
+- chore(brew): dont explicitly enable brew-\{update,upgrade\} timers by [@​tulilirockz](https://github.com/tulilirockz) in [#1591](https://github.com/ublue-os/aurora/pull/1591)
+- feat: set default wallpaper in common by [@​renner0e](https://github.com/renner0e) in [#1587](https://github.com/ublue-os/aurora/pull/1587)
+- feat: set coneheads wallpaper as default by [@​renner0e](https://github.com/renner0e) in [#1584](https://github.com/ublue-os/aurora/pull/1584)
+- fix: disable rpm-ostreed-automatic.timer by [@​inffy](https://github.com/inffy) in [#1578](https://github.com/ublue-os/aurora/pull/1578)
+- chore: remove a few files that got added to projectbluefin/common by [@​tulilirockz](https://github.com/tulilirockz) in [#1572](https://github.com/ublue-os/aurora/pull/1572)
+- chore: remove ublue-os-update-services by [@​renner0e](https://github.com/renner0e) in [#1571](https://github.com/ublue-os/aurora/pull/1571)
+- chore: delete ublue-fix-hostname by [@​renner0e](https://github.com/renner0e) in [#1570](https://github.com/ublue-os/aurora/pull/1570)
+- Regenerate January 2026 report with improved structure by [@​castrojo](https://github.com/castrojo) in [#593](https://github.com/projectbluefin/documentation/pull/593)
+- ci: Configure auto-merge for monthly reports workflow by [@​castrojo](https://github.com/castrojo) in [#589](https://github.com/projectbluefin/documentation/pull/589)
+- docs: Add comprehensive GSD agent selection guide by [@​castrojo](https://github.com/castrojo) in [#588](https://github.com/projectbluefin/documentation/pull/588)
+- Use projectbluefin/common for planned work tracking by [@​castrojo](https://github.com/castrojo) in [#587](https://github.com/projectbluefin/documentation/pull/587)
+- feat(reports): split monthly reports into planned vs opportunistic work by [@​castrojo](https://github.com/castrojo) in [#586](https://github.com/projectbluefin/documentation/pull/586)
+- feat(reports): add GitHub profile cards with gold foil effect for new contributors by [@​castrojo](https://github.com/castrojo) in [#585](https://github.com/projectbluefin/documentation/pull/585)
+- docs: add git workflow rules and labeling helper scripts by [@​castrojo](https://github.com/castrojo) in [#584](https://github.com/projectbluefin/documentation/pull/584)
+- refactor(reports): finalize monthly reports cleanup by [@​castrojo](https://github.com/castrojo) in [#583](https://github.com/projectbluefin/documentation/pull/583)
+- feat: Add Monthly Reports System (v1.1) by [@​castrojo](https://github.com/castrojo) in [#581](https://github.com/projectbluefin/documentation/pull/581)
+- refactor: simplify to npm-only package management by [@​castrojo](https://github.com/castrojo) in [#582](https://github.com/projectbluefin/documentation/pull/582)
+- feat(config): add git workflow configuration by [@​castrojo](https://github.com/castrojo) in [#580](https://github.com/projectbluefin/documentation/pull/580)
+- Update most prevalent documentation screenshots by [@​AlexanderVanhee](https://github.com/AlexanderVanhee) in [#579](https://github.com/projectbluefin/documentation/pull/579)
+- docs: update fedora media writer link on installation page by [@​RaduAvramescu](https://github.com/RaduAvramescu) in [#576](https://github.com/projectbluefin/documentation/pull/576)
+- fix(mise): Mise introduction and upstream links by [@​rwaltr](https://github.com/rwaltr) in [#577](https://github.com/projectbluefin/documentation/pull/577)
+- Cleanup: Remove GISCUS_SETUP.md and USER_ATTACHMENTS_MIGRATION.md files by [@​castrojo](https://github.com/castrojo) in [#571](https://github.com/projectbluefin/documentation/pull/571)
+- feat(docs): add platform tabs to troubleshooting page by [@​castrojo](https://github.com/castrojo) in [#570](https://github.com/projectbluefin/documentation/pull/570)
+- Enhance troubleshooting guide with new sections by [@​castrojo](https://github.com/castrojo) in [#569](https://github.com/projectbluefin/documentation/pull/569)
+- feat(docs): add hidden troubleshooting page by [@​castrojo](https://github.com/castrojo) in [#568](https://github.com/projectbluefin/documentation/pull/568)
+- docs(agents): remove non-existent communication.md reference by [@​castrojo](https://github.com/castrojo) in [#567](https://github.com/projectbluefin/documentation/pull/567)
+- Add SELinux options to devcontainer configuration by [@​leafyoung](https://github.com/leafyoung) in [#547](https://github.com/projectbluefin/documentation/pull/547)
+- Blog/modernizing custom images by [@​castrojo](https://github.com/castrojo) in [#561](https://github.com/projectbluefin/documentation/pull/561)
+- feat(agents): convert blog-poster skill to GitHub Copilot agent by [@​castrojo](https://github.com/castrojo) in [#556](https://github.com/projectbluefin/documentation/pull/556)
+- docs(administration): add ujust powerwash command documentation by [@​castrojo](https://github.com/castrojo) in [#554](https://github.com/projectbluefin/documentation/pull/554)
+- feat: move anaconda branding here instead of on ublue-os/packages by [@​tulilirockz](https://github.com/tulilirockz) in [#2](https://github.com/projectbluefin/branding/pull/2)
+- feat(ci): add ISO promotion workflow from testing to production by [@​castrojo](https://github.com/castrojo) in [#17](https://github.com/projectbluefin/iso/pull/17)
+- feat: build latest bootc and revert to f42 anaconda by [@​hanthor](https://github.com/hanthor) in [#15](https://github.com/projectbluefin/iso/pull/15)
+- fix: expicilty add anaconda package by [@​hanthor](https://github.com/hanthor) in [#16](https://github.com/projectbluefin/iso/pull/16)
+- feat: multi-distro support for local ISO build by [@​hanthor](https://github.com/hanthor) in [#14](https://github.com/projectbluefin/iso/pull/14)
+- feat: add local ISO build script by [@​hanthor](https://github.com/hanthor) in [#13](https://github.com/projectbluefin/iso/pull/13)
+- feat: "Welcome to Bluefin" on installer desktop icon by [@​tulilirockz](https://github.com/tulilirockz) in [#11](https://github.com/projectbluefin/iso/pull/11)
+- fix: use brewfile app list from common instead of reading old flatpak list files by [@​tulilirockz](https://github.com/tulilirockz) in [#10](https://github.com/projectbluefin/iso/pull/10)
+- (Experimental) Just script for disk install by [@​jumpyvi](https://github.com/jumpyvi) in [#51](https://github.com/projectbluefin/dakota/pull/51)
+- Copy binaries that we need from gnomeos-devel by [@​hecknt](https://github.com/hecknt) in [#49](https://github.com/projectbluefin/dakota/pull/49)
+- Set temporary "About" branding by [@​jumpyvi](https://github.com/jumpyvi) in [#48](https://github.com/projectbluefin/dakota/pull/48)
+- Remove ostree support from our end by [@​hecknt](https://github.com/hecknt) in [#46](https://github.com/projectbluefin/dakota/pull/46)
+- Modify the initramfs to add OSTree boot support by [@​hecknt](https://github.com/hecknt) in [#44](https://github.com/projectbluefin/dakota/pull/44)
+- FIx schema override file by [@​alatiera](https://github.com/alatiera) in [#42](https://github.com/projectbluefin/dakota/pull/42)
+- Add support for the flatpak version of qemu by [@​jumpyvi](https://github.com/jumpyvi) in [#41](https://github.com/projectbluefin/dakota/pull/41)
+- Re-add fallocate in `generate-bootable-image` by [@​hecknt](https://github.com/hecknt) in [#40](https://github.com/projectbluefin/dakota/pull/40)
+- Add bare metal installation instructions by [@​hecknt](https://github.com/hecknt) in [#29](https://github.com/projectbluefin/dakota/pull/29)
+- Rename from `distroless` to `dakota` everywhere by [@​hecknt](https://github.com/hecknt) in [#28](https://github.com/projectbluefin/dakota/pull/28)
+- Change the build system around to fix updates by [@​hecknt](https://github.com/hecknt) in [#26](https://github.com/projectbluefin/dakota/pull/26)
+- Fix container image labels by [@​sideeffffect](https://github.com/sideeffffect) in [#25](https://github.com/projectbluefin/dakota/pull/25)
+- feat: remove everything by [@​renner0e](https://github.com/renner0e) in [#22](https://github.com/projectbluefin/dakota/pull/22)
+- (Experimental) Just script for disk install by [@​jumpyvi](https://github.com/jumpyvi) in [#51](https://github.com/projectbluefin/dakota/pull/51)
+- Copy binaries that we need from gnomeos-devel by [@​hecknt](https://github.com/hecknt) in [#49](https://github.com/projectbluefin/dakota/pull/49)
+- Set temporary "About" branding by [@​jumpyvi](https://github.com/jumpyvi) in [#48](https://github.com/projectbluefin/dakota/pull/48)
+- Remove ostree support from our end by [@​hecknt](https://github.com/hecknt) in [#46](https://github.com/projectbluefin/dakota/pull/46)
+- Modify the initramfs to add OSTree boot support by [@​hecknt](https://github.com/hecknt) in [#44](https://github.com/projectbluefin/dakota/pull/44)
+- FIx schema override file by [@​alatiera](https://github.com/alatiera) in [#42](https://github.com/projectbluefin/dakota/pull/42)
+- Add support for the flatpak version of qemu by [@​jumpyvi](https://github.com/jumpyvi) in [#41](https://github.com/projectbluefin/dakota/pull/41)
+- Re-add fallocate in `generate-bootable-image` by [@​hecknt](https://github.com/hecknt) in [#40](https://github.com/projectbluefin/dakota/pull/40)
+- Add bare metal installation instructions by [@​hecknt](https://github.com/hecknt) in [#29](https://github.com/projectbluefin/dakota/pull/29)
+- Rename from `distroless` to `dakota` everywhere by [@​hecknt](https://github.com/hecknt) in [#28](https://github.com/projectbluefin/dakota/pull/28)
+- Change the build system around to fix updates by [@​hecknt](https://github.com/hecknt) in [#26](https://github.com/projectbluefin/dakota/pull/26)
+- Fix container image labels by [@​sideeffffect](https://github.com/sideeffffect) in [#25](https://github.com/projectbluefin/dakota/pull/25)
+- feat: remove everything by [@​renner0e](https://github.com/renner0e) in [#22](https://github.com/projectbluefin/dakota/pull/22)
 
 ## 🤖 Bot Activity
 
-| Repository | Bot | PRs |
-|------------|-----|-----|
-| common | copilot-swe-agent | 1 |
-| bluefin | ubot-7274 | 88 |
-| bluefin-lts | pull | 8 |
-| bluefin-lts | ubot-7274 | 50 |
-| bluefin-lts | testpullapp | 5 |
-| bluefin-lts | copilot-swe-agent | 1 |
-| aurora | ubot-7274 | 72 |
-| documentation | github-actions | 4 |
-| documentation | copilot-swe-agent | 4 |
-| iso | copilot-swe-agent | 7 |
+| Repository | Bot PRs |
+|------------|---------|
+| bluefin | 88 |
+| aurora | 72 |
+| bluefin-lts | 64 |
+| documentation | 8 |
+| iso | 7 |
+| common | 1 |
 
 <details>
 <summary>View bot activity details</summary>
 
-- [#116 docs: document flatpak customization system](https://github.com/projectbluefin/common/pull/116) in projectbluefin/common
-- [#4121 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 79b970c](https://github.com/ublue-os/bluefin/pull/4121) in ublue-os/bluefin
-- [#4120 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 94cb1fe](https://github.com/ublue-os/bluefin/pull/4120) in ublue-os/bluefin
-- [#4116 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 45677a5](https://github.com/ublue-os/bluefin/pull/4116) in ublue-os/bluefin
-- [#4115 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4a3ec99](https://github.com/ublue-os/bluefin/pull/4115) in ublue-os/bluefin
-- [#4112 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 3d1ec54](https://github.com/ublue-os/bluefin/pull/4112) in ublue-os/bluefin
-- [#4111 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e079560](https://github.com/ublue-os/bluefin/pull/4111) in ublue-os/bluefin
-- [#4104 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 9021d14](https://github.com/ublue-os/bluefin/pull/4104) in ublue-os/bluefin
-- [#4106 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a05cd42](https://github.com/ublue-os/bluefin/pull/4106) in ublue-os/bluefin
-- [#4105 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 783b7e9](https://github.com/ublue-os/bluefin/pull/4105) in ublue-os/bluefin
-- [#4103 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7c2058a](https://github.com/ublue-os/bluefin/pull/4103) in ublue-os/bluefin
-- [#4101 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 2181a76](https://github.com/ublue-os/bluefin/pull/4101) in ublue-os/bluefin
-- [#4100 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9e81ecd](https://github.com/ublue-os/bluefin/pull/4100) in ublue-os/bluefin
-- [#4094 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 239cbed](https://github.com/ublue-os/bluefin/pull/4094) in ublue-os/bluefin
-- [#4093 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9a31b4a](https://github.com/ublue-os/bluefin/pull/4093) in ublue-os/bluefin
-- [#4091 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 88e4328](https://github.com/ublue-os/bluefin/pull/4091) in ublue-os/bluefin
-- [#4090 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a1988df](https://github.com/ublue-os/bluefin/pull/4090) in ublue-os/bluefin
-- [#4088 chore(deps): update anchore/sbom-action digest to 62ad528](https://github.com/ublue-os/bluefin/pull/4088) in ublue-os/bluefin
-- [#4086 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 42debcf](https://github.com/ublue-os/bluefin/pull/4086) in ublue-os/bluefin
-- [#4085 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 30b194a](https://github.com/ublue-os/bluefin/pull/4085) in ublue-os/bluefin
-- [#4080 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 29b0423](https://github.com/ublue-os/bluefin/pull/4080) in ublue-os/bluefin
-- [#4079 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 3b3f5dd](https://github.com/ublue-os/bluefin/pull/4079) in ublue-os/bluefin
-- [#4075 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 731d5fc](https://github.com/ublue-os/bluefin/pull/4075) in ublue-os/bluefin
-- [#4074 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 0915431](https://github.com/ublue-os/bluefin/pull/4074) in ublue-os/bluefin
-- [#4070 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c940fd0](https://github.com/ublue-os/bluefin/pull/4070) in ublue-os/bluefin
-- [#4069 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d8c0136](https://github.com/ublue-os/bluefin/pull/4069) in ublue-os/bluefin
-- [#4068 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 3b2a1d4](https://github.com/ublue-os/bluefin/pull/4068) in ublue-os/bluefin
-- [#4067 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 20f0d29](https://github.com/ublue-os/bluefin/pull/4067) in ublue-os/bluefin
-- [#4064 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 0fb7539](https://github.com/ublue-os/bluefin/pull/4064) in ublue-os/bluefin
-- [#4063 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to b33a225](https://github.com/ublue-os/bluefin/pull/4063) in ublue-os/bluefin
-- [#4060 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 7b43fd6](https://github.com/ublue-os/bluefin/pull/4060) in ublue-os/bluefin
-- [#4059 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c84afd1](https://github.com/ublue-os/bluefin/pull/4059) in ublue-os/bluefin
-- [#4057 chore(deps): update actions/setup-node digest to 6044e13](https://github.com/ublue-os/bluefin/pull/4057) in ublue-os/bluefin
-- [#4058 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 12a6234](https://github.com/ublue-os/bluefin/pull/4058) in ublue-os/bluefin
-- [#4056 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 6eefe15](https://github.com/ublue-os/bluefin/pull/4056) in ublue-os/bluefin
-- [#4051 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e5ab9b1](https://github.com/ublue-os/bluefin/pull/4051) in ublue-os/bluefin
-- [#4050 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a5b28ca](https://github.com/ublue-os/bluefin/pull/4050) in ublue-os/bluefin
-- [#4049 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 94f6794](https://github.com/ublue-os/bluefin/pull/4049) in ublue-os/bluefin
-- [#4038 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4c4c93b](https://github.com/ublue-os/bluefin/pull/4038) in ublue-os/bluefin
-- [#4043 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 8d2e9f7](https://github.com/ublue-os/bluefin/pull/4043) in ublue-os/bluefin
-- [#4042 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to f30df81](https://github.com/ublue-os/bluefin/pull/4042) in ublue-os/bluefin
-- [#4037 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 5ce5ddc](https://github.com/ublue-os/bluefin/pull/4037) in ublue-os/bluefin
-- [#4036 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 2180547](https://github.com/ublue-os/bluefin/pull/4036) in ublue-os/bluefin
-- [#4035 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 3fef130](https://github.com/ublue-os/bluefin/pull/4035) in ublue-os/bluefin
-- [#4034 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 584fe33](https://github.com/ublue-os/bluefin/pull/4034) in ublue-os/bluefin
-- [#4013 chore(deps): update anchore/sbom-action digest to 0b82b0b](https://github.com/ublue-os/bluefin/pull/4013) in ublue-os/bluefin
-- [#4033 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to d1a415b](https://github.com/ublue-os/bluefin/pull/4033) in ublue-os/bluefin
-- [#4031 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 63c7219](https://github.com/ublue-os/bluefin/pull/4031) in ublue-os/bluefin
-- [#4027 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to abe58f2](https://github.com/ublue-os/bluefin/pull/4027) in ublue-os/bluefin
-- [#4029 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to cce128a](https://github.com/ublue-os/bluefin/pull/4029) in ublue-os/bluefin
-- [#4028 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 42f229a](https://github.com/ublue-os/bluefin/pull/4028) in ublue-os/bluefin
-- [#4026 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 39ade24](https://github.com/ublue-os/bluefin/pull/4026) in ublue-os/bluefin
-- [#4025 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 233b470](https://github.com/ublue-os/bluefin/pull/4025) in ublue-os/bluefin
-- [#4021 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d01f844](https://github.com/ublue-os/bluefin/pull/4021) in ublue-os/bluefin
-- [#4019 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 87e5c80](https://github.com/ublue-os/bluefin/pull/4019) in ublue-os/bluefin
-- [#4018 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d6a933b](https://github.com/ublue-os/bluefin/pull/4018) in ublue-os/bluefin
-- [#4015 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 2ed8419](https://github.com/ublue-os/bluefin/pull/4015) in ublue-os/bluefin
-- [#4014 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 21ef866](https://github.com/ublue-os/bluefin/pull/4014) in ublue-os/bluefin
-- [#4011 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e117db6](https://github.com/ublue-os/bluefin/pull/4011) in ublue-os/bluefin
-- [#4010 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9786fd7](https://github.com/ublue-os/bluefin/pull/4010) in ublue-os/bluefin
-- [#4009 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to f10b6e0](https://github.com/ublue-os/bluefin/pull/4009) in ublue-os/bluefin
-- [#4006 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 653ddbf](https://github.com/ublue-os/bluefin/pull/4006) in ublue-os/bluefin
-- [#4005 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 089beed](https://github.com/ublue-os/bluefin/pull/4005) in ublue-os/bluefin
-- [#4004 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 34139ff](https://github.com/ublue-os/bluefin/pull/4004) in ublue-os/bluefin
-- [#4003 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to fe77831](https://github.com/ublue-os/bluefin/pull/4003) in ublue-os/bluefin
-- [#4002 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to b49cf41](https://github.com/ublue-os/bluefin/pull/4002) in ublue-os/bluefin
-- [#3998 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to e69ca9c](https://github.com/ublue-os/bluefin/pull/3998) in ublue-os/bluefin
-- [#3997 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d9fd32c](https://github.com/ublue-os/bluefin/pull/3997) in ublue-os/bluefin
-- [#3996 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 89e5f76](https://github.com/ublue-os/bluefin/pull/3996) in ublue-os/bluefin
-- [#3990 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c69fbf9](https://github.com/ublue-os/bluefin/pull/3990) in ublue-os/bluefin
-- [#3989 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 288ee27](https://github.com/ublue-os/bluefin/pull/3989) in ublue-os/bluefin
-- [#3987 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7f4ecb6](https://github.com/ublue-os/bluefin/pull/3987) in ublue-os/bluefin
-- [#3985 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 9c2265c](https://github.com/ublue-os/bluefin/pull/3985) in ublue-os/bluefin
-- [#3980 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 5a4e3bc](https://github.com/ublue-os/bluefin/pull/3980) in ublue-os/bluefin
-- [#3979 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 81129a6](https://github.com/ublue-os/bluefin/pull/3979) in ublue-os/bluefin
-- [#3978 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to dd6ae9d](https://github.com/ublue-os/bluefin/pull/3978) in ublue-os/bluefin
-- [#3973 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to a6f9953](https://github.com/ublue-os/bluefin/pull/3973) in ublue-os/bluefin
-- [#3977 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 549e587](https://github.com/ublue-os/bluefin/pull/3977) in ublue-os/bluefin
-- [#3976 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to f963754](https://github.com/ublue-os/bluefin/pull/3976) in ublue-os/bluefin
-- [#3970 chore(deps): update ghcr.io/ublue-os/legacy-rechunk docker tag to v1.0.1](https://github.com/ublue-os/bluefin/pull/3970) in ublue-os/bluefin
-- [#3968 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344](https://github.com/ublue-os/bluefin/pull/3968) in ublue-os/bluefin
-- [#3967 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344](https://github.com/ublue-os/bluefin/pull/3967) in ublue-os/bluefin
-- [#3966 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to b836644](https://github.com/ublue-os/bluefin/pull/3966) in ublue-os/bluefin
-- [#3965 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 400dc1e](https://github.com/ublue-os/bluefin/pull/3965) in ublue-os/bluefin
-- [#3964 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4014cfd](https://github.com/ublue-os/bluefin/pull/3964) in ublue-os/bluefin
-- [#3963 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e0fae11](https://github.com/ublue-os/bluefin/pull/3963) in ublue-os/bluefin
-- [#3961 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 019f3c5](https://github.com/ublue-os/bluefin/pull/3961) in ublue-os/bluefin
-- [#3957 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to e1f9cd5](https://github.com/ublue-os/bluefin/pull/3957) in ublue-os/bluefin
-- [#3956 chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 03b7702](https://github.com/ublue-os/bluefin/pull/3956) in ublue-os/bluefin
-- [#1048 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1048) in ublue-os/bluefin-lts
-- [#1036 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1036) in ublue-os/bluefin-lts
-- [#1034 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1034) in ublue-os/bluefin-lts
-- [#1033 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1033) in ublue-os/bluefin-lts
-- [#1014 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1014) in ublue-os/bluefin-lts
-- [#1000 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/1000) in ublue-os/bluefin-lts
-- [#998 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/998) in ublue-os/bluefin-lts
-- [#994 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/994) in ublue-os/bluefin-lts
-- [#1057 chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 9d9881f](https://github.com/ublue-os/bluefin-lts/pull/1057) in ublue-os/bluefin-lts
-- [#1059 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 9021d14](https://github.com/ublue-os/bluefin-lts/pull/1059) in ublue-os/bluefin-lts
-- [#1055 chore(deps): update anchore/sbom-action digest to 62ad528](https://github.com/ublue-os/bluefin-lts/pull/1055) in ublue-os/bluefin-lts
-- [#1054 chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 0c79f2e](https://github.com/ublue-os/bluefin-lts/pull/1054) in ublue-os/bluefin-lts
-- [#1052 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 504a0c6](https://github.com/ublue-os/bluefin-lts/pull/1052) in ublue-os/bluefin-lts
-- [#1051 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to ddce029](https://github.com/ublue-os/bluefin-lts/pull/1051) in ublue-os/bluefin-lts
-- [#1050 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 731d5fc](https://github.com/ublue-os/bluefin-lts/pull/1050) in ublue-os/bluefin-lts
-- [#1049 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 0915431](https://github.com/ublue-os/bluefin-lts/pull/1049) in ublue-os/bluefin-lts
-- [#1047 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 3b2a1d4](https://github.com/ublue-os/bluefin-lts/pull/1047) in ublue-os/bluefin-lts
-- [#1046 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 0599ad1](https://github.com/ublue-os/bluefin-lts/pull/1046) in ublue-os/bluefin-lts
-- [#1044 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 20f0d29](https://github.com/ublue-os/bluefin-lts/pull/1044) in ublue-os/bluefin-lts
-- [#1042 chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 5cb6b2e](https://github.com/ublue-os/bluefin-lts/pull/1042) in ublue-os/bluefin-lts
-- [#1040 chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 07643c3](https://github.com/ublue-os/bluefin-lts/pull/1040) in ublue-os/bluefin-lts
-- [#1039 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 207713b](https://github.com/ublue-os/bluefin-lts/pull/1039) in ublue-os/bluefin-lts
-- [#1038 chore(deps): update actions/setup-node digest to 6044e13](https://github.com/ublue-os/bluefin-lts/pull/1038) in ublue-os/bluefin-lts
-- [#1037 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e5ab9b1](https://github.com/ublue-os/bluefin-lts/pull/1037) in ublue-os/bluefin-lts
-- [#1035 chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to e735a9b](https://github.com/ublue-os/bluefin-lts/pull/1035) in ublue-os/bluefin-lts
-- [#1032 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 334770f](https://github.com/ublue-os/bluefin-lts/pull/1032) in ublue-os/bluefin-lts
-- [#1031 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4c4c93b](https://github.com/ublue-os/bluefin-lts/pull/1031) in ublue-os/bluefin-lts
-- [#1030 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 556d113](https://github.com/ublue-os/bluefin-lts/pull/1030) in ublue-os/bluefin-lts
-- [#1029 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 3fef130](https://github.com/ublue-os/bluefin-lts/pull/1029) in ublue-os/bluefin-lts
-- [#1028 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 584fe33](https://github.com/ublue-os/bluefin-lts/pull/1028) in ublue-os/bluefin-lts
-- [#1027 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to d1a415b](https://github.com/ublue-os/bluefin-lts/pull/1027) in ublue-os/bluefin-lts
-- [#1025 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 63c7219](https://github.com/ublue-os/bluefin-lts/pull/1025) in ublue-os/bluefin-lts
-- [#1022 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 42f229a](https://github.com/ublue-os/bluefin-lts/pull/1022) in ublue-os/bluefin-lts
-- [#1023 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to e77791a](https://github.com/ublue-os/bluefin-lts/pull/1023) in ublue-os/bluefin-lts
-- [#1019 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to abe58f2](https://github.com/ublue-os/bluefin-lts/pull/1019) in ublue-os/bluefin-lts
-- [#1011 chore(deps): update anchore/sbom-action digest to 0b82b0b](https://github.com/ublue-os/bluefin-lts/pull/1011) in ublue-os/bluefin-lts
-- [#1005 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 89e5f76](https://github.com/ublue-os/bluefin-lts/pull/1005) in ublue-os/bluefin-lts
-- [#1010 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 3f67550](https://github.com/ublue-os/bluefin-lts/pull/1010) in ublue-os/bluefin-lts
-- [#1013 chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to caa431d](https://github.com/ublue-os/bluefin-lts/pull/1013) in ublue-os/bluefin-lts
-- [#999 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to eecf595](https://github.com/ublue-os/bluefin-lts/pull/999) in ublue-os/bluefin-lts
-- [#997 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7f4ecb6](https://github.com/ublue-os/bluefin-lts/pull/997) in ublue-os/bluefin-lts
-- [#995 chore(deps): update system_files/usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io digest to 925fe06](https://github.com/ublue-os/bluefin-lts/pull/995) in ublue-os/bluefin-lts
-- [#996 chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 395e8d8](https://github.com/ublue-os/bluefin-lts/pull/996) in ublue-os/bluefin-lts
-- [#979 chore(deps): update system_files/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com digest to f29b27e](https://github.com/ublue-os/bluefin-lts/pull/979) in ublue-os/bluefin-lts
-- [#978 chore(deps): update system_files/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com digest to 0ba42a0](https://github.com/ublue-os/bluefin-lts/pull/978) in ublue-os/bluefin-lts
-- [#973 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 9c2265c](https://github.com/ublue-os/bluefin-lts/pull/973) in ublue-os/bluefin-lts
-- [#966 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 5a4e3bc](https://github.com/ublue-os/bluefin-lts/pull/966) in ublue-os/bluefin-lts
-- [#965 chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 484e6d7](https://github.com/ublue-os/bluefin-lts/pull/965) in ublue-os/bluefin-lts
-- [#964 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to f963754](https://github.com/ublue-os/bluefin-lts/pull/964) in ublue-os/bluefin-lts
-- [#963 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 81129a6](https://github.com/ublue-os/bluefin-lts/pull/963) in ublue-os/bluefin-lts
-- [#962 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to c050ac0](https://github.com/ublue-os/bluefin-lts/pull/962) in ublue-os/bluefin-lts
-- [#961 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to a6f9953](https://github.com/ublue-os/bluefin-lts/pull/961) in ublue-os/bluefin-lts
-- [#959 chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344](https://github.com/ublue-os/bluefin-lts/pull/959) in ublue-os/bluefin-lts
-- [#956 chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 395e8d8](https://github.com/ublue-os/bluefin-lts/pull/956) in ublue-os/bluefin-lts
-- [#955 chore(deps): update system_files/usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io digest to 925fe06](https://github.com/ublue-os/bluefin-lts/pull/955) in ublue-os/bluefin-lts
-- [#954 chore(deps): update system_files/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com digest to f29b27e](https://github.com/ublue-os/bluefin-lts/pull/954) in ublue-os/bluefin-lts
-- [#953 chore(deps): update system_files/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com digest to 0ba42a0](https://github.com/ublue-os/bluefin-lts/pull/953) in ublue-os/bluefin-lts
-- [#952 chore(deps): pin cgr.dev/chainguard/wolfi-base docker tag to 0d8efc7 - autoclosed](https://github.com/ublue-os/bluefin-lts/pull/952) in ublue-os/bluefin-lts
-- [#993 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/993) in ublue-os/bluefin-lts
-- [#990 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/990) in ublue-os/bluefin-lts
-- [#988 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/988) in ublue-os/bluefin-lts
-- [#983 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/983) in ublue-os/bluefin-lts
-- [#977 [pull] lts from main](https://github.com/ublue-os/bluefin-lts/pull/977) in ublue-os/bluefin-lts
-- [#951 chore: align renovate config with ublue-os/bluefin](https://github.com/ublue-os/bluefin-lts/pull/951) in ublue-os/bluefin-lts
-- [#1677 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to dfe3afe](https://github.com/ublue-os/aurora/pull/1677) in ublue-os/aurora
-- [#1673 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to a27312f](https://github.com/ublue-os/aurora/pull/1673) in ublue-os/aurora
-- [#1671 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 4adc413](https://github.com/ublue-os/aurora/pull/1671) in ublue-os/aurora
-- [#1668 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 5e1bae1](https://github.com/ublue-os/aurora/pull/1668) in ublue-os/aurora
-- [#1667 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to b57b629](https://github.com/ublue-os/aurora/pull/1667) in ublue-os/aurora
-- [#1664 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 77a895e](https://github.com/ublue-os/aurora/pull/1664) in ublue-os/aurora
-- [#1663 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 523bf37](https://github.com/ublue-os/aurora/pull/1663) in ublue-os/aurora
-- [#1662 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 06036ff](https://github.com/ublue-os/aurora/pull/1662) in ublue-os/aurora
-- [#1660 chore(deps): update anchore/sbom-action digest to 62ad528](https://github.com/ublue-os/aurora/pull/1660) in ublue-os/aurora
-- [#1661 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 0f1438d](https://github.com/ublue-os/aurora/pull/1661) in ublue-os/aurora
-- [#1659 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to ef52102](https://github.com/ublue-os/aurora/pull/1659) in ublue-os/aurora
-- [#1658 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to de1e59b](https://github.com/ublue-os/aurora/pull/1658) in ublue-os/aurora
-- [#1656 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 35ea531](https://github.com/ublue-os/aurora/pull/1656) in ublue-os/aurora
-- [#1654 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 9045952](https://github.com/ublue-os/aurora/pull/1654) in ublue-os/aurora
-- [#1653 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 200def6](https://github.com/ublue-os/aurora/pull/1653) in ublue-os/aurora
-- [#1652 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to d9b3121](https://github.com/ublue-os/aurora/pull/1652) in ublue-os/aurora
-- [#1651 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 11c4146](https://github.com/ublue-os/aurora/pull/1651) in ublue-os/aurora
-- [#1648 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to e9ab644](https://github.com/ublue-os/aurora/pull/1648) in ublue-os/aurora
-- [#1645 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 2b3e2a5](https://github.com/ublue-os/aurora/pull/1645) in ublue-os/aurora
-- [#1644 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 6e1485c](https://github.com/ublue-os/aurora/pull/1644) in ublue-os/aurora
-- [#1642 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 40728b8](https://github.com/ublue-os/aurora/pull/1642) in ublue-os/aurora
-- [#1635 chore(deps): update actions/setup-node digest to 6044e13](https://github.com/ublue-os/aurora/pull/1635) in ublue-os/aurora
-- [#1634 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to b82237a](https://github.com/ublue-os/aurora/pull/1634) in ublue-os/aurora
-- [#1633 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 0fca07f](https://github.com/ublue-os/aurora/pull/1633) in ublue-os/aurora
-- [#1632 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to f9899fc](https://github.com/ublue-os/aurora/pull/1632) in ublue-os/aurora
-- [#1629 chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 2cc7b26](https://github.com/ublue-os/aurora/pull/1629) in ublue-os/aurora
-- [#1627 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to f1efb10](https://github.com/ublue-os/aurora/pull/1627) in ublue-os/aurora
-- [#1626 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 8257d84](https://github.com/ublue-os/aurora/pull/1626) in ublue-os/aurora
-- [#1625 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 38e11bb](https://github.com/ublue-os/aurora/pull/1625) in ublue-os/aurora
-- [#1623 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to e042ce3](https://github.com/ublue-os/aurora/pull/1623) in ublue-os/aurora
-- [#1622 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 2d52af0](https://github.com/ublue-os/aurora/pull/1622) in ublue-os/aurora
-- [#1621 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to e730ecd](https://github.com/ublue-os/aurora/pull/1621) in ublue-os/aurora
-- [#1620 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 00f20c5](https://github.com/ublue-os/aurora/pull/1620) in ublue-os/aurora
-- [#1619 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to cfa0abc](https://github.com/ublue-os/aurora/pull/1619) in ublue-os/aurora
-- [#1617 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 0e28d28](https://github.com/ublue-os/aurora/pull/1617) in ublue-os/aurora
-- [#1616 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 05c717f](https://github.com/ublue-os/aurora/pull/1616) in ublue-os/aurora
-- [#1612 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 1144115](https://github.com/ublue-os/aurora/pull/1612) in ublue-os/aurora
-- [#1611 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to dbfaf5f](https://github.com/ublue-os/aurora/pull/1611) in ublue-os/aurora
-- [#1610 chore(deps): update anchore/sbom-action digest to 0b82b0b](https://github.com/ublue-os/aurora/pull/1610) in ublue-os/aurora
-- [#1609 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7da7a8d](https://github.com/ublue-os/aurora/pull/1609) in ublue-os/aurora
-- [#1608 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to cfc1360](https://github.com/ublue-os/aurora/pull/1608) in ublue-os/aurora
-- [#1607 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 205152a](https://github.com/ublue-os/aurora/pull/1607) in ublue-os/aurora
-- [#1606 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to af9169d](https://github.com/ublue-os/aurora/pull/1606) in ublue-os/aurora
-- [#1605 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to cddbaac](https://github.com/ublue-os/aurora/pull/1605) in ublue-os/aurora
-- [#1603 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7442c3f](https://github.com/ublue-os/aurora/pull/1603) in ublue-os/aurora
-- [#1601 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 49e2cea](https://github.com/ublue-os/aurora/pull/1601) in ublue-os/aurora
-- [#1598 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 4673c56](https://github.com/ublue-os/aurora/pull/1598) in ublue-os/aurora
-- [#1600 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 786475f](https://github.com/ublue-os/aurora/pull/1600) in ublue-os/aurora
-- [#1599 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 64778c4](https://github.com/ublue-os/aurora/pull/1599) in ublue-os/aurora
-- [#1597 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 6b83b82](https://github.com/ublue-os/aurora/pull/1597) in ublue-os/aurora
-- [#1596 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to ea97922](https://github.com/ublue-os/aurora/pull/1596) in ublue-os/aurora
-- [#1594 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to b7b46d9](https://github.com/ublue-os/aurora/pull/1594) in ublue-os/aurora
-- [#1593 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to d94871c](https://github.com/ublue-os/aurora/pull/1593) in ublue-os/aurora
-- [#1592 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to bc8c0e5](https://github.com/ublue-os/aurora/pull/1592) in ublue-os/aurora
-- [#1590 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 078e422](https://github.com/ublue-os/aurora/pull/1590) in ublue-os/aurora
-- [#1588 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 1adbad0](https://github.com/ublue-os/aurora/pull/1588) in ublue-os/aurora
-- [#1586 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to cc6eebc](https://github.com/ublue-os/aurora/pull/1586) in ublue-os/aurora
-- [#1585 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7a8d7ac](https://github.com/ublue-os/aurora/pull/1585) in ublue-os/aurora
-- [#1583 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 761b2fc](https://github.com/ublue-os/aurora/pull/1583) in ublue-os/aurora
-- [#1579 chore(deps): update ghcr.io/ublue-os/legacy-rechunk docker tag to v1.0.1](https://github.com/ublue-os/aurora/pull/1579) in ublue-os/aurora
-- [#1582 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 59456e4](https://github.com/ublue-os/aurora/pull/1582) in ublue-os/aurora
-- [#1581 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to d585719](https://github.com/ublue-os/aurora/pull/1581) in ublue-os/aurora
-- [#1580 chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 39ae355](https://github.com/ublue-os/aurora/pull/1580) in ublue-os/aurora
-- [#1577 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to f720cd9](https://github.com/ublue-os/aurora/pull/1577) in ublue-os/aurora
-- [#1576 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 58f33f8](https://github.com/ublue-os/aurora/pull/1576) in ublue-os/aurora
-- [#1574 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 333bf99](https://github.com/ublue-os/aurora/pull/1574) in ublue-os/aurora
-- [#1575 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to fe243ef](https://github.com/ublue-os/aurora/pull/1575) in ublue-os/aurora
-- [#1573 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 2831bd0](https://github.com/ublue-os/aurora/pull/1573) in ublue-os/aurora
-- [#1569 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 30137b5](https://github.com/ublue-os/aurora/pull/1569) in ublue-os/aurora
-- [#1565 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 5881daa](https://github.com/ublue-os/aurora/pull/1565) in ublue-os/aurora
-- [#1564 chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 1b0cf4c](https://github.com/ublue-os/aurora/pull/1564) in ublue-os/aurora
-- [#1563 chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to ffa79af](https://github.com/ublue-os/aurora/pull/1563) in ublue-os/aurora
-- [#591 docs(reports): Monthly report for January 2026](https://github.com/projectbluefin/documentation/pull/591) in projectbluefin/documentation
-- [#578 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/578) in projectbluefin/documentation
-- [#572 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/572) in projectbluefin/documentation
-- [#566 docs: update driver versions](https://github.com/projectbluefin/documentation/pull/566) in projectbluefin/documentation
-- [#565 Use PROJECT_READ_TOKEN for board data fetching](https://github.com/projectbluefin/documentation/pull/565) in projectbluefin/documentation
-- [#564 Add GITHUB_TOKEN to build step for board data fetching](https://github.com/projectbluefin/documentation/pull/564) in projectbluefin/documentation
-- [#563 Add GitHub Project board activity changelog page](https://github.com/projectbluefin/documentation/pull/563) in projectbluefin/documentation
-- [#562 Add migration tooling for GitHub user-attachments to local static images](https://github.com/projectbluefin/documentation/pull/562) in projectbluefin/documentation
-- [#25 Fix LTS workflow image tags to match container registry](https://github.com/projectbluefin/iso/pull/25) in projectbluefin/iso
-- [#24 fix(ci): use stable image tag in pull request workflow](https://github.com/projectbluefin/iso/pull/24) in projectbluefin/iso
-- [#23 fix(ci): hardcode image_tag to stable in Build Stable ISOs workflow](https://github.com/projectbluefin/iso/pull/23) in projectbluefin/iso
-- [#20 feat(ci): replace apt-get rclone with Homebrew action](https://github.com/projectbluefin/iso/pull/20) in projectbluefin/iso
-- [#19 Remove GTS ISO variant, retain only stable/lts/lts-hwe](https://github.com/projectbluefin/iso/pull/19) in projectbluefin/iso
-- [#18 feat(ci): use separate secrets for production bucket in promote-iso workflow](https://github.com/projectbluefin/iso/pull/18) in projectbluefin/iso
-- [#12 Add image_tag parameter to support building ISOs from different container tags](https://github.com/projectbluefin/iso/pull/12) in projectbluefin/iso
+- docs: document flatpak customization system by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/common#116](https://github.com/projectbluefin/common/pull/116)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 79b970c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4121](https://github.com/ublue-os/bluefin/pull/4121)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 94cb1fe by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4120](https://github.com/ublue-os/bluefin/pull/4120)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 45677a5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4116](https://github.com/ublue-os/bluefin/pull/4116)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4a3ec99 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4115](https://github.com/ublue-os/bluefin/pull/4115)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 3d1ec54 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4112](https://github.com/ublue-os/bluefin/pull/4112)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e079560 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4111](https://github.com/ublue-os/bluefin/pull/4111)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 9021d14 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4104](https://github.com/ublue-os/bluefin/pull/4104)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a05cd42 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4106](https://github.com/ublue-os/bluefin/pull/4106)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 783b7e9 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4105](https://github.com/ublue-os/bluefin/pull/4105)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7c2058a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4103](https://github.com/ublue-os/bluefin/pull/4103)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 2181a76 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4101](https://github.com/ublue-os/bluefin/pull/4101)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9e81ecd by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4100](https://github.com/ublue-os/bluefin/pull/4100)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 239cbed by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4094](https://github.com/ublue-os/bluefin/pull/4094)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9a31b4a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4093](https://github.com/ublue-os/bluefin/pull/4093)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 88e4328 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4091](https://github.com/ublue-os/bluefin/pull/4091)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a1988df by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4090](https://github.com/ublue-os/bluefin/pull/4090)
+- chore(deps): update anchore/sbom-action digest to 62ad528 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4088](https://github.com/ublue-os/bluefin/pull/4088)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 42debcf by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4086](https://github.com/ublue-os/bluefin/pull/4086)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 30b194a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4085](https://github.com/ublue-os/bluefin/pull/4085)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 29b0423 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4080](https://github.com/ublue-os/bluefin/pull/4080)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 3b3f5dd by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4079](https://github.com/ublue-os/bluefin/pull/4079)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 731d5fc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4075](https://github.com/ublue-os/bluefin/pull/4075)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 0915431 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4074](https://github.com/ublue-os/bluefin/pull/4074)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c940fd0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4070](https://github.com/ublue-os/bluefin/pull/4070)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d8c0136 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4069](https://github.com/ublue-os/bluefin/pull/4069)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 3b2a1d4 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4068](https://github.com/ublue-os/bluefin/pull/4068)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 20f0d29 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4067](https://github.com/ublue-os/bluefin/pull/4067)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 0fb7539 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4064](https://github.com/ublue-os/bluefin/pull/4064)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to b33a225 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4063](https://github.com/ublue-os/bluefin/pull/4063)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 7b43fd6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4060](https://github.com/ublue-os/bluefin/pull/4060)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c84afd1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4059](https://github.com/ublue-os/bluefin/pull/4059)
+- chore(deps): update actions/setup-node digest to 6044e13 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4057](https://github.com/ublue-os/bluefin/pull/4057)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 12a6234 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4058](https://github.com/ublue-os/bluefin/pull/4058)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 6eefe15 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4056](https://github.com/ublue-os/bluefin/pull/4056)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e5ab9b1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4051](https://github.com/ublue-os/bluefin/pull/4051)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to a5b28ca by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4050](https://github.com/ublue-os/bluefin/pull/4050)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 94f6794 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4049](https://github.com/ublue-os/bluefin/pull/4049)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4c4c93b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4038](https://github.com/ublue-os/bluefin/pull/4038)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 8d2e9f7 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4043](https://github.com/ublue-os/bluefin/pull/4043)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to f30df81 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4042](https://github.com/ublue-os/bluefin/pull/4042)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 5ce5ddc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4037](https://github.com/ublue-os/bluefin/pull/4037)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 2180547 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4036](https://github.com/ublue-os/bluefin/pull/4036)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 3fef130 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4035](https://github.com/ublue-os/bluefin/pull/4035)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 584fe33 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4034](https://github.com/ublue-os/bluefin/pull/4034)
+- chore(deps): update anchore/sbom-action digest to 0b82b0b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4013](https://github.com/ublue-os/bluefin/pull/4013)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to d1a415b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4033](https://github.com/ublue-os/bluefin/pull/4033)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 63c7219 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4031](https://github.com/ublue-os/bluefin/pull/4031)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to abe58f2 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4027](https://github.com/ublue-os/bluefin/pull/4027)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to cce128a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4029](https://github.com/ublue-os/bluefin/pull/4029)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 42f229a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4028](https://github.com/ublue-os/bluefin/pull/4028)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 39ade24 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4026](https://github.com/ublue-os/bluefin/pull/4026)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 233b470 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4025](https://github.com/ublue-os/bluefin/pull/4025)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d01f844 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4021](https://github.com/ublue-os/bluefin/pull/4021)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 87e5c80 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4019](https://github.com/ublue-os/bluefin/pull/4019)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d6a933b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4018](https://github.com/ublue-os/bluefin/pull/4018)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 2ed8419 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4015](https://github.com/ublue-os/bluefin/pull/4015)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 21ef866 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4014](https://github.com/ublue-os/bluefin/pull/4014)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e117db6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4011](https://github.com/ublue-os/bluefin/pull/4011)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 9786fd7 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4010](https://github.com/ublue-os/bluefin/pull/4010)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to f10b6e0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4009](https://github.com/ublue-os/bluefin/pull/4009)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 653ddbf by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4006](https://github.com/ublue-os/bluefin/pull/4006)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 089beed by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4005](https://github.com/ublue-os/bluefin/pull/4005)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 34139ff by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4004](https://github.com/ublue-os/bluefin/pull/4004)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to fe77831 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4003](https://github.com/ublue-os/bluefin/pull/4003)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to b49cf41 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#4002](https://github.com/ublue-os/bluefin/pull/4002)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to e69ca9c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3998](https://github.com/ublue-os/bluefin/pull/3998)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to d9fd32c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3997](https://github.com/ublue-os/bluefin/pull/3997)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 89e5f76 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3996](https://github.com/ublue-os/bluefin/pull/3996)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to c69fbf9 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3990](https://github.com/ublue-os/bluefin/pull/3990)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 288ee27 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3989](https://github.com/ublue-os/bluefin/pull/3989)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7f4ecb6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3987](https://github.com/ublue-os/bluefin/pull/3987)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 9c2265c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3985](https://github.com/ublue-os/bluefin/pull/3985)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 5a4e3bc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3980](https://github.com/ublue-os/bluefin/pull/3980)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 81129a6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3979](https://github.com/ublue-os/bluefin/pull/3979)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to dd6ae9d by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3978](https://github.com/ublue-os/bluefin/pull/3978)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to a6f9953 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3973](https://github.com/ublue-os/bluefin/pull/3973)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 549e587 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3977](https://github.com/ublue-os/bluefin/pull/3977)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to f963754 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3976](https://github.com/ublue-os/bluefin/pull/3976)
+- chore(deps): update ghcr.io/ublue-os/legacy-rechunk docker tag to v1.0.1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3970](https://github.com/ublue-os/bluefin/pull/3970)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3968](https://github.com/ublue-os/bluefin/pull/3968)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3967](https://github.com/ublue-os/bluefin/pull/3967)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to b836644 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3966](https://github.com/ublue-os/bluefin/pull/3966)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 400dc1e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3965](https://github.com/ublue-os/bluefin/pull/3965)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4014cfd by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3964](https://github.com/ublue-os/bluefin/pull/3964)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e0fae11 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3963](https://github.com/ublue-os/bluefin/pull/3963)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 019f3c5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3961](https://github.com/ublue-os/bluefin/pull/3961)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to e1f9cd5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3957](https://github.com/ublue-os/bluefin/pull/3957)
+- chore(deps): update ghcr.io/ublue-os/silverblue-main:latest docker digest to 03b7702 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin#3956](https://github.com/ublue-os/bluefin/pull/3956)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1048](https://github.com/ublue-os/bluefin-lts/pull/1048)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1036](https://github.com/ublue-os/bluefin-lts/pull/1036)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1034](https://github.com/ublue-os/bluefin-lts/pull/1034)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1033](https://github.com/ublue-os/bluefin-lts/pull/1033)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1014](https://github.com/ublue-os/bluefin-lts/pull/1014)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#1000](https://github.com/ublue-os/bluefin-lts/pull/1000)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#998](https://github.com/ublue-os/bluefin-lts/pull/998)
+- [pull] lts from main by [@​pull](https://github.com/pull) in [ublue-os/bluefin-lts#994](https://github.com/ublue-os/bluefin-lts/pull/994)
+- chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 9d9881f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1057](https://github.com/ublue-os/bluefin-lts/pull/1057)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 9021d14 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1059](https://github.com/ublue-os/bluefin-lts/pull/1059)
+- chore(deps): update anchore/sbom-action digest to 62ad528 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1055](https://github.com/ublue-os/bluefin-lts/pull/1055)
+- chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 0c79f2e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1054](https://github.com/ublue-os/bluefin-lts/pull/1054)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 504a0c6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1052](https://github.com/ublue-os/bluefin-lts/pull/1052)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to ddce029 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1051](https://github.com/ublue-os/bluefin-lts/pull/1051)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 731d5fc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1050](https://github.com/ublue-os/bluefin-lts/pull/1050)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 0915431 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1049](https://github.com/ublue-os/bluefin-lts/pull/1049)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 3b2a1d4 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1047](https://github.com/ublue-os/bluefin-lts/pull/1047)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 0599ad1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1046](https://github.com/ublue-os/bluefin-lts/pull/1046)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 20f0d29 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1044](https://github.com/ublue-os/bluefin-lts/pull/1044)
+- chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to 5cb6b2e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1042](https://github.com/ublue-os/bluefin-lts/pull/1042)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 07643c3 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1040](https://github.com/ublue-os/bluefin-lts/pull/1040)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 207713b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1039](https://github.com/ublue-os/bluefin-lts/pull/1039)
+- chore(deps): update actions/setup-node digest to 6044e13 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1038](https://github.com/ublue-os/bluefin-lts/pull/1038)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to e5ab9b1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1037](https://github.com/ublue-os/bluefin-lts/pull/1037)
+- chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to e735a9b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1035](https://github.com/ublue-os/bluefin-lts/pull/1035)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 334770f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1032](https://github.com/ublue-os/bluefin-lts/pull/1032)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 4c4c93b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1031](https://github.com/ublue-os/bluefin-lts/pull/1031)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 556d113 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1030](https://github.com/ublue-os/bluefin-lts/pull/1030)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 3fef130 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1029](https://github.com/ublue-os/bluefin-lts/pull/1029)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 584fe33 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1028](https://github.com/ublue-os/bluefin-lts/pull/1028)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to d1a415b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1027](https://github.com/ublue-os/bluefin-lts/pull/1027)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 63c7219 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1025](https://github.com/ublue-os/bluefin-lts/pull/1025)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 42f229a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1022](https://github.com/ublue-os/bluefin-lts/pull/1022)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to e77791a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1023](https://github.com/ublue-os/bluefin-lts/pull/1023)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to abe58f2 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1019](https://github.com/ublue-os/bluefin-lts/pull/1019)
+- chore(deps): update anchore/sbom-action digest to 0b82b0b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1011](https://github.com/ublue-os/bluefin-lts/pull/1011)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 89e5f76 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1005](https://github.com/ublue-os/bluefin-lts/pull/1005)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 3f67550 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1010](https://github.com/ublue-os/bluefin-lts/pull/1010)
+- chore(deps): update cgr.dev/chainguard/wolfi-base:latest docker digest to caa431d by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#1013](https://github.com/ublue-os/bluefin-lts/pull/1013)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to eecf595 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#999](https://github.com/ublue-os/bluefin-lts/pull/999)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 7f4ecb6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#997](https://github.com/ublue-os/bluefin-lts/pull/997)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io digest to 925fe06 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#995](https://github.com/ublue-os/bluefin-lts/pull/995)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 395e8d8 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#996](https://github.com/ublue-os/bluefin-lts/pull/996)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com digest to f29b27e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#979](https://github.com/ublue-os/bluefin-lts/pull/979)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com digest to 0ba42a0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#978](https://github.com/ublue-os/bluefin-lts/pull/978)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 9c2265c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#973](https://github.com/ublue-os/bluefin-lts/pull/973)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 5a4e3bc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#966](https://github.com/ublue-os/bluefin-lts/pull/966)
+- chore(deps): update quay.io/centos-bootc/centos-bootc:c10s docker digest to 484e6d7 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#965](https://github.com/ublue-os/bluefin-lts/pull/965)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to f963754 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#964](https://github.com/ublue-os/bluefin-lts/pull/964)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 81129a6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#963](https://github.com/ublue-os/bluefin-lts/pull/963)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to c050ac0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#962](https://github.com/ublue-os/bluefin-lts/pull/962)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to a6f9953 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#961](https://github.com/ublue-os/bluefin-lts/pull/961)
+- chore(deps): update ghcr.io/projectbluefin/common:latest docker digest to 59b7344 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#959](https://github.com/ublue-os/bluefin-lts/pull/959)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/tmp/caffeine digest to 395e8d8 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#956](https://github.com/ublue-os/bluefin-lts/pull/956)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io digest to 925fe06 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#955](https://github.com/ublue-os/bluefin-lts/pull/955)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com digest to f29b27e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#954](https://github.com/ublue-os/bluefin-lts/pull/954)
+- chore(deps): update system_files/usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com digest to 0ba42a0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#953](https://github.com/ublue-os/bluefin-lts/pull/953)
+- chore(deps): pin cgr.dev/chainguard/wolfi-base docker tag to 0d8efc7 - autoclosed by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/bluefin-lts#952](https://github.com/ublue-os/bluefin-lts/pull/952)
+- [pull] lts from main by [@​testpullapp](https://github.com/testpullapp) in [ublue-os/bluefin-lts#993](https://github.com/ublue-os/bluefin-lts/pull/993)
+- [pull] lts from main by [@​testpullapp](https://github.com/testpullapp) in [ublue-os/bluefin-lts#990](https://github.com/ublue-os/bluefin-lts/pull/990)
+- [pull] lts from main by [@​testpullapp](https://github.com/testpullapp) in [ublue-os/bluefin-lts#988](https://github.com/ublue-os/bluefin-lts/pull/988)
+- [pull] lts from main by [@​testpullapp](https://github.com/testpullapp) in [ublue-os/bluefin-lts#983](https://github.com/ublue-os/bluefin-lts/pull/983)
+- [pull] lts from main by [@​testpullapp](https://github.com/testpullapp) in [ublue-os/bluefin-lts#977](https://github.com/ublue-os/bluefin-lts/pull/977)
+- chore: align renovate config with ublue-os/bluefin by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [ublue-os/bluefin-lts#951](https://github.com/ublue-os/bluefin-lts/pull/951)
+- chore(deps): update anchore/sbom-action digest to deef08a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1678](https://github.com/ublue-os/aurora/pull/1678)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to dfe3afe by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1677](https://github.com/ublue-os/aurora/pull/1677)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to a27312f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1673](https://github.com/ublue-os/aurora/pull/1673)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 4adc413 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1671](https://github.com/ublue-os/aurora/pull/1671)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 5e1bae1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1668](https://github.com/ublue-os/aurora/pull/1668)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to b57b629 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1667](https://github.com/ublue-os/aurora/pull/1667)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 77a895e by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1664](https://github.com/ublue-os/aurora/pull/1664)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 523bf37 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1663](https://github.com/ublue-os/aurora/pull/1663)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 06036ff by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1662](https://github.com/ublue-os/aurora/pull/1662)
+- chore(deps): update anchore/sbom-action digest to 62ad528 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1660](https://github.com/ublue-os/aurora/pull/1660)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 0f1438d by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1661](https://github.com/ublue-os/aurora/pull/1661)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to ef52102 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1659](https://github.com/ublue-os/aurora/pull/1659)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to de1e59b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1658](https://github.com/ublue-os/aurora/pull/1658)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 35ea531 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1656](https://github.com/ublue-os/aurora/pull/1656)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 9045952 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1654](https://github.com/ublue-os/aurora/pull/1654)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 200def6 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1653](https://github.com/ublue-os/aurora/pull/1653)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to d9b3121 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1652](https://github.com/ublue-os/aurora/pull/1652)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 11c4146 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1651](https://github.com/ublue-os/aurora/pull/1651)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to e9ab644 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1648](https://github.com/ublue-os/aurora/pull/1648)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 2b3e2a5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1645](https://github.com/ublue-os/aurora/pull/1645)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 6e1485c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1644](https://github.com/ublue-os/aurora/pull/1644)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 40728b8 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1642](https://github.com/ublue-os/aurora/pull/1642)
+- chore(deps): update actions/setup-node digest to 6044e13 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1635](https://github.com/ublue-os/aurora/pull/1635)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to b82237a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1634](https://github.com/ublue-os/aurora/pull/1634)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 0fca07f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1633](https://github.com/ublue-os/aurora/pull/1633)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to f9899fc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1632](https://github.com/ublue-os/aurora/pull/1632)
+- chore(deps): update quay.io/fedora-ostree-desktops/kinoite:43 docker digest to 2cc7b26 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1629](https://github.com/ublue-os/aurora/pull/1629)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to f1efb10 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1627](https://github.com/ublue-os/aurora/pull/1627)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 8257d84 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1626](https://github.com/ublue-os/aurora/pull/1626)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 38e11bb by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1625](https://github.com/ublue-os/aurora/pull/1625)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to e042ce3 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1623](https://github.com/ublue-os/aurora/pull/1623)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 2d52af0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1622](https://github.com/ublue-os/aurora/pull/1622)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to e730ecd by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1621](https://github.com/ublue-os/aurora/pull/1621)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 00f20c5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1620](https://github.com/ublue-os/aurora/pull/1620)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to cfa0abc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1619](https://github.com/ublue-os/aurora/pull/1619)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 0e28d28 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1617](https://github.com/ublue-os/aurora/pull/1617)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 05c717f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1616](https://github.com/ublue-os/aurora/pull/1616)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 1144115 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1612](https://github.com/ublue-os/aurora/pull/1612)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to dbfaf5f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1611](https://github.com/ublue-os/aurora/pull/1611)
+- chore(deps): update anchore/sbom-action digest to 0b82b0b by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1610](https://github.com/ublue-os/aurora/pull/1610)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7da7a8d by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1609](https://github.com/ublue-os/aurora/pull/1609)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to cfc1360 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1608](https://github.com/ublue-os/aurora/pull/1608)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 205152a by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1607](https://github.com/ublue-os/aurora/pull/1607)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to af9169d by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1606](https://github.com/ublue-os/aurora/pull/1606)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to cddbaac by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1605](https://github.com/ublue-os/aurora/pull/1605)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7442c3f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1603](https://github.com/ublue-os/aurora/pull/1603)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 49e2cea by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1601](https://github.com/ublue-os/aurora/pull/1601)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 4673c56 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1598](https://github.com/ublue-os/aurora/pull/1598)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 786475f by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1600](https://github.com/ublue-os/aurora/pull/1600)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 64778c4 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1599](https://github.com/ublue-os/aurora/pull/1599)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 6b83b82 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1597](https://github.com/ublue-os/aurora/pull/1597)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to ea97922 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1596](https://github.com/ublue-os/aurora/pull/1596)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to b7b46d9 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1594](https://github.com/ublue-os/aurora/pull/1594)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to d94871c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1593](https://github.com/ublue-os/aurora/pull/1593)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to bc8c0e5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1592](https://github.com/ublue-os/aurora/pull/1592)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 078e422 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1590](https://github.com/ublue-os/aurora/pull/1590)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 1adbad0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1588](https://github.com/ublue-os/aurora/pull/1588)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to cc6eebc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1586](https://github.com/ublue-os/aurora/pull/1586)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 7a8d7ac by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1585](https://github.com/ublue-os/aurora/pull/1585)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 761b2fc by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1583](https://github.com/ublue-os/aurora/pull/1583)
+- chore(deps): update ghcr.io/ublue-os/legacy-rechunk docker tag to v1.0.1 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1579](https://github.com/ublue-os/aurora/pull/1579)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 59456e4 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1582](https://github.com/ublue-os/aurora/pull/1582)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to d585719 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1581](https://github.com/ublue-os/aurora/pull/1581)
+- chore(deps): update ghcr.io/ublue-os/brew:latest docker digest to 39ae355 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1580](https://github.com/ublue-os/aurora/pull/1580)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to f720cd9 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1577](https://github.com/ublue-os/aurora/pull/1577)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 58f33f8 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1576](https://github.com/ublue-os/aurora/pull/1576)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 333bf99 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1574](https://github.com/ublue-os/aurora/pull/1574)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to fe243ef by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1575](https://github.com/ublue-os/aurora/pull/1575)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 2831bd0 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1573](https://github.com/ublue-os/aurora/pull/1573)
+- chore(deps): update ghcr.io/get-aurora-dev/common:latest docker digest to 30137b5 by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1569](https://github.com/ublue-os/aurora/pull/1569)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 5881daa by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1565](https://github.com/ublue-os/aurora/pull/1565)
+- chore(deps): update ghcr.io/ublue-os/kinoite-main:latest docker digest to 1b0cf4c by [@​ubot-7274](https://github.com/ubot-7274) in [ublue-os/aurora#1564](https://github.com/ublue-os/aurora/pull/1564)
+- docs(reports): Monthly report for January 2026 by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#591](https://github.com/projectbluefin/documentation/pull/591)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#578](https://github.com/projectbluefin/documentation/pull/578)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#572](https://github.com/projectbluefin/documentation/pull/572)
+- docs: update driver versions by [@​github-actions](https://github.com/github-actions) in [projectbluefin/documentation#566](https://github.com/projectbluefin/documentation/pull/566)
+- Use PROJECT_READ_TOKEN for board data fetching by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#565](https://github.com/projectbluefin/documentation/pull/565)
+- Add GITHUB_TOKEN to build step for board data fetching by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#564](https://github.com/projectbluefin/documentation/pull/564)
+- Add GitHub Project board activity changelog page by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#563](https://github.com/projectbluefin/documentation/pull/563)
+- Add migration tooling for GitHub user-attachments to local static images by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/documentation#562](https://github.com/projectbluefin/documentation/pull/562)
+- Fix LTS workflow image tags to match container registry by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#25](https://github.com/projectbluefin/iso/pull/25)
+- fix(ci): use stable image tag in pull request workflow by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#24](https://github.com/projectbluefin/iso/pull/24)
+- fix(ci): hardcode image_tag to stable in Build Stable ISOs workflow by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#23](https://github.com/projectbluefin/iso/pull/23)
+- feat(ci): replace apt-get rclone with Homebrew action by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#20](https://github.com/projectbluefin/iso/pull/20)
+- Remove GTS ISO variant, retain only stable/lts/lts-hwe by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#19](https://github.com/projectbluefin/iso/pull/19)
+- feat(ci): use separate secrets for production bucket in promote-iso workflow by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#18](https://github.com/projectbluefin/iso/pull/18)
+- Add image_tag parameter to support building ISOs from different container tags by [@​copilot-swe-agent](https://github.com/copilot-swe-agent) in [projectbluefin/iso#12](https://github.com/projectbluefin/iso/pull/12)
 
 </details>
 


### PR DESCRIPTION
## Summary

This PR improves the monthly reports formatting by adopting the Hyperlight project's single-line changelog style and simplifying the bot activity table.

### Changes

**1. Hyperlight-style single-line format**
- **Before**: `- [#183 feat: Add org.gnome.SoundRecorder](URL) by @user`
- **After**: `- feat: Add org.gnome.SoundRecorder by [@user](github-link) in [#183](URL)`

Benefits:
- Author names are now clickable links to GitHub profiles
- Format matches established patterns from successful OSS projects
- More natural reading order: title → author → PR number

**2. Simplified bot activity table**
- **Before**: Per-bot, per-repository breakdown (verbose table)
- **After**: Repository-level aggregation with total counts

Example:
| Repository | Bot PRs |
|------------|---------|
| bluefin | 88 |
| aurora | 72 |
| bluefin-lts | 64 |

Benefits:
- Reduces table size by ~70% for typical reports
- Readers only need total bot activity per repo
- Detailed per-bot breakdown still available in collapsible details

### Testing

- ✅ Regenerated December 2025 report with new formatting
- ✅ Regenerated January 2026 report with new formatting
- ✅ Built site successfully (`npm run build`)
- ✅ Verified HTML output renders correctly
- ✅ Confirmed bot table aggregation logic works

### Files Modified

- `scripts/lib/markdown-generator.mjs` - Updated formatting functions
- `reports/2025-12-31-report.mdx` - Regenerated with new format
- `reports/2026-01-31-report.mdx` - Regenerated with new format

Closes: `.planning/todos/pending/2026-01-27-simplify-bot-activity-table.md`