### PR TITLE
fix(feed): update release feeds card limit to 12

### DIFF
--- a/src/components/CommunityFeeds.tsx
+++ b/src/components/CommunityFeeds.tsx
@@ -42,7 +42,7 @@ const CommunityFeeds: React.FC = () => {
             <FeedItems
               feedId="bluefinLtsReleases"
               title="Bluefin LTS"
-              maxItems={10}
+              maxItems={12} // 12 weeks < 90 days
               showDescription={false}
             />
             <p className={styles.sectionByline}>
@@ -53,7 +53,7 @@ const CommunityFeeds: React.FC = () => {
             <FeedItems
               feedId="bluefinReleases"
               title="Bluefin GTS"
-              maxItems={10}
+              maxItems={12} // 12 weeks < 90 days
               showDescription={false}
               filter={(item) => item.title.startsWith("gts-")}
             />
@@ -65,7 +65,7 @@ const CommunityFeeds: React.FC = () => {
             <FeedItems
               feedId="bluefinReleases"
               title="Bluefin"
-              maxItems={10}
+              maxItems={12} // 12 weeks < 90 days
               showDescription={false}
               filter={(item) => item.title.startsWith("stable-")}
             />


### PR DESCRIPTION
Increase maxItems from 10/5 to 12 for Bluefin LTS, GTS and Stable feeds. This ensures approximately 90 days (12 weeks) of release history is shown.

Assisted-by: Google DeepMind Antigravity