### PR TITLE
Document early alpha `bluefin-cli` for cross-platform use

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -70,6 +70,10 @@ What greatness have I been missing? Being set in my old, tired ways.
 
 ![image](/img/user-attachments/89be8151-5b57-4b71-bbe5-988bef2d6798.jpg)
 
+# `bluefin-cli` for Mac and Windows (WSL)
+
+On a Mac or Windows machine? Want to play with the Bluefin user experience on your native operating system? No problem! We have an early alpha `bluefin-cli` cross-platform app brewing at `brew install ublue-os/tap/bluefin-cli` it should work on MacOS, any Linux, Windows (WSL+PowerShell). you can use it to grab Bluefin artwork and to bring all this Bluefin command line goodness to a terminal near you. Please [open issues with feedback](https://github.com/hanthor/bluefin-cli/issues/new)
+
 ### Bold Brew
 
 [Bold Brew](https://bold-brew.com/) (`bbrew`) is included as a text based user interface (TUI) to Brew. This application features full package management for homebrew in a nice nerdy interface:
@@ -158,6 +162,4 @@ brew tap colindean/fonts-nonfree && brew install --cask font-microsoft-office fo
 ```
 
 
-# Not on Bluefin?
 
-No problem! We have an early alpha `bluefin-cli` cross-platform app brewing at `brew install ublue-os/tap/bluefin-cli` it should work on MacOS, any Linux, Windows (WSL+PowerShell). you can use it to grab Bluefin artwork and to bring all this Bluefin command line goodness to a terminal near you. Please open issus with feedback at https://github.com/hanthor/bluefin-cli/issues/new


### PR DESCRIPTION
Added information about the early alpha `bluefin-cli` app for cross-platform usage.