### PR TITLE
fix(feed): fix discussion links and increase announcement count

### DIFF
--- a/src/components/CommunityFeeds.tsx
+++ b/src/components/CommunityFeeds.tsx
@@ -14,11 +14,12 @@ const CommunityFeeds: React.FC = () => {
         <div className={styles.header}>
           <h1>Changelogs and Feeds</h1>
           <p>
-            Stay up to date with the latest Bluefin releases. Looking for project activity and
-            development progress? Check out our{" "}
+            Stay up to date with the latest Bluefin releases. Looking for
+            project activity and development progress? Check out our{" "}
             <a href="/reports">Monthly Reports</a> for summaries of completed
             work from{" "}
-            <a href="https://todo.projectbluefin.io">todo.projectbluefin.io</a>. Stay frosty.
+            <a href="https://todo.projectbluefin.io">todo.projectbluefin.io</a>.
+            Stay frosty.
           </p>
         </div>
 
@@ -88,7 +89,7 @@ const CommunityFeeds: React.FC = () => {
             <FeedItems
               feedId="bluefinAnnouncements"
               title="Announcements"
-              maxItems={3}
+              maxItems={5}
               showDescription={false}
             />
           </div>

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -201,12 +201,22 @@ const FeedItems: React.FC<FeedItemsProps> = ({
                   itemLink = `https://github.com/ublue-os/bluefin/releases/tag/${tag}`;
                 } else if (feedId === "bluefinLtsReleases") {
                   itemLink = `https://github.com/ublue-os/bluefin-lts/releases/tag/${tag}`;
-                } else if (
-                  feedId === "bluefinDiscussions" ||
-                  feedId === "bluefinAnnouncements"
-                ) {
-                  // For discussions, the ID format might be different, but we'll try
-                  itemLink = `https://github.com/ublue-os/bluefin/discussions/${tag}`;
+                }
+              } else {
+                // Try to match GitHub Discussion IDs
+                // Format: "tag:github.com,2008:Discussion/12345"
+                const discussionMatch = item.id.match(
+                  /^tag:github\.com,\d+:Discussion\/(\d+)$/,
+                );
+
+                if (discussionMatch) {
+                  const [, discussionId] = discussionMatch;
+                  if (
+                    feedId === "bluefinDiscussions" ||
+                    feedId === "bluefinAnnouncements"
+                  ) {
+                    itemLink = `https://github.com/ublue-os/bluefin/discussions/${discussionId}`;
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Description
Fixes broken links for Community Discussions and Announcements by parsing the correct Atom feed ID format for GitHub Discussions. Also increases the number of displayed announcements from 3 to 5 to align with the discussions section.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI improvement

## Testing Done
- Local build: Yes (npm run build passed)
- Tested on running system: N/A
- Just recipes tested: N/A

## Related Issues
N/A

Assisted-by: Google DeepMind Antigravity