### PR TITLE
fix(components,scripts,ci): p2 component and script fixes

### DIFF
--- a/.github/workflows/monthly-reports.yml
+++ b/.github/workflows/monthly-reports.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache Prince XML
         id: cache-prince
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             /usr/local/lib/prince

--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -152,6 +152,30 @@ function lookupSbomVersions(sbomCache, streamId) {
   return null;
 }
 
+function normalizeSbomStreamTag(streamTag) {
+  if (!streamTag) return null;
+  if (streamTag === "stable-daily") return "stable";
+  return streamTag;
+}
+
+function buildSbomStreamId(spec, streamTag) {
+  const normalizedTag = normalizeSbomStreamTag(streamTag);
+  if (!spec?.sbomStreamId || !normalizedTag) return null;
+  return spec.sbomStreamId.replace(/-(stable|latest|lts|beta)$/, `-${normalizedTag}`);
+}
+
+function fallbackSbomVersionsByPackage(sbomCache, spec) {
+  if (!sbomCache?.streams || !spec?.org || !spec?.package) return null;
+  const streamEntries = Object.values(sbomCache.streams).filter(
+    (stream) => stream?.org === spec.org && stream?.package === spec.package,
+  );
+  for (const stream of streamEntries) {
+    const versions = lookupSbomVersions(sbomCache, stream.id);
+    if (versions) return versions;
+  }
+  return null;
+}
+
 function readCache() {
   return readJsonIfExists(OUTPUT_FILE, null);
 }
@@ -195,9 +219,14 @@ function parseFeedVersion(feedItem, labels) {
   return null;
 }
 
-function sbomVersionsForStream(sbomCache, sbomStreamId) {
-  if (!sbomCache || !sbomStreamId) return null;
-  return lookupSbomVersions(sbomCache, sbomStreamId);
+function sbomVersionsForStream(sbomCache, spec, streamTag) {
+  if (!sbomCache || !spec) return null;
+  const exactStreamId = buildSbomStreamId(spec, streamTag);
+  if (exactStreamId) {
+    const exact = lookupSbomVersions(sbomCache, exactStreamId);
+    if (exact) return exact;
+  }
+  return fallbackSbomVersionsByPackage(sbomCache, spec);
 }
 
 function latestFeedItem(feeds, source) {
@@ -327,7 +356,7 @@ async function buildStreamVersionInfo(
   feeds,
   sbomCache,
 ) {
-  const sbomVersions = sbomVersionsForStream(sbomCache, spec.sbomStreamId);
+  const sbomVersions = sbomVersionsForStream(sbomCache, spec, streamTag);
   const feedKey = streamTag === "lts" ? "lts" : streamTag;
   const feedSource = spec.versionSource
     ? { feed: spec.versionSource.feed, stream: feedKey }
@@ -558,7 +587,7 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
   }
 
   const feedItem = latestFeedItem(feeds, spec.versionSource);
-  const sbomVersions = sbomVersionsForStream(sbomCache, spec.sbomStreamId);
+  const sbomVersions = sbomVersionsForStream(sbomCache, spec, spec.versionSource?.stream);
   const versionsFromFeed = {
     gnome: sbomVersions?.gnome || null,
     kernel: sbomVersions?.kernel || null,

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -322,7 +322,7 @@
   line-height: 1.2;
   font-weight: 800;
   color: var(--ifm-color-emphasis-900);
-  word-break: break-word;
+  overflow-wrap: anywhere;
   position: relative;
   z-index: 2;
 }
@@ -645,7 +645,7 @@
 
 .rebaseInline code {
   display: block;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .commandBlock :global(.theme-code-block) {
@@ -658,7 +658,7 @@
 .commandBlock :global(pre) {
   margin: 0;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
   /* padding-right handled globally in custom.css */
 }
 
@@ -704,7 +704,7 @@
 .rebaseList code {
   display: inline-block;
   margin-top: 0.3rem;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* Dark mode: restore color-dodge for maximum shimmer on dark backgrounds */

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -48,11 +48,8 @@ function formatDate(value: string | null | undefined) {
     year: "numeric",
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   });
-}
-
-function valueOrFallback(value: string | null | undefined, fallback = "N/A") {
-  return value || fallback;
 }
 
 function VersionValue({ value }: { value: string | null | undefined }) {
@@ -80,7 +77,7 @@ function majorMinor(value: string | null | undefined) {
 
 function rebaseCommandForTag(tag: string) {
   const safeTag = /^[a-z0-9][a-z0-9._-]*$/i.test(tag) ? tag : "stable";
-  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.\"image-name\"' /usr/share/ublue-os/image-info.json):${safeTag}"`;
+  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.["image-name"]' /usr/share/ublue-os/image-info.json):${safeTag}"`;
 }
 
 function ReleaseNode({
@@ -92,11 +89,7 @@ function ReleaseNode({
   previousRow?: DriverRow;
   emphasize: boolean;
 }) {
-  const kernel = valueOrFallback(row.versions.kernel);
-  const nvidia = valueOrFallback(row.versions.nvidia);
-  const mesa = valueOrFallback(row.versions.mesa);
   const hwe = row.versions.hweKernel;
-  const gnome = valueOrFallback(row.versions.gnome);
 
   const kernelMajor = majorNumber(row.versions.kernel);
   const previousKernelMajor = majorNumber(previousRow?.versions.kernel);
@@ -191,7 +184,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>Kernel</span>
-            <VersionValue value={kernel} />
+            <VersionValue value={row.versions.kernel} />
             {kernelMajorBump && <span className={styles.bumpTag}>Major bump</span>}
             {kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
           </div>
@@ -211,7 +204,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>NVIDIA</span>
-            <VersionValue value={nvidia} />
+            <VersionValue value={row.versions.nvidia} />
             {nvidiaMajorBump && <span className={styles.nvidiaBumpTag}>Major bump</span>}
             {nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
           </div>
@@ -225,7 +218,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>Mesa</span>
-            <VersionValue value={mesa} />
+            <VersionValue value={row.versions.mesa} />
             {mesaMajorBump && <span className={styles.mesaBumpTag}>Major bump</span>}
             {mesaMinorBump && <span className={styles.mesaMinorTag}>Minor bump</span>}
           </div>
@@ -239,7 +232,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>GNOME</span>
-            <VersionValue value={gnome} />
+            <VersionValue value={row.versions.gnome} />
             {gnomeMajorBump && <span className={styles.gnomeBumpTag}>Major bump</span>}
             {gnomeMinorBump && <span className={styles.gnomeMinorTag}>Minor bump</span>}
           </div>

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import firehoseData from "@site/static/data/firehose-apps.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
 import FirehoseCard from "./FirehoseCard";
@@ -250,7 +250,11 @@ const FirehoseFeed: React.FC = () => {
     [filteredEvents],
   );
 
-  const featuredApp = useMemo(() => getFeaturedApp(uniqueApps), [uniqueApps]);
+  const [featuredApp, setFeaturedApp] = useState<FirehoseApp | null>(null);
+
+  useEffect(() => {
+    setFeaturedApp(getFeaturedApp(uniqueApps));
+  }, [uniqueApps]);
 
   const isEmpty = allEvents.length === 0;
 


### PR DESCRIPTION
Fixes #22: DriverVersionsCatalog — formatDate UTC timezone, deprecated word-break CSS → overflow-wrap:anywhere, jq bracket notation, versionMissing CSS applied directly from nullable values

Fixes #23: FeedItems — stopPropagation on ActionLinkButton/ContributorAvatar inside anchor cards; GHCR packageTagUrl uses raw registry tag (lts.YYYYMMDD) not normalized form; formatLongDate UTC timezone

Fixes #25: Pin actions/cache@v5 → @668228422ae6a00e4ad889ee87cd7109ec5666a7 (v5.0.4) in monthly-reports.yml and pdf.yml

Fixes #26: fetch-github-images.js attestation lookup prefers exact stream ID match before falling back to org/package family

Fixes #51: FirehoseFeed featured app selection moved to useEffect/useState — eliminates SSR/hydration date mismatch

Fixes #53: fetchReleases follows Link header pagination — no longer capped at 100 releases (bluefin-lts already has 192)

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot