### PR TITLE
feat(driver-versions): rebuild page as timeline with per-release reba…

### DIFF
--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -3,7 +3,7 @@ tags:
   - drivers
 ---
 
-import DriverVersionsTable from "@site/src/components/DriverVersionsTable";
+import DriverVersionsCatalog from "@site/src/components/DriverVersionsCatalog";
 
 # Driver Versions
 
@@ -13,79 +13,10 @@ This page tracks major driver versions across Bluefin releases to help users ide
 
 [@ublue-os/bluefin](https://github.com/ublue-os/bluefin) and [@ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts) publish detailed changelogs with every release that include kernel versions, Mesa driver versions, and NVIDIA driver versions. This report consolidates that information for the most recent Stable and LTS releases to help users troubleshoot driver-specific issues or test specific configurations.
 
-<DriverVersionsTable />
+## Stable
 
-:::info NVIDIA Availability
-NVIDIA driver versions are only listed in NVIDIA-specific image variants. Non-NVIDIA images do not include kmod-nvidia packages.
-:::
+<DriverVersionsCatalog streamId="bluefin-stable" />
 
-## How to Switch to a Specific Version
+## LTS
 
-To switch to any of these versions, use the `bootc switch` command with signature enforcement based on [@bootc-dev/bootc](https://github.com/containers/bootc):
-
-### Bluefin Stream
-
-```bash
-# Get your current image name
-IMAGE_NAME=$(jq -r '."image-name"' < /usr/share/ublue-os/image-info.json)
-
-# Switch to latest stable
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable
-
-# Switch to a specific stable version
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable-20251012
-
-# Switch to an older stable version (e.g., stable-20250928)
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable-20250928
-
-# Reboot to apply changes
-sudo systemctl reboot
-```
-
-### Bluefin LTS Stream
-
-```bash
-# Get your current image name
-IMAGE_NAME=$(jq -r '."image-name"' < /usr/share/ublue-os/image-info.json)
-
-# Switch to latest LTS
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:lts
-
-# Switch to a specific LTS version
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:lts.20251006
-
-# Reboot to apply changes
-sudo systemctl reboot
-```
-
-:::tip Finding Your Current Version
-Check your current Bluefin version with:
-
-```bash
-bootc status
-```
-
-:::
-
-:::info Signature Enforcement
-The `--enforce-container-sigpolicy` flag ensures you're always running a signed image, maintaining security and integrity of your system.
-:::
-
-## Testing & Rollback Strategy
-
-### For Users Testing Driver Issues
-
-1. **Identify the suspected problematic version** from the table above
-2. **Switch to the previous stable version** using `bootc switch`
-3. **Test your specific use case** (desktop performance, hardware compatibility, etc.)
-4. **Report findings** in the [@ublue-os/bluefin](https://github.com/ublue-os/bluefin) issue tracker with specific version numbers
-
-## References
-
-- [@ublue-os/bluefin](https://github.com/ublue-os/bluefin) - Stable releases
-- [@ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts) - LTS releases
-- [Bluefin Releases](https://github.com/ublue-os/bluefin/releases) - Stable releases
-- [Bluefin LTS Releases](https://github.com/ublue-os/bluefin-lts/releases) - LTS releases
-- [Bluefin Documentation](https://docs.projectbluefin.io/) - Official docs
-- [Bluefin LTS Documentation](https://docs.projectbluefin.io/lts) - LTS-specific docs
-- [@bootc-dev/bootc](https://github.com/containers/bootc) - Bootc reference
+<DriverVersionsCatalog streamId="bluefin-lts" />

--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -7,11 +7,7 @@ import DriverVersionsCatalog from "@site/src/components/DriverVersionsCatalog";
 
 # Driver Versions
 
-This page tracks major driver versions across Bluefin releases to help users identify and switch to specific driver versions.
-
-## Overview
-
-[@ublue-os/bluefin](https://github.com/ublue-os/bluefin) and [@ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts) publish detailed changelogs with every release that include kernel versions, Mesa driver versions, and NVIDIA driver versions. This report consolidates that information for the most recent Stable and LTS releases to help users troubleshoot driver-specific issues or test specific configurations.
+Sometimes the raptor just gets you. This page tracks major driver versions across Bluefin releases to help users identify and switch to specific driver versions. Good for ruling out major components. Remember to rebase back to the release stream later if you want to see if your issue gets fixed, use `ujust rebase-helper` for that. Good luck, you got this.
 
 ## Stable
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,11 @@
     "fetch-playlists": "node scripts/fetch-playlist-metadata.js",
     "fetch-github-profiles": "node scripts/fetch-github-profiles.js",
     "fetch-github-repos": "node scripts/fetch-github-repos.js",
-    "fetch-github-images": "node scripts/fetch-github-images.js",
     "fetch-github-driver-versions": "node scripts/fetch-github-driver-versions.js",
     "fetch-contributors": "node scripts/fetch-contributors.js",
     "fetch-board-data": "node scripts/fetch-board-data.js",
     "generate-report": "node scripts/generate-report.mjs",
-    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-images && npm run fetch-github-driver-versions && npm run fetch-contributors && npm run fetch-board-data"
+    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-contributors && npm run fetch-board-data"
   },
   "dependencies": {
     "@1password/docusaurus-plugin-stored-data": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "fetch-github-profiles": "node scripts/fetch-github-profiles.js",
     "fetch-github-repos": "node scripts/fetch-github-repos.js",
     "fetch-github-images": "node scripts/fetch-github-images.js",
+    "fetch-github-driver-versions": "node scripts/fetch-github-driver-versions.js",
     "fetch-contributors": "node scripts/fetch-contributors.js",
     "fetch-board-data": "node scripts/fetch-board-data.js",
     "generate-report": "node scripts/generate-report.mjs",
-    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-board-data"
+    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-images && npm run fetch-github-driver-versions && npm run fetch-contributors && npm run fetch-board-data"
   },
   "dependencies": {
     "@1password/docusaurus-plugin-stored-data": "^1.0.0",

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -253,7 +253,10 @@ function main() {
       fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
       console.log(`Driver versions data saved to ${OUTPUT_FILE}`);
     })
-    .catch(() => {
+    .catch((error) => {
+      console.warn(
+        `GitHub releases API failed, falling back to feeds: ${error?.message || "unknown error"}`,
+      );
       const bluefinFeed = readJsonIfExists(FEED_BLUEFIN, { items: [] });
       const ltsFeed = readJsonIfExists(FEED_LTS, { items: [] });
 

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -1,0 +1,301 @@
+const fs = require("fs");
+const path = require("path");
+
+const fetch = (...args) => import("node-fetch").then(({ default: fn }) => fn(...args));
+
+const OUTPUT_DIR = path.join(__dirname, "..", "static", "data");
+const OUTPUT_FILE = path.join(OUTPUT_DIR, "driver-versions.json");
+const FEED_BLUEFIN = path.join(__dirname, "..", "static", "feeds", "bluefin-releases.json");
+const FEED_LTS = path.join(__dirname, "..", "static", "feeds", "bluefin-lts-releases.json");
+
+const CACHE_MAX_AGE_HOURS = Number(process.env.DRIVER_VERSIONS_CACHE_HOURS || 168);
+const HISTORY_DAYS = Number(process.env.DRIVER_VERSIONS_HISTORY_DAYS || 90);
+const FORCE_REFRESH = process.argv.includes("--force");
+
+function readJsonIfExists(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function cacheAgeHours() {
+  if (!fs.existsSync(OUTPUT_FILE)) return Number.POSITIVE_INFINITY;
+  const stats = fs.statSync(OUTPUT_FILE);
+  return (Date.now() - stats.mtimeMs) / (1000 * 60 * 60);
+}
+
+function splitVersion(raw) {
+  if (!raw) return null;
+  const parts = String(raw)
+    .split("➡️")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : String(raw).trim();
+}
+
+function extractVersion(content, labels) {
+  if (!content) return null;
+
+  for (const label of labels) {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(
+      `<td><strong>${escaped}<\\/strong><\\/td>\\s*<td>([^<]+)<\\/td>`,
+      "i",
+    );
+    const match = content.match(regex);
+    if (!match || !match[1]) continue;
+    return splitVersion(match[1]);
+  }
+
+  return null;
+}
+
+function extractVersionFromMarkdown(content, labels) {
+  if (!content) return null;
+
+  for (const label of labels) {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`\\|\\s*\\*\\*${escaped}\\*\\*\\s*\\|\\s*([^|]+)\\|`, "i");
+    const match = content.match(regex);
+    if (!match || !match[1]) continue;
+    return splitVersion(match[1]);
+  }
+
+  return null;
+}
+
+function parseDate(value) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return null;
+  return new Date(timestamp).toISOString();
+}
+
+function tagFromItem(item, fallbackPrefix) {
+  const link = item?.link || "";
+  const parts = link.split("/");
+  const maybeTag = parts[parts.length - 1] || "";
+  if (maybeTag) return maybeTag;
+
+  const title = item?.title || "";
+  if (title.includes(":")) {
+    return title.split(":")[0].trim();
+  }
+
+  return `${fallbackPrefix}-unknown`;
+}
+
+function buildRow(item, streamId) {
+  const content = item?.content || "";
+  return {
+    stream: streamId,
+    tag: tagFromItem(item, streamId),
+    title: item?.title || null,
+    releaseUrl: item?.link || null,
+    publishedAt: parseDate(item?.pubDate || item?.updated || null),
+    versions: {
+      kernel: extractVersion(content, ["Kernel"]),
+      hweKernel: extractVersion(content, ["HWE Kernel"]),
+      mesa: extractVersion(content, ["Mesa"]),
+      nvidia: extractVersion(content, ["Nvidia", "NVIDIA"]),
+    },
+  };
+}
+
+function buildRowFromApiRelease(release, streamId) {
+  const body = release?.body || "";
+  return {
+    stream: streamId,
+    tag: release?.tag_name || `${streamId}-unknown`,
+    title: release?.name || null,
+    releaseUrl: release?.html_url || null,
+    publishedAt: parseDate(release?.published_at || release?.created_at || null),
+    versions: {
+      kernel: extractVersionFromMarkdown(body, ["Kernel"]),
+      hweKernel: extractVersionFromMarkdown(body, ["HWE Kernel"]),
+      mesa: extractVersionFromMarkdown(body, ["Mesa"]),
+      nvidia: extractVersionFromMarkdown(body, ["Nvidia", "NVIDIA"]),
+    },
+  };
+}
+
+function pickBluefinStableItems(feed) {
+  const items = Array.isArray(feed?.items) ? feed.items : [];
+  return items.filter((item) => String(item?.title || "").toLowerCase().startsWith("stable-"));
+}
+
+function pickLtsItems(feed) {
+  const items = Array.isArray(feed?.items) ? feed.items : [];
+  return items.filter((item) => {
+    const link = String(item?.link || "").toLowerCase();
+    if (link.includes("/releases/tag/lts.")) return true;
+    return String(item?.title || "").toLowerCase().includes(" lts:");
+  });
+}
+
+function buildStream(streamId, name, subtitle, command, feedItems) {
+  const cutoff = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+  const recentItems = feedItems.filter((item) => {
+    const parsed = Date.parse(item?.pubDate || item?.updated || "");
+    if (Number.isNaN(parsed)) return false;
+    return parsed >= cutoff;
+  });
+
+  const history = recentItems.map((item) => buildRow(item, streamId));
+  return {
+    id: streamId,
+    name,
+    subtitle,
+    command,
+    source: "cache",
+    rowCount: history.length,
+    latest: history[0] || null,
+    history,
+  };
+}
+
+async function fetchReleases(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "bluefin-docs-driver-versions",
+      ...(process.env.GITHUB_TOKEN
+        ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+        : {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub releases API failed for ${owner}/${repo}: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function buildStreamFromApi(streamId, name, subtitle, command, releases, tagPrefix) {
+  const cutoff = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+
+  const filtered = releases
+    .filter((release) => String(release?.tag_name || "").startsWith(tagPrefix))
+    .filter((release) => {
+      const parsed = Date.parse(release?.published_at || release?.created_at || "");
+      if (Number.isNaN(parsed)) return false;
+      return parsed >= cutoff;
+    })
+    .sort(
+      (a, b) =>
+        Date.parse(b?.published_at || b?.created_at || 0) -
+        Date.parse(a?.published_at || a?.created_at || 0),
+    );
+
+  const history = filtered.map((release) => buildRowFromApiRelease(release, streamId));
+
+  return {
+    id: streamId,
+    name,
+    subtitle,
+    command,
+    source: "github-api",
+    rowCount: history.length,
+    latest: history[0] || null,
+    history,
+  };
+}
+
+function main() {
+  const ageHours = cacheAgeHours();
+  if (ageHours < CACHE_MAX_AGE_HOURS && !FORCE_REFRESH) {
+    console.log(
+      `Driver versions cache is ${ageHours.toFixed(1)}h old (max ${CACHE_MAX_AGE_HOURS}h). Skipping fetch.`,
+    );
+    return;
+  }
+
+  return Promise.all([
+    fetchReleases("ublue-os", "bluefin"),
+    fetchReleases("ublue-os", "bluefin-lts"),
+  ])
+    .then(([bluefinReleases, ltsReleases]) => {
+      const streams = [
+        buildStreamFromApi(
+          "bluefin-stable",
+          "Bluefin",
+          "Current stable stream from ublue-os/bluefin.",
+          "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+          bluefinReleases,
+          "stable-",
+        ),
+        buildStreamFromApi(
+          "bluefin-lts",
+          "Bluefin LTS",
+          "Long-term support stream from ublue-os/bluefin-lts.",
+          "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
+          ltsReleases,
+          "lts.",
+        ),
+      ];
+
+      const output = {
+        generatedAt: new Date().toISOString(),
+        cacheHours: CACHE_MAX_AGE_HOURS,
+        historyDays: HISTORY_DAYS,
+        streams,
+      };
+
+      if (!fs.existsSync(OUTPUT_DIR)) {
+        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+      }
+
+      fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
+      console.log(`Driver versions data saved to ${OUTPUT_FILE}`);
+    })
+    .catch(() => {
+      const bluefinFeed = readJsonIfExists(FEED_BLUEFIN, { items: [] });
+      const ltsFeed = readJsonIfExists(FEED_LTS, { items: [] });
+
+      const streams = [
+        buildStream(
+          "bluefin-stable",
+          "Bluefin",
+          "Current stable stream from ublue-os/bluefin.",
+          "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+          pickBluefinStableItems(bluefinFeed),
+        ),
+        buildStream(
+          "bluefin-lts",
+          "Bluefin LTS",
+          "Long-term support stream from ublue-os/bluefin-lts.",
+          "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
+          pickLtsItems(ltsFeed),
+        ),
+      ];
+
+      const output = {
+        generatedAt: new Date().toISOString(),
+        cacheHours: CACHE_MAX_AGE_HOURS,
+        historyDays: HISTORY_DAYS,
+        streams,
+      };
+
+      if (!fs.existsSync(OUTPUT_DIR)) {
+        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+      }
+
+      fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
+      console.log(`Driver versions data saved to ${OUTPUT_FILE} (feed fallback)`);
+    });
+}
+
+try {
+  Promise.resolve(main()).catch((error) => {
+    console.error(error?.message || "Failed to generate driver versions data");
+    process.exit(1);
+  });
+} catch (error) {
+  console.error(error?.message || "Failed to generate driver versions data");
+  process.exit(1);
+}

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -1,0 +1,312 @@
+.timelinePage {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(2, minmax(0, auto));
+  gap: 1rem;
+  padding-left: 2.35rem;
+}
+
+.archiveRail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1.9rem;
+  pointer-events: none;
+}
+
+.archiveRail::before {
+  content: "";
+  position: absolute;
+  left: 0.8rem;
+  top: 1.05rem;
+  bottom: 1.05rem;
+  width: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--ifm-color-primary) 85%, #ffffff) 0%,
+    color-mix(in srgb, var(--ifm-color-primary) 55%, var(--ifm-color-emphasis-300)) 45%,
+    color-mix(in srgb, var(--ifm-color-emphasis-500) 72%, #6f7c8d) 100%
+  );
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ifm-color-primary) 16%, transparent);
+  transition: width 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+}
+
+.timelinePage:has(.archiveDetails[open]) .archiveRail::before {
+  width: 5px;
+  filter: saturate(1.12);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ifm-color-primary) 26%, transparent);
+}
+
+.archiveNow,
+.archivePast {
+  position: absolute;
+  left: 0;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.archiveNow {
+  top: 0;
+}
+
+.archivePast {
+  bottom: 0;
+}
+
+.streamSection {
+  position: relative;
+  padding: 0.25rem 0 0.5rem;
+  height: fit-content;
+}
+
+.streamHeader {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  align-items: flex-start;
+  margin-top: -0.45rem;
+  margin-bottom: 0.2rem;
+}
+
+.streamMeta {
+  font-size: 0.78rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  background: var(--ifm-color-emphasis-100);
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.timeline {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.timelineNode {
+  position: relative;
+}
+
+.nodeBody {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 0.65rem;
+  background: color-mix(in srgb, var(--ifm-background-color) 94%, var(--ifm-color-emphasis-100));
+}
+
+.nodeBodyLatest {
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 48%, var(--ifm-color-emphasis-300));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
+}
+
+.nodeHeader {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: baseline;
+}
+
+.releaseTagLink {
+  text-decoration: none;
+}
+
+.releaseTag {
+  font-size: 1rem;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.releaseDate {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.84rem;
+}
+
+.majorVersions {
+  margin-top: 0.55rem;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.majorVersionCard {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  background: color-mix(in srgb, #2f74b5 10%, var(--ifm-background-color));
+  padding: 0.5rem 0.6rem;
+}
+
+.majorBump {
+  border-color: color-mix(in srgb, #d97b00 70%, var(--ifm-color-emphasis-300));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #d97b00 28%, transparent);
+  background: color-mix(in srgb, #d97b00 14%, var(--ifm-background-color));
+}
+
+.nvidiaCard {
+  border-color: color-mix(in srgb, #76b900 55%, var(--ifm-color-emphasis-300));
+  background: color-mix(in srgb, #76b900 13%, var(--ifm-background-color));
+}
+
+.nvidiaMajorBump {
+  border-color: color-mix(in srgb, #76b900 82%, var(--ifm-color-emphasis-300));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #76b900 35%, transparent);
+  background: color-mix(in srgb, #76b900 22%, var(--ifm-background-color));
+}
+
+.nvidiaMinorBump {
+  border-color: color-mix(in srgb, #76b900 68%, var(--ifm-color-emphasis-300));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #76b900 24%, transparent);
+  background: color-mix(in srgb, #76b900 16%, var(--ifm-background-color));
+}
+
+.minorBump {
+  border-color: color-mix(in srgb, #9aa4b0 78%, var(--ifm-color-emphasis-300));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #9aa4b0 26%, transparent);
+  background: color-mix(in srgb, #c7ccd3 24%, var(--ifm-background-color));
+}
+
+.majorVersionLabel {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-700);
+  font-weight: 700;
+}
+
+.majorVersionValue {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 1.15rem;
+  line-height: 1.2;
+  font-weight: 800;
+  color: var(--ifm-color-emphasis-900);
+  word-break: break-word;
+}
+
+.versionMissing {
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+}
+
+.bumpTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid color-mix(in srgb, #d97b00 70%, var(--ifm-color-emphasis-300));
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.minorTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid color-mix(in srgb, #8f99a5 78%, var(--ifm-color-emphasis-300));
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-800);
+  background: color-mix(in srgb, #d2d7de 38%, var(--ifm-background-color));
+}
+
+.rebaseInline {
+  margin-top: 0.6rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  background: var(--ifm-background-color);
+}
+
+.rebaseInlineLabel {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 0.25rem;
+}
+
+.rebaseInline code {
+  display: block;
+  word-break: break-word;
+}
+
+.commandBlock :global(.theme-code-block) {
+  display: inline-block;
+  width: auto;
+  max-width: 100%;
+  margin-top: 0.15rem;
+  margin-bottom: 0;
+}
+
+.commandBlock :global(button[class*="copyButton"]) {
+  opacity: 1;
+}
+
+.commandBlock :global([class*="buttonGroup"] button) {
+  opacity: 1 !important;
+}
+
+.commandBlock :global(pre) {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.archiveTimeline {
+  margin-top: 0.7rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.emptyText {
+  margin: 0.65rem 0 0;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.rebaseSection {
+  margin-top: 0.9rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 0.65rem;
+  background: color-mix(in srgb, #2f9e7f 10%, var(--ifm-background-color));
+}
+
+.rebaseTitle {
+  margin: 0;
+  font-size: 0.98rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.rebaseList {
+  margin: 0.5rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.rebaseList li {
+  margin-bottom: 0.45rem;
+}
+
+.rebaseList li:last-child {
+  margin-bottom: 0;
+}
+
+.rebaseList code {
+  display: inline-block;
+  margin-top: 0.3rem;
+  word-break: break-word;
+}

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -1,0 +1,269 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import Heading from "@theme/Heading";
+import CodeBlock from "@theme/CodeBlock";
+import driverVersionsData from "@site/static/data/driver-versions.json";
+import styles from "./DriverVersionsCatalog.module.css";
+
+interface VersionSet {
+  kernel: string | null;
+  hweKernel: string | null;
+  mesa: string | null;
+  nvidia: string | null;
+}
+
+interface DriverRow {
+  stream: string;
+  tag: string;
+  title: string | null;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+  versions: VersionSet;
+}
+
+interface DriverStream {
+  id: string;
+  name: string;
+  subtitle: string;
+  command: string;
+  source: "cache" | "live" | "unavailable";
+  rowCount: number;
+  latest: DriverRow | null;
+  history: DriverRow[];
+}
+
+interface DriverCatalog {
+  generatedAt?: string;
+  streams?: DriverStream[];
+}
+
+const catalog = driverVersionsData as DriverCatalog;
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "Unknown";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Unknown";
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function valueOrFallback(value: string | null | undefined, fallback = "N/A") {
+  return value || fallback;
+}
+
+function VersionValue({ value }: { value: string | null | undefined }) {
+  if (!value) {
+    return <span className={`${styles.majorVersionValue} ${styles.versionMissing}`}>N/A</span>;
+  }
+  return <span className={styles.majorVersionValue}>{value}</span>;
+}
+
+function majorNumber(value: string | null | undefined) {
+  if (!value) return null;
+  const match = value.match(/(\d+)/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function majorMinor(value: string | null | undefined) {
+  if (!value) return { major: null as number | null, minor: null as number | null };
+  const match = value.match(/(\d+)\.(\d+)/);
+  if (!match) return { major: null, minor: null };
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+  };
+}
+
+function rebaseCommandForTag(tag: string) {
+  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.\"image-name\"' /usr/share/ublue-os/image-info.json):${tag}"`;
+}
+
+function ReleaseNode({
+  row,
+  previousRow,
+  emphasize,
+}: {
+  row: DriverRow;
+  previousRow?: DriverRow;
+  emphasize: boolean;
+}) {
+  const kernel = valueOrFallback(row.versions.kernel);
+  const nvidia = valueOrFallback(row.versions.nvidia);
+  const mesa = valueOrFallback(row.versions.mesa);
+  const hwe = row.versions.hweKernel;
+
+  const kernelMajor = majorNumber(row.versions.kernel);
+  const previousKernelMajor = majorNumber(previousRow?.versions.kernel);
+  const kernelMajorBump =
+    kernelMajor !== null &&
+    previousKernelMajor !== null &&
+    previousKernelMajor !== kernelMajor;
+  const kernelParts = majorMinor(row.versions.kernel);
+  const previousKernelParts = majorMinor(previousRow?.versions.kernel);
+  const kernelMinorBump =
+    !kernelMajorBump &&
+    kernelParts.major !== null &&
+    previousKernelParts.major !== null &&
+    kernelParts.minor !== null &&
+    previousKernelParts.minor !== null &&
+    kernelParts.major === previousKernelParts.major &&
+    kernelParts.minor !== previousKernelParts.minor;
+
+  const nvidiaMajor = majorNumber(row.versions.nvidia);
+  const previousNvidiaMajor = majorNumber(previousRow?.versions.nvidia);
+  const nvidiaMajorBump =
+    nvidiaMajor !== null &&
+    previousNvidiaMajor !== null &&
+    previousNvidiaMajor !== nvidiaMajor;
+  const nvidiaParts = majorMinor(row.versions.nvidia);
+  const previousNvidiaParts = majorMinor(previousRow?.versions.nvidia);
+  const nvidiaMinorBump =
+    !nvidiaMajorBump &&
+    nvidiaParts.major !== null &&
+    previousNvidiaParts.major !== null &&
+    nvidiaParts.minor !== null &&
+    previousNvidiaParts.minor !== null &&
+    nvidiaParts.major === previousNvidiaParts.major &&
+    nvidiaParts.minor !== previousNvidiaParts.minor;
+
+  return (
+    <article className={styles.timelineNode}>
+      <div className={emphasize ? `${styles.nodeBody} ${styles.nodeBodyLatest}` : styles.nodeBody}>
+        <header className={styles.nodeHeader}>
+          {row.releaseUrl ? (
+            <Link to={row.releaseUrl} target="_blank" rel="noopener noreferrer" className={styles.releaseTagLink}>
+              <strong className={styles.releaseTag}>{row.tag}</strong>
+            </Link>
+          ) : (
+            <strong className={styles.releaseTag}>{row.tag}</strong>
+          )}
+          <span className={styles.releaseDate}>{formatDate(row.publishedAt)}</span>
+        </header>
+
+        <div className={styles.majorVersions}>
+          <div
+            className={
+              kernelMajorBump
+                ? `${styles.majorVersionCard} ${styles.majorBump}`
+                : !emphasize && kernelMinorBump
+                  ? `${styles.majorVersionCard} ${styles.minorBump}`
+                  : styles.majorVersionCard
+            }
+          >
+            <span className={styles.majorVersionLabel}>Kernel</span>
+            <VersionValue value={kernel} />
+            {kernelMajorBump && <span className={styles.bumpTag}>Major bump</span>}
+            {!emphasize && kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
+          </div>
+          <div
+            className={
+              nvidiaMajorBump
+                ? `${styles.majorVersionCard} ${styles.nvidiaCard} ${styles.nvidiaMajorBump}`
+                : !emphasize && nvidiaMinorBump
+                  ? `${styles.majorVersionCard} ${styles.nvidiaCard} ${styles.nvidiaMinorBump}`
+                  : `${styles.majorVersionCard} ${styles.nvidiaCard}`
+            }
+          >
+            <span className={styles.majorVersionLabel}>NVIDIA</span>
+            <VersionValue value={nvidia} />
+            {nvidiaMajorBump && <span className={styles.bumpTag}>Major bump</span>}
+            {!emphasize && nvidiaMinorBump && <span className={styles.minorTag}>Minor bump</span>}
+          </div>
+          <div className={styles.majorVersionCard}>
+            <span className={styles.majorVersionLabel}>Mesa</span>
+            <VersionValue value={mesa} />
+          </div>
+          <div className={styles.majorVersionCard}>
+            <span className={styles.majorVersionLabel}>HWE</span>
+            <VersionValue value={hwe} />
+          </div>
+        </div>
+
+        <div className={styles.rebaseInline}>
+          <span className={styles.rebaseInlineLabel}>Rebase to this release</span>
+          <div className={styles.commandBlock}>
+            <CodeBlock language="bash">{rebaseCommandForTag(row.tag)}</CodeBlock>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+interface DriverVersionsCatalogProps {
+  streamId: "bluefin-stable" | "bluefin-lts";
+}
+
+export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalogProps): React.JSX.Element {
+  const allStreams = Array.isArray(catalog.streams) ? catalog.streams : [];
+  const stream = allStreams.find((entry) => entry.id === streamId);
+
+  if (!stream) {
+    return <p className={styles.emptyText}>No driver version data available yet.</p>;
+  }
+
+  return (
+    <div className={styles.timelinePage}>
+      <aside className={styles.archiveRail} aria-hidden="true">
+        <span className={styles.archiveNow}>Now</span>
+        <span className={styles.archivePast}>Past</span>
+      </aside>
+
+      {(() => {
+        const latest = stream.latest;
+        const older = stream.history.slice(1);
+
+        return (
+          <section key={stream.id} className={styles.streamSection}>
+            <header className={styles.streamHeader}>
+              <span className={styles.streamMeta}>
+                {stream.source} · {stream.rowCount} releases in {streamId === "bluefin-lts" ? "LTS" : "Stable"} ·
+                updated {formatDate(catalog.generatedAt)}
+              </span>
+            </header>
+
+            {latest ? (
+              <>
+                <div className={styles.timeline}>
+                  <ReleaseNode row={latest} previousRow={older[0]} emphasize />
+                </div>
+
+                {older.length > 0 && (
+                  <div className={styles.archiveTimeline}>
+                    {older.map((row, index) => (
+                      <ReleaseNode
+                        key={`${stream.id}-${row.tag}-${row.publishedAt || "na"}`}
+                        row={row}
+                        previousRow={older[index + 1]}
+                        emphasize={false}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                <section className={styles.rebaseSection}>
+                  <Heading as="h3" className={styles.rebaseTitle}>
+                    Final Step: Reboot
+                  </Heading>
+                  <ol className={styles.rebaseList}>
+                    <li>
+                      After running one of the per-release rebase commands above, reboot to activate the deployment:
+                      <div className={styles.commandBlock}>
+                        <CodeBlock language="bash">sudo systemctl reboot</CodeBlock>
+                      </div>
+                    </li>
+                  </ol>
+                </section>
+              </>
+            ) : (
+              <p className={styles.emptyText}>No release rows parsed for this stream yet.</p>
+            )}
+          </section>
+        );
+      })()}
+    </div>
+  );
+}

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -78,7 +78,8 @@ function majorMinor(value: string | null | undefined) {
 }
 
 function rebaseCommandForTag(tag: string) {
-  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.\"image-name\"' /usr/share/ublue-os/image-info.json):${tag}"`;
+  const safeTag = /^[a-z0-9][a-z0-9._-]*$/i.test(tag) ? tag : "stable";
+  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.\"image-name\"' /usr/share/ublue-os/image-info.json):${safeTag}"`;
 }
 
 function ReleaseNode({
@@ -200,6 +201,24 @@ interface DriverVersionsCatalogProps {
 export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalogProps): React.JSX.Element {
   const allStreams = Array.isArray(catalog.streams) ? catalog.streams : [];
   const stream = allStreams.find((entry) => entry.id === streamId);
+  const fallbackLabel = streamId === "bluefin-lts" ? "LTS" : "Stable";
+
+  if (!stream && allStreams.length > 0) {
+    return (
+      <div className={styles.timelinePage}>
+        <aside className={styles.archiveRail} aria-hidden="true">
+          <span className={styles.archiveNow}>Now</span>
+          <span className={styles.archivePast}>Past</span>
+        </aside>
+        <section className={styles.streamSection}>
+          <header className={styles.streamHeader}>
+            <span className={styles.streamMeta}>cache · 0 releases in {fallbackLabel}</span>
+          </header>
+          <p className={styles.emptyText}>No releases in the last 90 days for this stream.</p>
+        </section>
+      </div>
+    );
+  }
 
   if (!stream) {
     return <p className={styles.emptyText}>No driver version data available yet.</p>;


### PR DESCRIPTION
…se commands

Regenerate driver versions from cached data and present stable/LTS as clear backwards timelines with highly visible kernel/NVIDIA/Mesa/HWE values. Improve usability with always-visible copy controls, major/minor bump highlights, and cleaner archive-first layout for faster troubleshooting.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot