### PR TITLE
fix(images): wire fetch-github-images into fetch-data chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21666,7 +21666,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "fetch-github-profiles": "node scripts/fetch-github-profiles.js",
     "fetch-github-repos": "node scripts/fetch-github-repos.js",
     "fetch-github-driver-versions": "node scripts/fetch-github-driver-versions.js",
+    "fetch-github-images": "node scripts/fetch-github-images.js",
     "fetch-contributors": "node scripts/fetch-contributors.js",
     "fetch-board-data": "node scripts/fetch-board-data.js",
     "generate-report": "node scripts/generate-report.mjs",
-    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-contributors && npm run fetch-board-data"
+    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-board-data"
   },
   "dependencies": {
     "@1password/docusaurus-plugin-stored-data": "^1.0.0",


### PR DESCRIPTION
The fetch-github-images.js script existed but was never added to the fetch-data npm script. As a result, static/data/images.json was never generated during npm start or npm run build, causing the /images page to render blank (the component falls back to an empty product list when the fetch returns 404).

Adds the fetch-github-images script entry and inserts it into the fetch-data chain so images.json is generated on every build and dev server start.

Assisted-by: Claude Sonnet 4.6 via OpenCode