### PR TITLE
fix(ci): always re-fetch driver versions data on every build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Fetch data
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
+          # Always re-fetch driver versions on every build so GNOME/kernel/mesa
+          # versions stay current. The data is small (GitHub API call) and the
+          # script's internal 168h TTL would otherwise serve stale cached data.
+          DRIVER_VERSIONS_CACHE_HOURS: "0"
         run: npm run fetch-data
 
       - name: Run TypeScript validation


### PR DESCRIPTION
The fetch-github-driver-versions.js script has an internal 168-hour cache TTL. When the GHA data cache is restored, the file mtime is recent, so the TTL check passes and the script skips the fetch — serving stale data indefinitely until a script file is modified.

This caused the GNOME version column to show missing on the driver-versions page: the cached driver-versions.json was generated before the gnome field was added to buildRowFromApiRelease.

Set DRIVER_VERSIONS_CACHE_HOURS=0 so driver versions are always re-fetched from the GitHub releases API on every CI build. The data is small and the fetch takes under 5 seconds.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot