### PR TITLE
fix(ci): run fetch-data before typecheck

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Fetch data
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
+        run: npm run fetch-data
+
       - name: Run TypeScript validation
         run: npm run typecheck
 


### PR DESCRIPTION
The typecheck step fails because it depends on generated JSON files that are created by the fetch-data script. This change ensures data is fetched before type validation runs.

Assisted-by: Google DeepMind Antigravity