### PR TITLE
fix: correct stale repo refs, announcement bar, and CI cache key

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: static/data
-          key: github-data-${{ hashFiles('scripts/fetch-github-*.js') }}-${{ github.run_number }}
+          key: github-data-${{ hashFiles('scripts/fetch-github-*.js') }}
           restore-keys: |
             github-data-${{ hashFiles('scripts/fetch-github-*.js') }}-
             github-data-

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,22 +1,22 @@
 ---
 sidebar_position: 6
-title: Biweekly Reports
+title: Monthly Reports
 ---
 
-# Biweekly Reports
+# Monthly Reports
 
-Biweekly reports provide transparent, data-driven summaries of completed work, active contributors, and project momentum from the [Bluefin Project Board](https://todo.projectbluefin.io).
+Monthly reports provide transparent, data-driven summaries of completed work, active contributors, and project momentum from the [Bluefin Project Board](https://todo.projectbluefin.io).
 
-## What Are Biweekly Reports?
+## What Are Monthly Reports?
 
-Biweekly reports are automatically generated every other week, summarizing:
+Monthly reports are automatically generated each month, summarizing:
 
 - **Completed Work:** Items moved to "Done" on the project board, categorized by area and type
 - **Contributors:** Everyone who contributed during the period, with special recognition for first-time contributors
 - **Bot Activity:** Automated dependency updates and maintenance tasks
 - **Project Status:** ChillOps philosophy indicators for each project area
 
-Reports are published every other Monday covering the previous two-week period.
+Reports are published monthly covering the previous month's activity.
 
 ## ChillOps Philosophy
 
@@ -88,7 +88,7 @@ Understanding the content types:
 | -------------- | -------------------------------------- | ----------- | ------------------------ |
 | **Changelogs** | OS release notes with package versions | Per release | GitHub Releases          |
 | **Blog Posts** | Deep dives, announcements, tutorials   | Ad-hoc      | Manual authoring         |
-| **Reports**    | Project activity summaries             | Biweekly    | Project board automation |
+| **Reports**    | Project activity summaries             | Monthly     | Project board automation |
 
 **Use changelogs** to see what changed in a specific OS release.  
 **Use blog posts** for detailed explanations and guides.  
@@ -104,7 +104,7 @@ Understanding the content types:
 
 Reports are 100% automatically generated from the project board:
 
-1. Every other Monday at 10:00 UTC
+1. Monthly on the last day of the month at 10:00 UTC
 2. GitHub Actions workflow fetches project board data
 3. Script categorizes completed items by labels
 4. Markdown report generated and committed

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -45,14 +45,14 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           // Disables the landing page
           routeBasePath: "/",
-          editUrl: "https://github.com/ublue-os/bluefin-docs/tree/main",
+          editUrl: "https://github.com/projectbluefin/documentation/tree/main",
         },
         blog: {
           blogTitle: "Bluefin's Blog",
           blogDescription: "Official Blog and Announcements",
           blogSidebarCount: "ALL",
           blogSidebarTitle: "Raptor News",
-          editUrl: "https://github.com/ublue-os/bluefin-docs/edit/main/",
+          editUrl: "https://github.com/projectbluefin/documentation/edit/main/",
           authorsMapPath: "authors.yaml",
           truncateMarker: /(?!.*)/,
           feedOptions: {
@@ -124,7 +124,7 @@ const config: Config = {
     announcementBar: {
       id: "announcement",
       content:
-        'Reminder: Bluefin GTS will merge into Bluefin on 1 March 2026. Check the <a href="https://docs.projectbluefin.io/blog/bluefin-2025/">State of the Raptor</a> for more information.',
+        'Reminder: Bluefin GTS will be merged the week of March 9th. Check the <a href="https://docs.projectbluefin.io/blog/bluefin-2025/">State of the Raptor</a> for more information.',
       backgroundColor: "#fafbfc",
       textColor: "#091E42",
       isCloseable: true,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -124,7 +124,7 @@ const config: Config = {
     announcementBar: {
       id: "announcement",
       content:
-        'Reminder: Bluefin GTS will be merged the week of March 9th. Check the <a href="https://docs.projectbluefin.io/blog/bluefin-2025/">State of the Raptor</a> for more information.',
+        'Reminder: Bluefin GTS has been merged into mainline Bluefin. Check the <a href="https://docs.projectbluefin.io/blog/bluefin-2025/">State of the Raptor</a> for more information.',
       backgroundColor: "#fafbfc",
       textColor: "#091E42",
       isCloseable: true,

--- a/scripts/fetch-contributors.js
+++ b/scripts/fetch-contributors.js
@@ -13,8 +13,8 @@ const CACHE_MAX_AGE_HOURS = 24;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
 // GitHub repo details
-const REPO_OWNER = "ublue-os";
-const REPO_NAME = "bluefin-docs";
+const REPO_OWNER = "projectbluefin";
+const REPO_NAME = "documentation";
 
 // Bot accounts to filter out
 const BOT_LOGINS = [

--- a/src/components/PageContributors.tsx
+++ b/src/components/PageContributors.tsx
@@ -94,7 +94,7 @@ const fetchFileContributors = async (
 ): Promise<Contributor[]> => {
   return requestQueue.add(async () => {
     const response = await fetch(
-      `https://api.github.com/repos/ublue-os/bluefin-docs/commits?path=${filePath}`,
+      `https://api.github.com/repos/projectbluefin/documentation/commits?path=${filePath}`,
       {
         headers: {
           Accept: "application/vnd.github.v3+json",

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -20,7 +20,7 @@ export default function FooterWrapper(props: Props): React.ReactElement {
     const editUrl = metadata.editUrl;
 
     // Extract file path from edit URL
-    // Example: https://github.com/ublue-os/bluefin-docs/tree/main/docs/installation.md
+    // Example: https://github.com/projectbluefin/documentation/tree/main/docs/installation.md
     if (editUrl) {
       const match = editUrl.match(/\/(?:edit|tree)\/[^/]+\/(.+)$/);
       if (match) {


### PR DESCRIPTION
## Summary

- Update announcement bar: will merge the week of March 9th
- Fix editUrl in docusaurus.config.ts (ublue-os/bluefin-docs -> projectbluefin/documentation) - Edit this page links were broken
- Fix REPO_OWNER/REPO_NAME in scripts/fetch-contributors.js - contributor data was fetching from a nonexistent repo
- Fix API URL in src/components/PageContributors.tsx - per-doc contributor footers returning empty
- Fix stale comment in src/theme/DocItem/Footer/index.tsx
- Fix docs/reports.md: Biweekly -> Monthly throughout
- Fix CI cache key in pages.yml: remove run_number so cache is actually restored

## Test Plan

- typecheck: clean
- npm run build: passes