### PR TITLE
fix(driver-versions): make shimmer visible in light mode

### DIFF
--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -164,7 +164,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -208,7 +208,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -247,7 +247,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -286,7 +286,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -422,7 +422,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -461,7 +461,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -537,7 +537,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -576,7 +576,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: color-dodge;
+  mix-blend-mode: overlay;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -705,4 +705,16 @@
   display: inline-block;
   margin-top: 0.3rem;
   word-break: break-word;
+}
+
+/* Dark mode: restore color-dodge for maximum shimmer on dark backgrounds */
+[data-theme="dark"] .majorBump::after,
+[data-theme="dark"] .nvidiaMajorBump::after,
+[data-theme="dark"] .nvidiaMinorBump::after,
+[data-theme="dark"] .minorBump::after,
+[data-theme="dark"] .mesaMajorBump::after,
+[data-theme="dark"] .mesaMinorBump::after,
+[data-theme="dark"] .gnomeMajorBump::after,
+[data-theme="dark"] .gnomeMinorBump::after {
+  mix-blend-mode: color-dodge;
 }


### PR DESCRIPTION
Use mix-blend-mode: overlay as the default for all 8 driver bump card ::after shimmer rules so the foil effect is visible on the near-white backgrounds of light mode. Add a [data-theme="dark"] override block that restores color-dodge for the full holographic shimmer on dark backgrounds.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot