### PR TITLE
fix(sbom): enforce sbom-only version sources across docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /static/feeds/*.json
 /static/data/*.json
 !/static/data/sbom-attestations.json
+!/static/data/sbom-attestations-frontend.json
 !/static/data/firehose-apps.json
 
 # Misc

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -30,6 +30,11 @@ const RELEASE_URL_BY_STREAM = {
   "bluefin-lts": "https://github.com/ublue-os/bluefin-lts/releases",
 };
 
+const RELEASE_REPO_BY_STREAM = {
+  "bluefin-stable": "ublue-os/bluefin",
+  "bluefin-lts": "ublue-os/bluefin-lts",
+};
+
 function readJsonIfExists(filePath, fallback) {
   if (!fs.existsSync(filePath)) return fallback;
   try {
@@ -202,7 +207,13 @@ function rowFromSbomRelease(streamId, cacheKey, releaseEntry, nvidiaVersion) {
     stream: streamId,
     tag: releaseEntry?.tag || cacheKey,
     title: releaseEntry?.tag || cacheKey,
-    releaseUrl: RELEASE_URL_BY_STREAM[streamId] || null,
+    releaseUrl: (() => {
+      const tag = releaseEntry?.tag || cacheKey;
+      const repo = RELEASE_REPO_BY_STREAM[streamId];
+      return repo && tag
+        ? `https://github.com/${repo}/releases/tag/${tag}`
+        : RELEASE_URL_BY_STREAM[streamId] || null;
+    })(),
     publishedAt,
     versions: {
       kernel: pkg.kernel || null,
@@ -254,15 +265,26 @@ function buildStreamFromSbom(
   };
 }
 
+function normalizeReleaseTag(tag) {
+  // GitHub LTS release tags use dots (lts.YYYYMMDD) but SBOM cache keys use
+  // hyphens (lts-YYYYMMDD). Normalize so NVIDIA lookups match SBOM entries.
+  return typeof tag === "string" ? tag.replace(/^lts\./, "lts-") : tag;
+}
+
 function buildNvidiaMap(releases) {
   const map = {};
   for (const release of releases || []) {
     const tag = release?.tag_name;
     if (!tag) continue;
-    map[tag] = extractVersionFromMarkdown(release?.body || "", [
+    const normalizedTag = normalizeReleaseTag(tag);
+    const version = extractVersionFromMarkdown(release?.body || "", [
       "Nvidia",
       "NVIDIA",
     ]);
+    map[normalizedTag] = version;
+    // Also key by raw tag so stable-YYYYMMDD lookups (no normalization needed)
+    // still resolve correctly without a second pass.
+    if (normalizedTag !== tag) map[tag] = version;
   }
   return map;
 }
@@ -294,24 +316,34 @@ function buildStream(streamId, name, subtitle, command, feedItems, sbomCache) {
 }
 
 async function fetchReleases(owner, repo) {
-  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "bluefin-docs-driver-versions",
-      ...(process.env.GITHUB_TOKEN
-        ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
-        : {}),
-    },
-  });
+  const releases = [];
+  let url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "bluefin-docs-driver-versions",
+    ...(process.env.GITHUB_TOKEN
+      ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+      : {}),
+  };
 
-  if (!response.ok) {
-    throw new Error(
-      `GitHub releases API failed for ${owner}/${repo}: ${response.status}`,
-    );
+  while (url) {
+    const response = await fetch(url, { headers });
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub releases API failed for ${owner}/${repo}: ${response.status}`,
+      );
+    }
+
+    const page = await response.json();
+    releases.push(...page);
+
+    const link = response.headers.get("link");
+    const next = link?.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
+    url = next;
   }
 
-  return response.json();
+  return releases;
 }
 
 function buildStreamFromApi(

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -59,6 +59,20 @@ const OUTPUT_FILE = path.join(
   "sbom-attestations.json",
 );
 
+/**
+ * Frontend-facing slim copy of the SBOM cache.
+ * Identical structure but with `allPackages` stripped from every release —
+ * keeping only `packageVersions` and `attestation`. This prevents the full
+ * RPM inventory (hundreds of entries per release) from bloating the JS bundle.
+ */
+const FRONTEND_OUTPUT_FILE = path.join(
+  __dirname,
+  "..",
+  "static",
+  "data",
+  "sbom-attestations-frontend.json",
+);
+
 // How many calendar days of releases to scan per stream.
 const LOOKBACK_DAYS = Number(process.env.SBOM_LOOKBACK_DAYS || 90);
 
