### PR TITLE
feat(changelogs): redesign changelog page with combined feed and commit view

### DIFF
--- a/scripts/lib/build-metrics.mjs
+++ b/scripts/lib/build-metrics.mjs
@@ -21,7 +21,6 @@ const TRACKED_WORKFLOWS = [
     repo: "ublue-os/bluefin",
     workflowId: 125772764,
   },
-  { name: "bluefin:gts", repo: "ublue-os/bluefin", workflowId: 125772761 },
   { name: "bluefin:latest", repo: "ublue-os/bluefin", workflowId: 146755607 },
 
   // ublue-os/bluefin-lts workflows

--- a/scripts/update-driver-versions.js
+++ b/scripts/update-driver-versions.js
@@ -271,7 +271,7 @@ function fetchGitHub(url) {
 }
 
 /**
- * Get latest release for each stream (stable, gts, lts)
+ * Get latest release for each stream (stable, lts)
  */
 async function getLatestReleases() {
   console.log("Fetching latest releases from GitHub...");
@@ -297,15 +297,11 @@ async function getLatestReleases() {
     r.tag_name.startsWith("stable-"),
   );
 
-  // Find latest GTS release
-  const latestGts = bluefinReleases.find((r) => r.tag_name.startsWith("gts-"));
-
   // Find latest LTS release
   const latestLts = bluefinLtsReleases[0]; // LTS releases all start with "lts."
 
   return {
     stable: latestStable,
-    gts: latestGts,
     lts: latestLts,
   };
 }
@@ -434,17 +430,15 @@ async function updateDocument() {
     const releases = await getLatestReleases();
 
     // Validate releases were found
-    if (!releases.stable || !releases.gts || !releases.lts) {
+    if (!releases.stable || !releases.lts) {
       console.error("❌ Failed to fetch all required releases");
       console.error("  Stable:", releases.stable?.tag_name || "NOT FOUND");
-      console.error("  GTS:", releases.gts?.tag_name || "NOT FOUND");
       console.error("  LTS:", releases.lts?.tag_name || "NOT FOUND");
       process.exit(1);
     }
 
     console.log("Latest releases:");
     console.log("- Stable:", releases.stable.tag_name);
-    console.log("- GTS:", releases.gts.tag_name);
     console.log("- LTS:", releases.lts.tag_name);
 
     // Find the table sections and insert new rows
@@ -493,49 +487,6 @@ async function updateDocument() {
           const rowTag = lines[i].match(/\|\s*\*\*([^*]+)\*\*/)?.[1];
           if (!rowTag || !seenTags.has(rowTag)) {
             if (rowTag) seenTags.add(rowTag);
-            newContent += lines[i] + "\n";
-          } else {
-            console.log(`ℹ️  Skipping duplicate row: ${rowTag}`);
-          }
-          i++;
-        }
-        continue;
-      } else if (line === "## Bluefin GTS") {
-        // Copy section header
-        newContent += line + "\n";
-        i++;
-        // Skip any blank lines after the section header
-        while (i < lines.length && lines[i].trim() === "") {
-          newContent += lines[i] + "\n";
-          i++;
-        }
-        // Copy table header rows
-        newContent += lines[i] + "\n"; // Table header row 1
-        i++;
-        newContent += lines[i] + "\n"; // Table header row 2
-        i++;
-        // Check if the first row is already the latest GTS
-        let firstRowTag = null;
-        if (i < lines.length && lines[i].startsWith("|")) {
-          firstRowTag = lines[i].match(/\|\s*\*\*([^*]+)\*\*/)?.[1];
-        }
-        if (firstRowTag !== releases.gts.tag_name) {
-          // Insert new row at the top
-          const newRow = await formatTableRow(releases.gts, "gts");
-          newContent += newRow + "\n";
-          console.log(`✅ Added new GTS release: ${releases.gts.tag_name}`);
-        } else {
-          console.log(
-            `ℹ️  GTS release ${releases.gts.tag_name} already exists at top`,
-          );
-        }
-
-        // Continue with existing rows, deduplicating by tag name
-        const seenGtsTags = new Set([releases.gts.tag_name]);
-        while (i < lines.length && lines[i].startsWith("|")) {
-          const rowTag = lines[i].match(/\|\s*\*\*([^*]+)\*\*/)?.[1];
-          if (!rowTag || !seenGtsTags.has(rowTag)) {
-            if (rowTag) seenGtsTags.add(rowTag);
             newContent += lines[i] + "\n";
           } else {
             console.log(`ℹ️  Skipping duplicate row: ${rowTag}`);

--- a/src/components/CommunityFeeds.module.css
+++ b/src/components/CommunityFeeds.module.css
@@ -19,15 +19,13 @@
 
 .packageSummaryGrid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 420px));
   gap: 2rem;
   margin-bottom: 3rem;
+  justify-content: center;
 }
 
 .feedGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 2rem;
   margin-bottom: 3rem;
 }
 
