### PR TITLE
docs: remove retired GTS references from active documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,7 +77,7 @@ Bluefin is a combination of a set of configuration OCI containers which are then
 
 ### Images 
 
-- Bluefin stable and GTS: [@ublue-os/bluefin](https://github.com/ublue-os/bluefin) - generates Fedora-based Bluefin OCI container
+- Bluefin stable: [@ublue-os/bluefin](https://github.com/ublue-os/bluefin) - generates Fedora-based Bluefin OCI container
 - Bluefin LTS [@ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts) - generates a CentOS-based Bluefin OCI container
 - Bluefin distroless prototype (aka Dakotaraptor) [@ublue-os/dakota](https://github.com/projectbluefin/dakota) - generates a GNOME OS based Bluefin OCI container
 
@@ -155,7 +155,6 @@ We're making containers here with bash and a little bit of Python, it's not the 
 |---------|---------|------------------|----------------|
 | **latest** | Daily builds | Multiple times per day | 43 (current) |
 | **stable** | Weekly builds | Weekly | 43 |
-| **gts** | Long-term support | As needed | 42 |
 
 ### Prerequisites
 

--- a/docs/local.md
+++ b/docs/local.md
@@ -67,7 +67,7 @@ Performs the same cleaning operations as `clean` but with elevated privileges us
 Validates the combination of image, tag, and flavor provided as arguments.
 
 - Checks if the provided image, tag, and flavor exist in the predefined associative arrays.
-- Ensures that certain combinations (e.g., `gts` tag with `aurora` image) are not allowed.
+- Ensures that certain combinations (e.g., an invalid tag with `aurora` image) are not allowed.
 
 ### sudoif
 

--- a/docs/lts.mdx
+++ b/docs/lts.mdx
@@ -35,7 +35,7 @@ Bluefin LTS also offers a HWE (Hardware Enablement) branch with:
 
 Bluefin LTS ships with Linux 6.12.0, which is the kernel for the lifetime of release. It is for change-averse users. Bluefin LTS provides a backported GNOME desktop so that you are not left behind. And an optional `hwe` branch with new kernels.
 
-### Differences from Bluefin 
+### Differences from Bluefin
 
 - There may be instances when something from Bluefin is not implemented in Bluefin LTS. Please [file an issue](https://github.com/ublue-os/bluefin-lts/issues) and tag it with `parity` and the team will investigate. They'll never match _exactly_ but we can get the important ones done
 - Appimages are hard unsupported (those fuse packages aren't even in CentOS)
@@ -116,7 +116,7 @@ The [qcow2](https://qemu-project.gitlab.io/qemu/system/images.html) file will be
 
 Hibernation is on by default in a suspend-then-hibernate configuration. Here is the [exact config](https://github.com/ublue-os/bluefin-lts/blob/c0c8e2166cb5d0c4dd511ab3f677450c2cf8de0c/build_scripts/40-services.sh#L6). The device will suspend then go into hibernation after two hours. See the [systemd-sleep.conf](https://www.freedesktop.org/software/systemd/man/latest/systemd-sleep.conf.html) documentation.
 
-Note that secureboot and hibernation are mutually exclusive. We do not yet offer secureboot enabled images of Bluefin LTS, if you need that functionality now we recommend the normal Bluefin and Bluefin GTS images.
+Note that secureboot and hibernation are mutually exclusive. We do not yet offer secureboot enabled images of Bluefin LTS, if you need that functionality now we recommend the normal Bluefin images.
 
 ## Supporting Bluefin LTS
 

--- a/src/components/CommunityFeeds.tsx
+++ b/src/components/CommunityFeeds.tsx
@@ -25,43 +25,15 @@ const CommunityFeeds: React.FC = () => {
 
         {/* Package Summary Boxes */}
         <div className={styles.packageSummaryGrid}>
-          <PackageSummary feedKey="bluefinLtsReleases" title="Bluefin LTS" />
-          <PackageSummary
-            feedKey="bluefinReleases"
-            title="Bluefin GTS"
-            filter={(item) => item.title.startsWith("gts-")}
-          />
           <PackageSummary
             feedKey="bluefinReleases"
             title="Bluefin"
             filter={(item) => item.title.startsWith("stable-")}
           />
+          <PackageSummary feedKey="bluefinLtsReleases" title="Bluefin LTS" />
         </div>
 
         <div className={styles.feedGrid}>
-          <div className={styles.feedColumn}>
-            <FeedItems
-              feedId="bluefinLtsReleases"
-              title="Bluefin LTS"
-              maxItems={10}
-              showDescription={false}
-            />
-            <p className={styles.sectionByline}>
-              <em>Achillobator giganticus</em>
-            </p>
-          </div>
-          <div className={styles.feedColumn}>
-            <FeedItems
-              feedId="bluefinReleases"
-              title="Bluefin GTS"
-              maxItems={10}
-              showDescription={false}
-              filter={(item) => item.title.startsWith("gts-")}
-            />
-            <p className={styles.sectionByline}>
-              <em>Deinonychus antirrhopus</em>
-            </p>
-          </div>
           <div className={styles.feedColumn}>
             <FeedItems
               feedId="bluefinReleases"
@@ -72,6 +44,17 @@ const CommunityFeeds: React.FC = () => {
             />
             <p className={styles.sectionByline}>
               <em>Utahraptor ostrommaysi</em>
+            </p>
+          </div>
+          <div className={styles.feedColumn}>
+            <FeedItems
+              feedId="bluefinLtsReleases"
+              title="Bluefin LTS"
+              maxItems={10}
+              showDescription={false}
+            />
+            <p className={styles.sectionByline}>
+              <em>Achillobator giganticus</em>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

GTS has been retired and merged into `bluefin:stable`. This PR removes all active references to GTS from documentation pages and the changelogs feed component.

## Changes

- **`docs/lts.mdx`**: Remove GTS from the secureboot recommendation — users needing secureboot are now directed to normal Bluefin images
- **`docs/local.md`**: Remove `gts` tag example from the `validate` task description
- **`docs/contributing.md`**: Remove GTS from the Images list and drop the `gts` row from the Release Channels table
- **`src/components/CommunityFeeds.tsx`**: Replace 3-column layout (LTS / GTS / Stable) with 2-column layout (Bluefin stable first, Bluefin LTS second)

## Notes

- Blog posts are not modified — they are historical record
- TypeScript and production build both pass cleanly