### PR TITLE
docs: add tieguy to advisors and mentors

### DIFF
--- a/docs/donations/contributors.mdx
+++ b/docs/donations/contributors.mdx
@@ -177,6 +177,7 @@ The following individuals have made a lasting impact on Bluefin's design, either
   <GitHubProfileCard username="jberkus" />
   <GitHubProfileCard username="krisnova" />
   <GitHubProfileCard username="rochaporto" />
+  <GitHubProfileCard username="tieguy" />
 </div>
 
 :::note[Miguel de Cervantes]


### PR DESCRIPTION
Adds [@tieguy](https://github.com/tieguy) to the Advisors and Mentors section of the contributors page.

## Changes
- Added GitHubProfileCard for tieguy in the mentors section
- Profile data will be auto-fetched at build time

## Testing
Verified locally with dev server