@@ -114,18 +112,13 @@
 
 /* Responsive design */
 @media (max-width: 996px) {
-  .feedGrid {
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-  }
-
   .additionalFeedsGrid {
     grid-template-columns: 1fr 1fr;
     gap: 1.5rem;
   }
 
   .packageSummaryGrid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 420px));
     gap: 1.5rem;
   }
 
@@ -145,11 +138,6 @@
 
   .header h1 {
     font-size: 1.75rem;
-  }
-
-  .feedGrid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
   }
 
   .additionalFeedsGrid {

--- a/src/components/CommunityFeeds.tsx
+++ b/src/components/CommunityFeeds.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import FeedItems from "../components/FeedItems";
+import { CombinedFeedItems } from "../components/FeedItems";
 import PackageSummary from "../components/PackageSummary";
 import styles from "./CommunityFeeds.module.css";
 
@@ -25,38 +26,27 @@ const CommunityFeeds: React.FC = () => {
 
         {/* Package Summary Boxes */}
         <div className={styles.packageSummaryGrid}>
+          <PackageSummary feedKey="bluefinLtsReleases" title="Bluefin LTS" />
           <PackageSummary
             feedKey="bluefinReleases"
             title="Bluefin"
             filter={(item) => item.title.startsWith("stable-")}
           />
-          <PackageSummary feedKey="bluefinLtsReleases" title="Bluefin LTS" />
         </div>
 
         <div className={styles.feedGrid}>
-          <div className={styles.feedColumn}>
-            <FeedItems
-              feedId="bluefinReleases"
-              title="Bluefin"
-              maxItems={10}
-              showDescription={false}
-              filter={(item) => item.title.startsWith("stable-")}
-            />
-            <p className={styles.sectionByline}>
-              <em>Utahraptor ostrommaysi</em>
-            </p>
-          </div>
-          <div className={styles.feedColumn}>
-            <FeedItems
-              feedId="bluefinLtsReleases"
-              title="Bluefin LTS"
-              maxItems={10}
-              showDescription={false}
-            />
-            <p className={styles.sectionByline}>
-              <em>Achillobator giganticus</em>
-            </p>
-          </div>
+          <CombinedFeedItems
+            title="Release Changelogs"
+            feeds={[
+              { feedId: "bluefinLtsReleases", label: "Bluefin LTS" },
+              {
+                feedId: "bluefinReleases",
+                label: "Bluefin",
+                filter: (item) => item.title.startsWith("stable-"),
+              },
+            ]}
+            maxItems={20}
+          />
         </div>
 
         <div className={styles.additionalFeedsGrid}>

--- a/src/components/FeedItems.module.css
+++ b/src/components/FeedItems.module.css
@@ -64,6 +64,66 @@
   gap: 0.5rem;
 }
 
+.feedItemHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.feedLabel {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2em 0.55em;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.feedLabelBluefin {
+  background: #0057b8;
+  color: #ffffff;
+}
+
+.feedLabelLts {
+  background: #5c3d1e;
+  color: #ffffff;
+}
+
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+  flex-shrink: 0;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.feedItem:hover .copyButton {
+  opacity: 1;
+}
+
+.copyButton:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  background: none;
+}
+
 .feedItemTitle {
   margin: 0;
   font-size: 1.25rem;
@@ -139,6 +199,58 @@
 .versionChange strong {
   color: var(--ifm-color-emphasis-800);
   font-weight: 500;
+}
+
+.commitList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.82rem;
+  font-family: var(--ifm-font-family-monospace);
+  background: var(--ifm-color-emphasis-100);
+  border-left: 3px solid var(--ifm-color-emphasis-300);
+  border-radius: 0 4px 4px 0;
+  padding: 0.4rem 0.6rem;
+}
+
+.commitRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  line-height: 1.4;
+}
+
+.commitHash {
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  text-decoration: none;
+}
+
+.commitHash:hover {
+  text-decoration: underline;
+}
+
+.commitSubject {
+  color: var(--ifm-color-emphasis-800);
+  flex: 1;
+  min-width: 0;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.82rem;
+}
+
+.commitSubject a {
+  color: var(--ifm-color-primary);
+}
+
+.commitAuthor {
+  color: var(--ifm-color-emphasis-500);
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.78rem;
 }
 
 /* Responsive design */

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import useStoredFeed from "@theme/useStoredFeed";
 import styles from "./FeedItems.module.css";
 import {
@@ -6,12 +6,49 @@ import {
   extractVersionChange,
 } from "../config/packageConfig";
 
+// Small inline copy button — renders a clipboard icon, shows a tick for 1.5s after copy
+const CopyButton: React.FC<{ text: string }> = ({ text }) => {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      });
+    },
+    [text],
+  );
+  return (
+    <button
+      onClick={handleCopy}
+      className={styles.copyButton}
+      title={copied ? "Copied!" : "Copy version"}
+      aria-label={copied ? "Copied!" : `Copy ${text}`}
+    >
+      {copied ? "✓" : "⎘"}
+    </button>
+  );
+};
+
 interface FeedItemsProps {
   feedId: string;
   title: string;
   maxItems?: number;
   showDescription?: boolean;
   filter?: (item: FeedItem) => boolean;
+}
+
+interface CombinedFeedItemsProps {
+  feeds: Array<{
+    feedId: string;
+    label: string;
+    filter?: (item: FeedItem) => boolean;
+  }>;
+  title: string;
+  maxItems?: number;
+  showDescription?: boolean;
 }
 
 interface VersionChange {
@@ -67,6 +104,49 @@ const formatLongDate = (dateString: string): string => {
   });
 };
 
