### PR TITLE
fix(images): address issue #20 reviewer feedback — cert identity, par…

### DIFF
--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -383,8 +383,12 @@ function buildSecurityInfo(spec, inspectTag) {
   const hasNoPipeline = !isKeyless && !cosignKeyUrl;
 
   // Keyless: GitHub OIDC / Sigstore — certificate-based, no public key file.
+  // The OIDC identity is derived from keyRepo so LTS/GDX variants resolve to their own
+  // workflow repo automatically. We use --certificate-identity-regexp with a ^ anchor so
+  // any workflow file under .github/workflows/ in the signing repo is accepted (the exact
+  // workflow filename may differ across streams).
   const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
-  const OIDC_IDENTITY = `https://github.com/ublue-os/bluefin/.github/workflows/reusable-build.yml@refs/heads/main`;
+  const OIDC_IDENTITY_PREFIX = `^https://github.com/${spec.keyRepo}/.github/workflows/`;
   const SLSA_TYPE = "https://slsa.dev/provenance/v1";
 
   if (hasNoPipeline) {
@@ -400,8 +404,8 @@ function buildSecurityInfo(spec, inspectTag) {
   if (isKeyless) {
     return {
       cosignKeyUrl: null,
-      verifyCommand: `cosign verify --certificate-oidc-issuer ${OIDC_ISSUER} --certificate-identity ${OIDC_IDENTITY} ${imageRef}`,
-      attestCommand: `cosign verify-attestation --type ${SLSA_TYPE} --certificate-oidc-issuer ${OIDC_ISSUER} --certificate-identity ${OIDC_IDENTITY} ${imageRef}`,
+      verifyCommand: `cosign verify --certificate-oidc-issuer ${OIDC_ISSUER} --certificate-identity-regexp '${OIDC_IDENTITY_PREFIX}' ${imageRef}`,
+      attestCommand: `cosign verify-attestation --type ${SLSA_TYPE} --certificate-oidc-issuer ${OIDC_ISSUER} --certificate-identity-regexp '${OIDC_IDENTITY_PREFIX}' ${imageRef}`,
       hasAttestation: true,
       sbomCommand: `syft scan ${imageRef} -o spdx-json`,
     };

--- a/scripts/lib/graphql-queries.mjs
+++ b/scripts/lib/graphql-queries.mjs
@@ -377,9 +377,9 @@ export async function fetchClosedItemsFromRepo(
   startDate,
   endDate,
 ) {
+  // Declared outside try so partial results are preserved on mid-pagination error.
+  const allItems = [];
   try {
-    const allItems = [];
-
     // Paginate closed issues (server-side date filter via `since` keeps page count low)
     let issuesCursor = null;
     let issuesHasNextPage = true;
@@ -452,10 +452,11 @@ export async function fetchClosedItemsFromRepo(
     return allItems;
   } catch (error) {
     console.error(
-      `Error fetching closed items from ${owner}/${name}: ${error.message}`,
+      `Returning ${allItems.length} partial items before failure from ${owner}/${name}: ${error.message}`,
     );
-    // Return empty array instead of throwing - don't fail entire report for one repo
-    return [];
+    // Return partial results rather than empty array — avoids silently discarding
+    // items already fetched from earlier pages before the error occurred.
+    return allItems;
   }
 }
 


### PR DESCRIPTION
…tial results, auth

Problem 1: Replace hardcoded OIDC_IDENTITY with a value derived from spec.keyRepo and switch from --certificate-identity (exact match) to --certificate-identity-regexp with a ^ anchored prefix. This ensures keyless cosign commands are correct for each product (e.g. ublue-os/bluefin vs ublue-os/bluefin-lts) without hardcoding a single workflow filename.

Problem 2: Verified by design — buildSecurityInfo() is called per-product with inspectTag derived from streams[0].tag (the actual resolved stream tag). No structural change needed; existing call site at line 586 is already stream-aware.

Problem 3: Move allItems declaration outside the try block in fetchClosedItemsFromRepo() so partial results accumulated across earlier pagination pages are returned on error rather than being silently discarded with an empty array.

Problem 4: Verified by design — all fetch() calls in fetch-github-images.js flow through fetchText() which already attaches Authorization + User-Agent headers. No raw fetch() calls bypass auth. No new helper needed.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot