### PR TITLE
fix(feed): fix discussion links and increase announcement count

### DIFF
--- a/src/components/CommunityFeeds.tsx
+++ b/src/components/CommunityFeeds.tsx
@@ -88,7 +88,7 @@ const CommunityFeeds: React.FC = () => {
             <FeedItems
               feedId="bluefinAnnouncements"
               title="Announcements"
-              maxItems={3}
+              maxItems={5}
               showDescription={false}
             />
           </div>

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -194,19 +194,29 @@ const FeedItems: React.FC<FeedItemsProps> = ({
               const idMatch = item.id.match(
                 /^tag:github\.com,\d+:Repository\/(\d+)\/(.+)$/,
               );
-              if (idMatch) {
+                if (idMatch) {
                 const [, repoId, tag] = idMatch;
                 // For GitHub releases, we need to determine the repo name from the feedId
                 if (feedId === "bluefinReleases") {
                   itemLink = `https://github.com/ublue-os/bluefin/releases/tag/${tag}`;
                 } else if (feedId === "bluefinLtsReleases") {
                   itemLink = `https://github.com/ublue-os/bluefin-lts/releases/tag/${tag}`;
-                } else if (
-                  feedId === "bluefinDiscussions" ||
-                  feedId === "bluefinAnnouncements"
-                ) {
-                  // For discussions, the ID format might be different, but we'll try
-                  itemLink = `https://github.com/ublue-os/bluefin/discussions/${tag}`;
+                }
+              } else {
+                // Try to match GitHub Discussion IDs
+                // Format: "tag:github.com,2008:Discussion/12345"
+                const discussionMatch = item.id.match(
+                  /^tag:github\.com,\d+:Discussion\/(\d+)$/,
+                );
+
+                if (discussionMatch) {
+                  const [, discussionId] = discussionMatch;
+                  if (
+                    feedId === "bluefinDiscussions" ||
+                    feedId === "bluefinAnnouncements"
+                  ) {
+                    itemLink = `https://github.com/ublue-os/bluefin/discussions/${discussionId}`;
+                  }
                 }
               }
             }


### PR DESCRIPTION
Update regex to parse GitHub Discussion Atom feed IDs correctly. Increase displayed announcements to 5 to align with community discussions. Keeps release feeds at 10 items (native Atom feed limit).

Assisted-by: Google DeepMind Antigravity