+interface CommitEntry {
+  hash: string;
+  hashUrl: string;
+  subject: string; // raw HTML — may contain <a> links to PRs/issues
+  author: string;
+}
+
+// Extract the Commits table from release HTML content
+const extractCommits = (content: string): CommitEntry[] => {
+  if (!content) return [];
+
+  // Find the <h3>Commits</h3> section (feed content is already HTML, not markdown)
+  const commitsMatch = content.match(
+    /<h3>Commits<\/h3>\s*<table[\s\S]*?<tbody>([\s\S]*?)<\/tbody>/,
+  );
+  if (!commitsMatch) return [];
+
+  const tbody = commitsMatch[1];
+  const rows = tbody.match(/<tr>([\s\S]*?)<\/tr>/g);
+  if (!rows) return [];
+
+  const commits: CommitEntry[] = [];
+  for (const row of rows) {
+    // Hash cell: <td><strong><a href="URL">HASH</a></strong></td>
+    const hashMatch = row.match(
+      /<td><strong><a href="([^"]+)">([^<]+)<\/a><\/strong><\/td>/,
+    );
+    // Subject cell: second <td> — may contain nested HTML
+    const cells = row.match(/<td>([\s\S]*?)<\/td>/g);
+    // Author cell: third <td>
+    if (!hashMatch || !cells || cells.length < 3) continue;
+
+    const hashUrl = hashMatch[1];
+    const hash = hashMatch[2];
+    // Strip outer <td>…</td> tags from subject cell
+    const subject = cells[1].replace(/^<td>|<\/td>$/g, "");
+    const author = cells[2].replace(/<[^>]+>/g, "").trim();
+
+    commits.push({ hash, hashUrl, subject, author });
+  }
+  return commits;
+};
+
 // Helper function to extract key version changes from changelog content
 const extractVersionSummary = (content: string): VersionChange[] => {
   const changes: VersionChange[] = [];
@@ -89,27 +169,79 @@ const isReleaseFeed = (feedId: string): boolean => {
   return feedId === "bluefinReleases" || feedId === "bluefinLtsReleases";
 };
 
+// Helper to extract item items from a raw parsed feed
+const extractItems = (feedData: ParsedFeed): FeedItem[] => {
+  if (feedData?.rss?.channel?.item) {
+    return Array.isArray(feedData.rss.channel.item)
+      ? feedData.rss.channel.item
+      : [feedData.rss.channel.item];
+  } else if (feedData?.channel?.item) {
+    return Array.isArray(feedData.channel.item)
+      ? feedData.channel.item
+      : [feedData.channel.item];
+  } else if (feedData?.feed?.entry) {
+    return Array.isArray(feedData.feed.entry)
+      ? feedData.feed.entry
+      : [feedData.feed.entry];
+  }
+  return [];
+};
+
+// Helper to resolve the URL for an item given its feedId
+const resolveItemLink = (item: FeedItem, feedId: string): string => {
+  let itemLink = "";
+  if (typeof item.link === "string" && item.link) {
+    itemLink = item.link;
+  } else if (item.link && typeof item.link === "object") {
+    if (Array.isArray(item.link)) {
+      const htmlLink =
+        item.link.find((l) => l.$ && l.$.type === "text/html") ||
+        item.link.find((l) => l.rel === "alternate") ||
+        item.link[0];
+      itemLink = htmlLink?.href || htmlLink?.$.href || "";
+    } else {
+      itemLink = (item.link as { href?: string }).href || "";
+    }
+  }
+  if (!itemLink && item.id && typeof item.id === "string") {
+    const idMatch = item.id.match(
+      /^tag:github\.com,\d+:Repository\/(\d+)\/(.+)$/,
+    );
+    if (idMatch) {
+      const [, , tag] = idMatch;
+      if (feedId === "bluefinReleases") {
+        itemLink = `https://github.com/ublue-os/bluefin/releases/tag/${tag}`;
+      } else if (feedId === "bluefinLtsReleases") {
+        itemLink = `https://github.com/ublue-os/bluefin-lts/releases/tag/${tag}`;
+      }
+    } else {
+      const discussionMatch = item.id.match(
+        /^tag:github\.com,\d+:Discussion\/(\d+)$/,
+      );
+      if (
+        discussionMatch &&
+        (feedId === "bluefinDiscussions" || feedId === "bluefinAnnouncements")
+      ) {
+        itemLink = `https://github.com/ublue-os/bluefin/discussions/${discussionMatch[1]}`;
+      }
+    }
+  }
+  return itemLink;
+};
+
 // Helper function to format release titles for better readability
 const formatReleaseTitle = (title: string, feedId: string): string => {
   if (feedId === "bluefinLtsReleases") {
-    // For LTS releases: Remove "bluefin-lts LTS: " or "Bluefin LTS: " prefix
-    // Example: "bluefin-lts LTS: 20250910 (c10s, #cfd65ad)" -> "20250910 (c10s, #cfd65ad)"
-    // Example: "Bluefin LTS: 20250808 (c10s)" -> "20250808 (c10s)"
-    return title.replace(/^(bluefin-lts|Bluefin) LTS: /, "");
+    // For LTS releases: Replace "bluefin-lts LTS: " or "Bluefin LTS: " prefix with "lts-"
+    // Example: "bluefin-lts LTS: 20250910 (c10s, #cfd65ad)" -> "lts-20250910 (c10s, #cfd65ad)"
+    // Example: "Bluefin LTS: 20250808 (c10s)" -> "lts-20250808 (c10s)"
+    return title.replace(/^(bluefin-lts|Bluefin) LTS: /, "lts-");
   } else if (feedId === "bluefinReleases") {
-    // For stable releases: Remove "stable-" prefix and ": Stable" text, simplify Fedora version
-    // Example: "stable-20250907: Stable (F42.20250907, #921e6ba)" -> "20250907 (F42 #921e6ba)"
+    // For stable releases: Keep "stable-" prefix, strip ": Stable" text, simplify Fedora version
+    // Example: "stable-20250907: Stable (F42.20250907, #921e6ba)" -> "stable-20250907 (F42 #921e6ba)"
     if (title.startsWith("stable-")) {
       return title.replace(
-        /^stable-([^:]+): Stable \(F(\d+)\.\d+, (#[^)]+)\)$/,
-        "$1 (F$2 $3)",
-      );
-    }
-    // For GTS releases: Remove "gts-" prefix and ": Gts" text, simplify Fedora version
-    // Example: "gts-20250907: Gts (F41.20250907, #921e6ba)" -> "20250907 (F41 #921e6ba)"
-    else if (title.startsWith("gts-")) {
-      return title.replace(
-        /^gts-([^:]+): Gts \(F(\d+)\.\d+, (#[^)]+)\)$/,
+        /^(stable-[^:]+): Stable \(F(\d+)\.\d+, (#[^)]+)\)$/,
         "$1 (F$2 $3)",
       );
     }
@@ -129,22 +261,7 @@ const FeedItems: React.FC<FeedItemsProps> = ({
   try {
     const feedData: ParsedFeed = useStoredFeed(feedId);
 
-    // Handle different RSS/Atom feed structures
-    let items: FeedItem[] = [];
-
-    if (feedData?.rss?.channel?.item) {
-      items = Array.isArray(feedData.rss.channel.item)
-        ? feedData.rss.channel.item
-        : [feedData.rss.channel.item];
-    } else if (feedData?.channel?.item) {
-      items = Array.isArray(feedData.channel.item)
-        ? feedData.channel.item
-        : [feedData.channel.item];
-    } else if (feedData?.feed?.entry) {
-      items = Array.isArray(feedData.feed.entry)
-        ? feedData.feed.entry
-        : [feedData.feed.entry];
-    }
+    let items: FeedItem[] = extractItems(feedData);
 
     // Apply filter if provided
     if (filter) {
@@ -168,78 +285,18 @@ const FeedItems: React.FC<FeedItemsProps> = ({
         <h3 className={styles.feedTitle}>{title}</h3>
         <ul className={styles.feedList}>
           {displayItems.map((item, index) => {
-            // Extract values handling both RSS and Atom formats
-            let itemLink = "";
-
-            // First try to get link from the link field
-            if (typeof item.link === "string" && item.link) {
-              itemLink = item.link;
-            } else if (item.link && typeof item.link === "object") {
-              // Handle Atom link structure - could be an array or object
-              if (Array.isArray(item.link)) {
-                // For GitHub Atom feeds, look for type="text/html" first, then fall back to rel="alternate"
-                const htmlLink =
-                  item.link.find((l) => l.$ && l.$.type === "text/html") ||
-                  item.link.find((l) => l.rel === "alternate") ||
-                  item.link[0];
-                itemLink = htmlLink?.href || htmlLink?.$.href || "";
-              } else {
-                itemLink = item.link.href || "";
-              }
-            }
-
-            // If no link found, try to construct it from GitHub Atom feed ID format
-            if (!itemLink && item.id && typeof item.id === "string") {
-              // GitHub Atom feed IDs look like: "tag:github.com,2008:Repository/611397346/stable-20250907"
-              const idMatch = item.id.match(
-                /^tag:github\.com,\d+:Repository\/(\d+)\/(.+)$/,
-              );
-                if (idMatch) {
-                const [, repoId, tag] = idMatch;
-                // For GitHub releases, we need to determine the repo name from the feedId
-                if (feedId === "bluefinReleases") {
-                  itemLink = `https://github.com/ublue-os/bluefin/releases/tag/${tag}`;
-                } else if (feedId === "bluefinLtsReleases") {
-                  itemLink = `https://github.com/ublue-os/bluefin-lts/releases/tag/${tag}`;
-                }
-              } else {
-                // Try to match GitHub Discussion IDs
-                // Format: "tag:github.com,2008:Discussion/12345"
-                const discussionMatch = item.id.match(
-                  /^tag:github\.com,\d+:Discussion\/(\d+)$/,
-                );
-
-                if (discussionMatch) {
-                  const [, discussionId] = discussionMatch;
-                  if (
-                    feedId === "bluefinDiscussions" ||
-                    feedId === "bluefinAnnouncements"
-                  ) {
-                    itemLink = `https://github.com/ublue-os/bluefin/discussions/${discussionId}`;
-                  }
-                }
-              }
-            }
-
+            const itemLink = resolveItemLink(item, feedId);
             const itemDate = item.pubDate || item.updated;
-            const itemAuthor =
-              typeof item.author === "string" ? item.author : item.author?.name;
-
-            // No individual authors displayed for release feeds - moved to section level
             const itemDescription =
               item.description ||
               (typeof item.content === "object"
                 ? item.content?.value
                 : item.content);
             const itemId = item.guid || item.id || itemLink || index;
-
-            // Extract executive summary for release feeds
             const versionSummary =
               isReleaseFeed(feedId) && itemDescription
                 ? extractVersionSummary(itemDescription)
                 : [];
-
-            // Format the title for better readability
             const displayTitle = formatReleaseTitle(item.title, feedId);
 
             return (
@@ -322,5 +379,168 @@ const FeedItems: React.FC<FeedItemsProps> = ({
     );
   }
 };
+
+// CombinedFeedItems — merges multiple feeds into one chronological list.
+// Each feed entry is tagged with a label badge so users can tell releases apart.
+const CombinedFeedItems: React.FC<CombinedFeedItemsProps> = ({
+  feeds,
+  title,
+  maxItems = 20,
+  showDescription = false,
+}) => {
+  try {
+    // Call useStoredFeed for each feed (hooks must be called unconditionally at top level)
+    const feedDataLts: ParsedFeed = useStoredFeed(
+      feeds[0]?.feedId ?? "bluefinLtsReleases",
+    );
+    const feedDataStable: ParsedFeed = useStoredFeed(
+      feeds[1]?.feedId ?? "bluefinReleases",
+    );
+    const rawFeeds = [feedDataLts, feedDataStable];
+
+    // Tag each item with its source feedId + label, then merge
+    type TaggedItem = FeedItem & { _feedId: string; _label: string };
+    const tagged: TaggedItem[] = feeds.flatMap((feedMeta, i) => {
+      let items = extractItems(rawFeeds[i]);
+      if (feedMeta.filter) items = items.filter(feedMeta.filter);
+      return items.map((item) => ({
+        ...item,
+        _feedId: feedMeta.feedId,
+        _label: feedMeta.label,
+      }));
+    });
+
+    // Sort newest-first by date
+    tagged.sort((a, b) => {
+      const da = new Date(a.pubDate || a.updated || 0).getTime();
+      const db = new Date(b.pubDate || b.updated || 0).getTime();
+      return db - da;
+    });
+
+    const displayItems = tagged.slice(0, maxItems);
+
+    if (displayItems.length === 0) {
+      return (
+        <div className={styles.feedContainer}>
+          <h3 className={styles.feedTitle}>{title}</h3>
+          <p className={styles.noItems}>No items available</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.feedContainer}>
+        <h3 className={styles.feedTitle}>{title}</h3>
+        <ul className={styles.feedList}>
+          {displayItems.map((item, index) => {
+            const itemLink = resolveItemLink(item, item._feedId);
+            const itemDate = item.pubDate || item.updated;
+            const itemDescription =
+              item.description ||
+              (typeof item.content === "object"
+                ? item.content?.value
+                : item.content);
+            const itemId = item.guid || item.id || itemLink || index;
+            const versionSummary =
+              isReleaseFeed(item._feedId) && itemDescription
+                ? extractVersionSummary(itemDescription)
+                : [];
+            const commits =
+              isReleaseFeed(item._feedId) && itemDescription
+                ? extractCommits(itemDescription)
+                : [];
+            const displayTitle = formatReleaseTitle(item.title, item._feedId);
+
+            const inner = (
+              <div className={styles.feedItemContent}>
+                <div className={styles.feedItemHeader}>
+                  <span
+                    className={`${styles.feedLabel} ${item._feedId === "bluefinLtsReleases" ? styles.feedLabelLts : styles.feedLabelBluefin}`}
+                  >
+                    {item._label}
+                  </span>
+                  <h4 className={styles.feedItemTitle}>{displayTitle}</h4>
+                  <CopyButton text={displayTitle} />
+                </div>
+                {itemDate && (
+                  <time className={styles.feedItemDate}>
+                    {formatLongDate(itemDate)}
+                  </time>
+                )}
+                {versionSummary.length > 0 && (
+                  <ul className={styles.executiveSummary}>
+                    {versionSummary.map((change) => (
+                      <li key={change.name} className={styles.versionChange}>
+                        <strong>{change.name}:</strong> {change.change}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {commits.length > 0 && (
+                  <div
+                    className={styles.commitList}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {commits.map((c) => (
+                      <div key={c.hash} className={styles.commitRow}>
+                        <a
+                          href={c.hashUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.commitHash}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {c.hash}
+                        </a>
+                        <span
+                          className={styles.commitSubject}
+                          dangerouslySetInnerHTML={{ __html: c.subject }}
+                        />
+                        <span className={styles.commitAuthor}>{c.author}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {showDescription && itemDescription && (
+                  <div
+                    className={styles.feedItemDescription}
+                    dangerouslySetInnerHTML={{ __html: itemDescription }}
+                  />
+                )}
+              </div>
+            );
+
+            return (
+              <li key={itemId} className={styles.feedItem}>
+                {itemLink ? (
+                  <a
+                    href={itemLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.feedItemLink}
+                  >
+                    {inner}
+                  </a>
+                ) : (
+                  inner
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  } catch (error) {
+    console.error("Error loading combined feeds:", error);
+    return (
+      <div className={styles.feedContainer}>
+        <h3 className={styles.feedTitle}>{title}</h3>
+        <p className={styles.error}>Error loading feed data</p>
+      </div>
+    );
+  }
+};
+
+export { CombinedFeedItems };
 
 export default FeedItems;


### PR DESCRIPTION
## Summary

- Replaces the two-column feed grid with a single full-width combined feed that merges Bluefin and Bluefin LTS releases sorted newest-first, with per-entry stream badges
- Adds a commits table to each release card, parsed from the Commits section already present in the release feed — hash links, PR-linked subjects, and author per row
- Adds a CopyButton (clipboard icon, fades in on hover, 1.5s confirmation) to each card title
- Centers the PackageSummary boxes (max 420px, LTS left / Bluefin right)
- Removes GTS from update-driver-versions.js and build-metrics.mjs (already removed from the image)

## Test Plan

- [x] npm run typecheck passes
- [x] npm run build passes
- [x] Commits table visible on each release card at /changelogs
- [x] Stream badges (brown = LTS, blue = Bluefin) render correctly
- [x] CopyButton copies card title to clipboard