### PR TITLE
chore(ci): update node version to 20 in monthly reports

### DIFF
--- a/.github/workflows/monthly-reports.yml
+++ b/.github/workflows/monthly-reports.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Description
Node 18 is EOL. Updating to Node 20 (Active LTS) to match other workflows and fix local generation issues.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI improvement

## Testing Done
- Local build: Yes (npm run build passed)
- Tested on running system: N/A
- Just recipes tested: N/A
- Report Generation: Verified locally with `npm run generate-report`

## Related Issues
N/A