@@ -1020,6 +1034,23 @@ async function main() {
   fs.writeFileSync(tmpFile, JSON.stringify(output, null, 2), "utf-8");
   fs.renameSync(tmpFile, OUTPUT_FILE);
   console.log(`\nSBOM attestation cache written to ${OUTPUT_FILE}`);
+
+  // Write slim frontend copy — strips allPackages from every release so the
+  // JS bundle only includes packageVersions + attestation (not full RPM lists).
+  const frontendStreams = {};
+  for (const [streamId, stream] of Object.entries(streams)) {
+    const slimReleases = {};
+    for (const [key, entry] of Object.entries(stream.releases || {})) {
+      const { allPackages: _dropped, ...rest } = entry;
+      slimReleases[key] = rest;
+    }
+    frontendStreams[streamId] = { ...stream, releases: slimReleases };
+  }
+  const frontendOutput = { ...output, streams: frontendStreams };
+  const tmpFrontend = FRONTEND_OUTPUT_FILE + ".tmp";
+  fs.writeFileSync(tmpFrontend, JSON.stringify(frontendOutput, null, 2), "utf-8");
+  fs.renameSync(tmpFrontend, FRONTEND_OUTPUT_FILE);
+  console.log(`SBOM frontend slim cache written to ${FRONTEND_OUTPUT_FILE}`);
 }
 
 if (require.main === module) {

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import useStoredFeed from "@theme/useStoredFeed";
 import styles from "./FeedItems.module.css";
 import githubProfilesData from "@site/static/data/github-profiles.json";
-import sbomAttestationsData from "@site/static/data/sbom-attestations.json";
+import sbomAttestationsData from "@site/static/data/sbom-attestations-frontend.json";
 import type { SbomAttestationsData } from "../types/sbom";
 
 // Small inline copy button — renders a clipboard icon, shows a tick for 1.5s after copy
@@ -306,13 +306,18 @@ const extractReleaseTag = (title: string): string | null => {
   const tagMatch = title.match(
     /(stable-\d{8}|beta-\d{8}|latest-\d{8}|lts[-.]\d{8})/i,
   );
-  if (!tagMatch) return null;
+  if (tagMatch) {
+    // Normalise lts.YYYYMMDD → lts-YYYYMMDD to match cache key format
+    return tagMatch[1]
+      .toLowerCase()
+      .replace(/^lts\.(\d{8})$/, "lts-$1");
+  }
 
-  // Normalise lts.YYYYMMDD → lts-YYYYMMDD to match cache key format
-  const normalized = tagMatch[1]
-    .toLowerCase()
-    .replace(/^lts\.(\d{8})$/, "lts-$1");
-  return normalized;
+  // LTS feed titles use "bluefin-lts LTS: YYYYMMDD (...)" format — extract date
+  const ltsDateMatch = title.match(/\bLTS:\s*(\d{8})\b/i);
+  if (ltsDateMatch) return `lts-${ltsDateMatch[1]}`;
+
+  return null;
 };
 
 const getSupplyChainLinks = (title: string, feedId?: string): SupplyChainLinks => {

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -5,7 +5,6 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./ImagesCatalog.module.css";
-import imagesCatalogData from "@site/static/data/images.json";
 
 
 interface StreamInfo {
@@ -140,7 +139,24 @@ function formatDate(value?: string | null) {
 }
 
 export default function ImagesCatalogComponent(): React.JSX.Element {
-  const catalog = (imagesCatalogData as ImagesCatalog) || { products: [] };
+  const [catalog, setCatalog] = React.useState<ImagesCatalog>({ products: [] });
+
+  React.useEffect(() => {
+    let mounted = true;
+    fetch("/data/images.json")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (!mounted || !data || !Array.isArray(data.products)) return;
+        setCatalog(data as ImagesCatalog);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCatalog({ products: [] });
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const products = Array.isArray(catalog?.products) ? catalog.products : [];
   const [nvidiaModeByProduct, setNvidiaModeByProduct] = React.useState<Record<string, boolean>>(

--- a/static/data/sbom-attestations-frontend.json
+++ b/static/data/sbom-attestations-frontend.json
@@ -1,0 +1,1 @@
+{ "generatedAt": null, "streams": {} }


### PR DESCRIPTION
Make SBOM attestations the authoritative source for kernel, GNOME, Mesa, and Fedora across driver, images, and changelog surfaces while keeping NVIDIA as the explicit fallback workaround.

Refs: #35 #38 #50 #52 #57

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot