### PR TITLE
docs(downloads,driver-versions): fix links and remove backup ISO section

### DIFF
--- a/docs/downloads-testing.md
+++ b/docs/downloads-testing.md
@@ -52,7 +52,7 @@ The AI workstation with Nvidia and CUDA.\
 
 | Version     | GPU           | Download                                                                                 | Torrent | Checksum                                                                     |
 | ----------- | ------------- | ---------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------- |
-| Bluefin GDX | Nvidia        | [📥 bluefin-gdx-x86_64.iso](https://projectbluefin.dev/bluefin-gdx-lts-x86_64.iso)       |         | [🔐 Verify](https://projectbluefin.dev/bluefin-gdx-lts-x86_64.iso-CHECKSUM)  |
+| Bluefin GDX | Nvidia        | [📥 bluefin-gdx-lts-x86_64.iso](https://projectbluefin.dev/bluefin-gdx-lts-x86_64.iso)   |         | [🔐 Verify](https://projectbluefin.dev/bluefin-gdx-lts-x86_64.iso-CHECKSUM)  |
 | Bluefin GDX | ARM (aarch64) | [📥 bluefin-gdx-lts-aarch64.iso](https://projectbluefin.dev/bluefin-gdx-lts-aarch64.iso) |         | [🔐 Verify](https://projectbluefin.dev/bluefin-gdx-lts-aarch64.iso-CHECKSUM) |
 
 ## Verifying Downloads with Checksums

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -40,22 +40,8 @@ The AI workstation with Nvidia and CUDA.\
 
 | Version     | GPU           | Download                                                                                         | Torrent | Checksum                                                                             |
 | ----------- | ------------- | ------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------ |
-| Bluefin GDX | Nvidia        | [📥 bluefin-gdx-x86_64.iso](https://download.projectbluefin.io/bluefin-gdx-lts-x86_64.iso)       |         | [🔐 Verify](https://download.projectbluefin.io/bluefin-gdx-lts-x86_64.iso-CHECKSUM)  |
+| Bluefin GDX | Nvidia        | [📥 bluefin-gdx-lts-x86_64.iso](https://download.projectbluefin.io/bluefin-gdx-lts-x86_64.iso)   |         | [🔐 Verify](https://download.projectbluefin.io/bluefin-gdx-lts-x86_64.iso-CHECKSUM)  |
 | Bluefin GDX | ARM (aarch64) | [📥 bluefin-gdx-lts-aarch64.iso](https://download.projectbluefin.io/bluefin-gdx-lts-aarch64.iso) |         | [🔐 Verify](https://download.projectbluefin.io/bluefin-gdx-lts-aarch64.iso-CHECKSUM) |
-
-## Older Backup ISOs
-
-These are the older Anaconda-based installers with an older version of Bluefin, but don't worry it will autoupdate. Try this if nothing else works:
-
-#### Bluefin (AMD/Intel)
-
-📥 **Download:** [bluefin-stable.iso](https://projectbluefin.dev/bluefin-stable.iso)  
-🔐 **Verify:** [Checksum](https://projectbluefin.dev/bluefin-stable.iso-CHECKSUM)
-
-#### Bluefin (for Nvidia)
-
-📥 **Download:** [bluefin-nvidia-stable.iso](https://projectbluefin.dev/bluefin-nvidia-stable.iso)  
-🔐 **Verify:** [Checksum](https://projectbluefin.dev/bluefin-nvidia-stable.iso-CHECKSUM)
 
 ## Verifying Downloads with Checksums
 

--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -9,6 +9,19 @@ import DriverVersionsCatalog from "@site/src/components/DriverVersionsCatalog";
 
 Sometimes the raptor just gets you. This page tracks major driver versions across Bluefin releases to help users identify and switch to specific driver versions. Good for ruling out major components. Remember to rebase back to the release stream later if you want to see if your issue gets fixed, use `ujust rebase-helper` for that. Good luck, you got this.
 
+:::tip bootc switch preflight
+Before switching streams or pinning a dated tag, verify the target exists for your current image variant:
+
+```bash
+IMAGE_NAME=$(jq -r '."image-name"' < /usr/share/ublue-os/image-info.json)
+TARGET_TAG=stable
+skopeo inspect docker://ghcr.io/ublue-os/${IMAGE_NAME}:${TARGET_TAG} >/dev/null
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/${IMAGE_NAME}:${TARGET_TAG}
+```
+
+If you hit `manifest unknown`, the tag is not published for that image/stream pair.
+:::
+
 ## Stable
 
 <DriverVersionsCatalog streamId="bluefin-stable" />

--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -15,8 +15,8 @@ Before switching streams or pinning a dated tag, verify the target exists for yo
 ```bash
 IMAGE_NAME=$(jq -r '."image-name"' < /usr/share/ublue-os/image-info.json)
 TARGET_TAG=stable
-skopeo inspect docker://ghcr.io/ublue-os/${IMAGE_NAME}:${TARGET_TAG} >/dev/null
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/${IMAGE_NAME}:${TARGET_TAG}
+skopeo inspect docker://ghcr.io/${IMAGE_NAME}:${TARGET_TAG} >/dev/null && \
+  sudo bootc switch --enforce-container-sigpolicy ghcr.io/${IMAGE_NAME}:${TARGET_TAG}
 ```
 
 If you hit `manifest unknown`, the tag is not published for that image/stream pair.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -121,6 +121,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    docs: {
+      sidebar: {
+        hideable: false,
+      },
+    },
     announcementBar: {
       id: "announcement",
       content:

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
       label: "Documentation",
       collapsed: false,
       items: [
+        "index",
         "introduction",
         "installation",
         "administration",

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -3,7 +3,6 @@ import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import imagesData from "@site/static/data/images.json";
 import styles from "./ImagesCatalog.module.css";
 
 interface StreamInfo {
@@ -63,8 +62,6 @@ interface ImagesCatalog {
   generatedAt?: string;
   products: Product[];
 }
-
-const catalog = imagesData as ImagesCatalog;
 
 function sourceText(source: "live" | "cache" | "unavailable", kind: string) {
   if (source === "live") return `${kind}: live`;
@@ -143,6 +140,27 @@ function formatDate(value?: string | null) {
 }
 
 export default function ImagesCatalogComponent(): React.JSX.Element {
+  const [catalog, setCatalog] = React.useState<ImagesCatalog>({ products: [] });
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    fetch("/data/images.json")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (!mounted || !data || !Array.isArray(data.products)) return;
+        setCatalog(data as ImagesCatalog);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCatalog({ products: [] });
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   const products = Array.isArray(catalog?.products) ? catalog.products : [];
   const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<Record<string, boolean>>(
     {},


### PR DESCRIPTION
Align GDX URL labels, remove the legacy backup ISO block from Downloads, and add a bootc preflight check on Driver Versions to prevent manifest mismatch errors before switching tags.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot