### PR TITLE
feat(changelogs): add prominent OS release cards interleaved in timeline

### DIFF
--- a/src/components/FirehoseFeed.module.css
+++ b/src/components/FirehoseFeed.module.css
@@ -252,6 +252,16 @@
   border-radius: 8px;
 }
 
+.osHiddenNotice {
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+  background: var(--ifm-color-warning-contrast-background, #fff3cd);
+  border-left: 3px solid var(--ifm-color-warning, #e0a800);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: var(--ifm-color-warning-dark, #856404);
+}
+
 .clearFiltersBtn {
   margin-top: 0.75rem;
   padding: 0.4rem 1rem;

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useMemo, useEffect } from "react";
 import firehoseData from "@site/static/data/firehose-apps.json";
+import bluefinReleasesData from "@site/static/feeds/bluefin-releases.json";
+import bluefinLtsReleasesData from "@site/static/feeds/bluefin-lts-releases.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
+import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent } from "../types/os-feed";
+import { parseOsRelease } from "../utils/parseOsRelease";
 import FirehoseCard from "./FirehoseCard";
+import OsReleaseCard from "./OsReleaseCard";
 import FirehoseFilters from "./FirehoseFilters";
 import styles from "./FirehoseFeed.module.css";
 
@@ -20,6 +25,30 @@ export interface FlatRelease {
   release: FirehoseRelease;
   dateMs: number;
 }
+
+// ── OS release events (parsed once at module scope) ───────────────────────────
+
+function loadOsEvents(
+  feedData: typeof bluefinReleasesData,
+  stream: "stable" | "lts",
+): OsReleaseEvent[] {
+  const events: OsReleaseEvent[] = [];
+  for (const item of feedData.items ?? []) {
+    const release = parseOsRelease(item, stream);
+    if (!release) continue; // GTS entry or parse failure — skip
+    const dateMs = new Date(item.pubDate).getTime();
+    if (isNaN(dateMs)) continue;
+    events.push({ kind: "os", stream, dateMs, release });
+  }
+  return events;
+}
+
+const STABLE_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinReleasesData, "stable");
+const LTS_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinLtsReleasesData, "lts");
+const ALL_OS_EVENTS: OsReleaseEvent[] = [
+  ...STABLE_OS_EVENTS,
+  ...LTS_OS_EVENTS,
+].sort((a, b) => b.dateMs - a.dateMs);
 
 /**
  * Flatten every app's releases array into individual events.
@@ -118,7 +147,13 @@ function getFeaturedApp(uniqueApps: UniqueApp[]): FirehoseApp | null {
 
 // ── Statistics panel ──────────────────────────────────────────────────────────
 
-function Statistics({ uniqueApps }: { uniqueApps: UniqueApp[] }) {
+function Statistics({
+  uniqueApps,
+  osEventCount,
+}: {
+  uniqueApps: UniqueApp[];
+  osEventCount: number;
+}) {
   const counts = useMemo(() => {
     const byType: Record<string, number> = {};
     for (const { app } of uniqueApps) {
@@ -139,6 +174,12 @@ function Statistics({ uniqueApps }: { uniqueApps: UniqueApp[] }) {
             <dd>{count}</dd>
           </React.Fragment>
         ))}
+        {osEventCount > 0 && (
+          <>
+            <dt>OS Releases</dt>
+            <dd>{osEventCount}</dd>
+          </>
+        )}
       </dl>
     </section>
   );
@@ -229,10 +270,13 @@ const DEFAULT_FILTERS: FirehoseFilterState = {
   updatedWithin: "all",
   verifiedOnly: false,
   unverifiedOnly: false,
+  showOsReleases: true,
 };
 
 const FirehoseFeed: React.FC = () => {
   const [filters, setFilters] = useState<FirehoseFilterState>(DEFAULT_FILTERS);
+
+  // ── App events ──────────────────────────────────────────────────────────────
 
   const allEvents: FlatRelease[] = useMemo(
     () => flattenReleases(firehoseData.apps ?? []),
@@ -241,10 +285,8 @@ const FirehoseFeed: React.FC = () => {
 
   const filteredEvents = useMemo(() => applyFilters(allEvents, filters), [allEvents, filters]);
 
-  // Single deduplication pass — shared by getFeaturedApp, Statistics, and FirehoseFilters
   const uniqueApps: UniqueApp[] = useMemo(() => toUniqueApps(allEvents), [allEvents]);
 
-  // Unique apps after filters — one card per app in the main feed
   const filteredUniqueApps: UniqueApp[] = useMemo(
     () => toUniqueApps(filteredEvents),
     [filteredEvents],
@@ -256,7 +298,43 @@ const FirehoseFeed: React.FC = () => {
     setFeaturedApp(getFeaturedApp(uniqueApps));
   }, [uniqueApps]);
 
-  const isEmpty = allEvents.length === 0;
+  // ── OS release events ───────────────────────────────────────────────────────
+
+  const filteredOsEvents = useMemo((): OsReleaseEvent[] => {
+    if (!filters.showOsReleases) return [];
+    if (filters.updatedWithin === "all") return ALL_OS_EVENTS;
+    const maxAge = DAYS_MS[filters.updatedWithin];
+    const now = Date.now();
+    return ALL_OS_EVENTS.filter((e) => now - e.dateMs <= maxAge);
+  }, [filters.showOsReleases, filters.updatedWithin]);
+
+  // How many OS events are hidden by the date filter (for inline notice)
+  const hiddenOsCount = useMemo(
+    () =>
+      filters.showOsReleases && filters.updatedWithin !== "all"
+        ? ALL_OS_EVENTS.length - filteredOsEvents.length
+        : 0,
+    [filteredOsEvents, filters.showOsReleases, filters.updatedWithin],
+  );
+
+  // ── Unified timeline ────────────────────────────────────────────────────────
+  //
+  // App events are deduplicated to one card per app (most recent release).
+  // OS events are kept individually — all 10 stable + 10 LTS appear as
+  // separate cards sorted by date. The two streams are interleaved chronologically.
+
+  const timeline = useMemo((): FlatTimelineEvent[] => {
+    const appEntries: AppTimelineEvent[] = filteredUniqueApps.map(
+      ({ app, latestMs }) => ({
+        kind: "app" as const,
+        app,
+        dateMs: latestMs,
+      }),
+    );
+    return [...appEntries, ...filteredOsEvents].sort((a, b) => b.dateMs - a.dateMs);
+  }, [filteredUniqueApps, filteredOsEvents]);
+
+  const isEmpty = allEvents.length === 0 && ALL_OS_EVENTS.length === 0;
 
   return (
     <div className={styles.layout}>
@@ -270,11 +348,27 @@ const FirehoseFeed: React.FC = () => {
           onFiltersChange={setFilters}
           matchCount={filteredUniqueApps.length}
         />
-        {!isEmpty && <Statistics uniqueApps={uniqueApps} />}
+        {!isEmpty && (
+          <Statistics uniqueApps={uniqueApps} osEventCount={ALL_OS_EVENTS.length} />
+        )}
       </aside>
 
       {/* ── Main feed ── */}
       <main className={styles.feedColumn}>
+        {/* Inline notice when OS events are hidden by the date filter */}
+        {hiddenOsCount > 0 && (
+          <p className={styles.osHiddenNotice}>
+            {hiddenOsCount} OS release{hiddenOsCount !== 1 ? "s" : ""} hidden by the
+            date filter.{" "}
+            <button
+              className={styles.clearFiltersBtn}
+              onClick={() => setFilters({ ...filters, updatedWithin: "all" })}
+            >
+              Show all
+            </button>
+          </p>
+        )}
+
         {isEmpty ? (
           <div className={styles.emptyState}>
             <p>
@@ -289,9 +383,9 @@ const FirehoseFeed: React.FC = () => {
               pipeline runs every 6 hours — check back soon.
             </p>
           </div>
-        ) : filteredUniqueApps.length === 0 ? (
+        ) : timeline.length === 0 ? (
           <div className={styles.emptyState}>
-            <p>No apps match the current filters.</p>
+            <p>No items match the current filters.</p>
             <button
               className={styles.clearFiltersBtn}
               onClick={() => setFilters(DEFAULT_FILTERS)}
@@ -300,9 +394,13 @@ const FirehoseFeed: React.FC = () => {
             </button>
           </div>
         ) : (
-          filteredUniqueApps.map(({ app }) => (
-            <FirehoseCard key={app.id} app={app} />
-          ))
+          timeline.map((event) =>
+            event.kind === "os" ? (
+              <OsReleaseCard key={`os-${event.release.tag}`} event={event} />
+            ) : (
+              <FirehoseCard key={event.app.id} app={event.app} />
+            ),
+          )
         )}
       </main>
     </div>

--- a/src/components/FirehoseFilters.tsx
+++ b/src/components/FirehoseFilters.tsx
@@ -67,6 +67,7 @@ const FirehoseFilters: React.FC<FirehoseFiltersProps> = ({
       updatedWithin: "all",
       verifiedOnly: false,
       unverifiedOnly: false,
+      showOsReleases: true,
     });
   }
 
@@ -170,6 +171,21 @@ const FirehoseFilters: React.FC<FirehoseFiltersProps> = ({
             </option>
           ))}
         </select>
+      </section>
+
+      {/* OS Releases toggle */}
+      <section className={styles.filterSection}>
+        <h3 className={styles.filterHeading}>OS Releases</h3>
+        <label className={styles.checkLabel}>
+          <input
+            type="checkbox"
+            checked={filters.showOsReleases}
+            onChange={(e) =>
+              onFiltersChange({ ...filters, showOsReleases: e.target.checked })
+            }
+          />
+          <span>Show OS releases</span>
+        </label>
       </section>
     </aside>
   );

--- a/src/components/OsReleaseCard.module.css
+++ b/src/components/OsReleaseCard.module.css
@@ -1,0 +1,435 @@
+/* ── Card shell ─────────────────────────────────────────────────────────────── */
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: var(--ifm-background-color);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+  transition: box-shadow 0.2s;
+}
+
+.card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Mascot art (::after pseudo, matching ImagesCatalog pattern) ── */
+
+.cardStable::after,
+.cardLts::after {
+  content: "";
+  position: absolute;
+  right: 1rem;
+  top: 0.75rem;
+  width: 120px;
+  height: 120px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: right top;
+  pointer-events: none;
+  opacity: 0.35;
+}
+
+.cardStable::after {
+  background-image: url("/img/characters/bluefin-small.webp");
+}
+
+.cardLts::after {
+  background-image: url("/img/characters/achillobator.webp");
+}
+
+/* ── Stream accent borders ── */
+
+.cardStable {
+  border-left: 3px solid var(--ifm-color-primary);
+}
+
+.cardLts {
+  border-left: 3px solid #d97706;
+}
+
+/* ── Header ────────────────────────────────────────────────────────────────── */
+
+.cardHeader {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 0.75rem;
+  /* Leave room for mascot art on the right */
+  padding-right: 130px;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.cardTitle {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  margin: 0;
+  line-height: 1.2;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.releaseTag {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.releaseDate {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* ── Stream badge ────────────────────────────────────────────────────────────── */
+
+.streamBadge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.badgeStable {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.badgeLts {
+  background: rgba(217, 119, 6, 0.15);
+  color: #b45309;
+  border: 1px solid rgba(217, 119, 6, 0.35);
+}
+
+/* ── Base version chip (Fedora / CentOS) ─────────────────────────────────────── */
+
+.baseChip {
+  font-size: 0.74rem;
+  color: var(--ifm-color-emphasis-600);
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 4px;
+  padding: 0.1rem 0.45rem;
+}
+
+/* ── Package version chips ───────────────────────────────────────────────────── */
+
+.chipsRow {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.6rem;
+}
+
+.dxRow {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.75rem;
+}
+
+.dxLabel {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600);
+  flex-shrink: 0;
+}
+
+.versionChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.8rem;
+}
+
+.chipChanged {
+  background: rgba(234, 179, 8, 0.1);
+  border-color: rgba(234, 179, 8, 0.4);
+}
+
+.chipLabel {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.chipValue {
+  color: var(--ifm-color-emphasis-900);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+}
+
+.chipUpdated {
+  font-size: 0.7rem;
+  color: #d97706;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* ── Collapsible toggle ──────────────────────────────────────────────────────── */
+
+.collapsible {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 0.4rem;
+}
+
+.collapsibleToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.collapsibleToggle:hover {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-emphasis-400);
+  color: var(--ifm-color-emphasis-900);
+}
+
+.chevron {
+  font-size: 0.75rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.collapsiblePanel {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: var(--ifm-background-surface-color, var(--ifm-color-emphasis-50));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+/* ── Package diff ────────────────────────────────────────────────────────────── */
+
+.diffSection {
+  font-size: 0.82rem;
+}
+
+.diffGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.76rem;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0.6rem 0 0.3rem;
+}
+
+.diffGroupHeader:first-child {
+  margin-top: 0;
+}
+
+.diffRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.18rem 0.4rem;
+  border-radius: 3px;
+  margin-bottom: 0.08rem;
+}
+
+.diffAdded {
+  background: rgba(34, 197, 94, 0.07);
+}
+
+.diffChanged {
+  background: rgba(234, 179, 8, 0.07);
+}
+
+.diffRemoved {
+  background: rgba(239, 68, 68, 0.07);
+}
+
+.diffName {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-800);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diffVersion {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+  flex-shrink: 0;
+}
+
+.diffVersionChange {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.prevVersion {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+  text-decoration: line-through;
+}
+
+.versionArrow {
+  color: var(--ifm-color-emphasis-400);
+  font-size: 0.7rem;
+}
+
+.newVersion {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  color: #15803d;
+}
+
+/* ── Commits ─────────────────────────────────────────────────────────────────── */
+
+.commitsSection {
+  font-size: 0.82rem;
+}
+
+.commitRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.commitRow:last-child {
+  border-bottom: none;
+}
+
+.commitHash {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  color: var(--ifm-color-primary);
+  flex-shrink: 0;
+  min-width: 56px;
+}
+
+.commitHash a {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.commitHash a:hover {
+  text-decoration: underline;
+}
+
+.commitSubject {
+  flex: 1;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commitAuthor {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+  flex-shrink: 0;
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────────── */
+
+.cardFooter {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.6rem;
+  margin-top: 0.6rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.viewLink {
+  font-size: 0.85rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.viewLink:hover {
+  text-decoration: underline;
+}
+
+/* ── Shared ──────────────────────────────────────────────────────────────────── */
+
+.emptyNote {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
+  margin: 0;
+  font-style: italic;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .card {
+    padding: 1rem;
+  }
+
+  .cardHeader {
+    padding-right: 80px;
+  }
+
+  .cardStable::after,
+  .cardLts::after {
+    width: 70px;
+    height: 70px;
+    opacity: 0.25;
+  }
+
+  .commitSubject {
+    white-space: normal;
+  }
+
+  .chipsRow,
+  .dxRow {
+    gap: 0.35rem;
+  }
+}

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -1,0 +1,281 @@
+import React, { useState } from "react";
+import type {
+  OsReleaseEvent,
+  ParsedMajorPackage,
+  ParsedCommit,
+  ParsedDiffEntry,
+} from "../types/os-feed";
+import styles from "./OsReleaseCard.module.css";
+
+// ── Date formatting ───────────────────────────────────────────────────────────
+
+function formatDate(dateMs: number): string {
+  const d = new Date(dateMs);
+  if (isNaN(d.getTime())) return "";
+  // UTC to avoid SSR/hydration mismatch from local timezone offsets
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+// ── Collapsible ───────────────────────────────────────────────────────────────
+
+interface CollapsibleProps {
+  id: string;
+  label: string;
+  children: React.ReactNode;
+}
+
+function Collapsible({ id, label, children }: CollapsibleProps) {
+  const [open, setOpen] = useState(false);
+  const panelId = `${id}-panel`;
+  return (
+    <div className={styles.collapsible}>
+      <button
+        type="button"
+        className={styles.collapsibleToggle}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
+        <span className={styles.chevron} aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        {label}
+      </button>
+      {open && (
+        <div id={panelId} className={styles.collapsiblePanel}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Package diff section ──────────────────────────────────────────────────────
+
+function PackageDiffSection({ fullDiff }: { fullDiff: ParsedDiffEntry[] }) {
+  if (fullDiff.length === 0) {
+    return <p className={styles.emptyNote}>No package diff available.</p>;
+  }
+
+  const added = fullDiff.filter((e) => e.indicator === "added");
+  const changed = fullDiff.filter((e) => e.indicator === "changed");
+  const removed = fullDiff.filter((e) => e.indicator === "removed");
+
+  return (
+    <div className={styles.diffSection}>
+      {added.length > 0 && (
+        <>
+          <div className={styles.diffGroupHeader}>
+            <span aria-hidden="true">✨</span> Added ({added.length})
+          </div>
+          {added.map((e) => (
+            <div key={e.name} className={`${styles.diffRow} ${styles.diffAdded}`}>
+              <span className={styles.diffName}>{e.name}</span>
+              <span className={styles.diffVersion}>{e.newVersion}</span>
+            </div>
+          ))}
+        </>
+      )}
+      {changed.length > 0 && (
+        <>
+          <div className={styles.diffGroupHeader}>
+            <span aria-hidden="true">🔄</span> Updated ({changed.length})
+          </div>
+          {changed.map((e) => (
+            <div key={e.name} className={`${styles.diffRow} ${styles.diffChanged}`}>
+              <span className={styles.diffName}>{e.name}</span>
+              <span className={styles.diffVersionChange}>
+                <span className={styles.prevVersion}>{e.prevVersion}</span>
+                <span className={styles.versionArrow} aria-hidden="true">→</span>
+                <span className={styles.newVersion}>{e.newVersion}</span>
+              </span>
+            </div>
+          ))}
+        </>
+      )}
+      {removed.length > 0 && (
+        <>
+          <div className={styles.diffGroupHeader}>
+            <span aria-hidden="true">❌</span> Removed ({removed.length})
+          </div>
+          {removed.map((e) => (
+            <div key={e.name} className={`${styles.diffRow} ${styles.diffRemoved}`}>
+              <span className={styles.diffName}>{e.name}</span>
+              <span className={styles.diffVersion}>{e.prevVersion}</span>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Commits section ───────────────────────────────────────────────────────────
+
+function CommitsSection({ commits }: { commits: ParsedCommit[] }) {
+  if (commits.length === 0) {
+    return <p className={styles.emptyNote}>No commits listed.</p>;
+  }
+  return (
+    <div className={styles.commitsSection}>
+      {commits.map((c) => (
+        <div key={`${c.hash}-${c.subject.slice(0, 20)}`} className={styles.commitRow}>
+          <span className={styles.commitHash}>
+            {c.url ? (
+              <a href={c.url} target="_blank" rel="noopener noreferrer">
+                {c.hash}
+              </a>
+            ) : (
+              c.hash
+            )}
+          </span>
+          <span className={styles.commitSubject}>{c.subject}</span>
+          {c.author && <span className={styles.commitAuthor}>{c.author}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Version chip ──────────────────────────────────────────────────────────────
+
+function VersionChip({ pkg }: { pkg: ParsedMajorPackage }) {
+  const changed = Boolean(pkg.prevVersion);
+  return (
+    <span
+      className={`${styles.versionChip} ${changed ? styles.chipChanged : ""}`}
+      title={changed ? `Previously: ${pkg.prevVersion}` : undefined}
+    >
+      <span className={styles.chipLabel}>{pkg.name}</span>
+      <span className={styles.chipValue}>{pkg.version}</span>
+      {changed && (
+        <span className={styles.chipUpdated} aria-label="updated">
+          ↑
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ── Chip labels we surface in the header chips row ────────────────────────────
+
+const HEADER_CHIP_NAMES = ["Kernel", "Gnome", "Mesa", "Podman", "Nvidia"];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface OsReleaseCardProps {
+  event: OsReleaseEvent;
+}
+
+const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
+  const { release, dateMs, stream } = event;
+  const isLts = stream === "lts";
+  const streamLabel = isLts ? "LTS" : "Stable";
+  const cardClass = `${styles.card} ${isLts ? styles.cardLts : styles.cardStable}`;
+
+  // Key package chips (header row): subset of well-known packages
+  const headerChips = HEADER_CHIP_NAMES.flatMap((name) => {
+    const pkg = release.majorPackages.find(
+      (p) => p.name.toLowerCase() === name.toLowerCase(),
+    );
+    return pkg ? [pkg] : [];
+  });
+
+  // Diff summary for collapsible label
+  const addedCount = release.fullDiff.filter((e) => e.indicator === "added").length;
+  const changedCount = release.fullDiff.filter((e) => e.indicator === "changed").length;
+  const removedCount = release.fullDiff.filter((e) => e.indicator === "removed").length;
+  const diffParts: string[] = [];
+  if (changedCount > 0) diffParts.push(`${changedCount} updated`);
+  if (addedCount > 0) diffParts.push(`${addedCount} added`);
+  if (removedCount > 0) diffParts.push(`${removedCount} removed`);
+  const diffSummary = diffParts.join(" · ");
+
+  const cardId = `os-release-${release.tag}`;
+
+  return (
+    <article
+      className={cardClass}
+      aria-label={`${streamLabel} OS release ${release.tag}`}
+    >
+      {/* ── Header ── */}
+      <div className={styles.cardHeader}>
+        <div className={styles.titleRow}>
+          <span
+            className={`${styles.streamBadge} ${isLts ? styles.badgeLts : styles.badgeStable}`}
+          >
+            {streamLabel}
+          </span>
+          <h2 className={styles.cardTitle}>Bluefin</h2>
+        </div>
+
+        <div className={styles.metaRow}>
+          <span className={styles.releaseTag}>{release.tag}</span>
+          <span className={styles.releaseDate}>{formatDate(dateMs)}</span>
+          {release.fedoraVersion && (
+            <span className={styles.baseChip}>Fedora {release.fedoraVersion}</span>
+          )}
+          {release.centosVersion && (
+            <span className={styles.baseChip}>CentOS {release.centosVersion}</span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Key package version chips ── */}
+      {headerChips.length > 0 && (
+        <div className={styles.chipsRow}>
+          {headerChips.map((pkg) => (
+            <VersionChip key={pkg.name} pkg={pkg} />
+          ))}
+        </div>
+      )}
+
+      {/* ── DX packages ── */}
+      {release.dxPackages.length > 0 && (
+        <div className={styles.dxRow}>
+          <span className={styles.dxLabel}>DX</span>
+          {release.dxPackages.map((pkg) => (
+            <VersionChip key={pkg.name} pkg={pkg} />
+          ))}
+        </div>
+      )}
+
+      {/* ── Collapsible: package diff ── */}
+      {release.fullDiff.length > 0 && (
+        <Collapsible
+          id={`${cardId}-diff`}
+          label={`Package changes${diffSummary ? ` — ${diffSummary}` : ""}`}
+        >
+          <PackageDiffSection fullDiff={release.fullDiff} />
+        </Collapsible>
+      )}
+
+      {/* ── Collapsible: commits ── */}
+      <Collapsible
+        id={`${cardId}-commits`}
+        label={`Commits${release.commits.length > 0 ? ` (${release.commits.length})` : ""}`}
+      >
+        <CommitsSection commits={release.commits} />
+      </Collapsible>
+
+      {/* ── Footer ── */}
+      <div className={styles.cardFooter}>
+        <a
+          href={release.githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.viewLink}
+        >
+          View on GitHub →
+        </a>
+      </div>
+    </article>
+  );
+};
+
+export default OsReleaseCard;

--- a/src/types/firehose.ts
+++ b/src/types/firehose.ts
@@ -127,4 +127,6 @@ export interface FirehoseFilterState {
   updatedWithin: "all" | "1d" | "7d" | "30d" | "90d";
   verifiedOnly: boolean;
   unverifiedOnly: boolean;
+  /** Whether to show OS release cards in the timeline. Defaults to true. */
+  showOsReleases: boolean;
 }

--- a/src/types/os-feed.ts
+++ b/src/types/os-feed.ts
@@ -1,0 +1,119 @@
+/**
+ * Types for OS release feed data.
+ *
+ * Raw feed data lives in:
+ *   static/feeds/bluefin-releases.json     (stable stream)
+ *   static/feeds/bluefin-lts-releases.json (lts stream)
+ *
+ * GTS (Good Till September) was a retired stream. gts-prefixed entries may
+ * appear in the stable feed as historical records — they are skipped by the
+ * parser. Tracked for cleanup in castrojo/documentation issue 68.
+ */
+
+import type { FirehoseApp } from "./firehose";
+
+// ── Raw feed shape ────────────────────────────────────────────────────────────
+
+/** One item from the GitHub Releases RSS-to-JSON feed. */
+export interface OsFeedItem {
+  title: string;
+  link: string;
+  pubDate: string; // ISO 8601
+  contentSnippet: string;
+  content: string; // HTML — contains structured tables for packages and commits
+}
+
+export interface OsFeedData {
+  title: string;
+  items: OsFeedItem[];
+}
+
+// ── Parsed structures ─────────────────────────────────────────────────────────
+
+/** The two active Bluefin release streams. GTS is retired — skipped in parser. */
+export type OsStream = "stable" | "lts";
+
+/**
+ * A package entry from the "Major packages" or "Major DX packages" section.
+ * prevVersion is set when the version cell contains "old ➡️ new" (a changed package).
+ * prevVersion is null when the package version is listed without an arrow (unchanged or new).
+ */
+export interface ParsedMajorPackage {
+  name: string;
+  /** Current version. */
+  version: string;
+  /** Previous version, present only when the cell shows "prev ➡️ current". */
+  prevVersion: string | null;
+}
+
+/** A commit entry from the "Commits" table. Author is absent in LTS 2-column tables. */
+export interface ParsedCommit {
+  hash: string;
+  /** Full GitHub commit URL (https://github.com/... only). Null if not found. */
+  url: string | null;
+  /** Plain-text commit subject (HTML stripped). */
+  subject: string;
+  /** Commit author name. Null in LTS feed (2-column table format). */
+  author: string | null;
+}
+
+/**
+ * One entry from the full package diff tables ("All Images", "Base Images",
+ * "Dev Experience Images"). These use emoji indicators in the first column.
+ */
+export interface ParsedDiffEntry {
+  indicator: "added" | "changed" | "removed";
+  name: string;
+  prevVersion: string | null;
+  newVersion: string | null;
+}
+
+/** All structured data parsed from a single OsFeedItem. */
+export interface ParsedOsRelease {
+  stream: OsStream;
+  /** Release tag, e.g. "stable-20260331" or "lts-20251223". */
+  tag: string;
+  /** URL to the GitHub release page. */
+  githubUrl: string;
+  /** Fedora base version, e.g. "43". Null for LTS (CentOS base). */
+  fedoraVersion: string | null;
+  /** CentOS base version, e.g. "c10s". Null for stable (Fedora base). */
+  centosVersion: string | null;
+  /** Entries from the "Major packages" table. */
+  majorPackages: ParsedMajorPackage[];
+  /** Entries from the "Major DX packages" (or "Major GDX packages") table. */
+  dxPackages: ParsedMajorPackage[];
+  /** Commit list. Empty array if no commits section is present. */
+  commits: ParsedCommit[];
+  /**
+   * Merged full package diff from all 4-column diff tables
+   * ("All Images", "Base Images", "Dev Experience Images").
+   */
+  fullDiff: ParsedDiffEntry[];
+}
+
+// ── Timeline event types ──────────────────────────────────────────────────────
+
+/**
+ * A timeline event representing one OS release.
+ * kind: "os" discriminant enables exhaustive narrowing with AppTimelineEvent.
+ */
+export interface OsReleaseEvent {
+  kind: "os";
+  stream: OsStream;
+  dateMs: number;
+  release: ParsedOsRelease;
+}
+
+/**
+ * A timeline event wrapping a Firehose app (one card per app, most recent release).
+ * kind: "app" discriminant enables exhaustive narrowing with OsReleaseEvent.
+ */
+export interface AppTimelineEvent {
+  kind: "app";
+  dateMs: number;
+  app: FirehoseApp;
+}
+
+/** Discriminated union for the unified Firehose + OS release timeline. */
+export type FlatTimelineEvent = AppTimelineEvent | OsReleaseEvent;

--- a/src/types/os-feeds.d.ts
+++ b/src/types/os-feeds.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Ambient module declarations for OS release feed JSON files.
+ *
+ * These files live in static/feeds/ and are committed to the repo
+ * (unlike gitignored data/ files). The declarations are needed because
+ * Docusaurus uses @site path aliases which TypeScript does not resolve
+ * without explicit module declarations.
+ */
+
+declare module "@site/static/feeds/bluefin-releases.json" {
+  import type { OsFeedData } from "@site/src/types/os-feed";
+  const data: OsFeedData;
+  export default data;
+}
+
+declare module "@site/static/feeds/bluefin-lts-releases.json" {
+  import type { OsFeedData } from "@site/src/types/os-feed";
+  const data: OsFeedData;
+  export default data;
+}

--- a/src/utils/parseOsRelease.ts
+++ b/src/utils/parseOsRelease.ts
@@ -1,0 +1,280 @@
+/**
+ * Parser for OS release feed HTML content.
+ *
+ * Each item in static/feeds/bluefin-releases.json and
+ * static/feeds/bluefin-lts-releases.json contains a `content` field with
+ * machine-generated HTML. This module parses that HTML into structured data
+ * using regex, avoiding a full DOM parser (no new dependencies).
+ *
+ * GTS (Good Till September) is a retired stream. Items with gts- prefixed
+ * titles are skipped (return null). Cleanup tracked in castrojo/documentation
+ * issue 68.
+ */
+
+import type {
+  OsFeedItem,
+  OsStream,
+  ParsedMajorPackage,
+  ParsedCommit,
+  ParsedDiffEntry,
+  ParsedOsRelease,
+} from "../types/os-feed";
+
+// ── HTML utilities ────────────────────────────────────────────────────────────
+
+/** Strip HTML tags and decode basic entities to plain text. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+// ── Stream detection ──────────────────────────────────────────────────────────
+
+/** Returns true for retired GTS release entries. */
+function isGtsItem(title: string): boolean {
+  return /^gts-/i.test(title.trim());
+}
+
+/**
+ * Detect the release stream from the item title.
+ * Returns null for retired GTS items or unrecognized title formats.
+ */
+function detectStream(title: string): OsStream | null {
+  if (isGtsItem(title)) return null;
+  if (/^lts[.-]/i.test(title) || /\bLTS:/i.test(title)) return "lts";
+  if (/^(stable|beta|latest)-/i.test(title)) return "stable";
+  return null;
+}
+
+// ── Metadata extraction ───────────────────────────────────────────────────────
+
+/** Extract Fedora base version from title, e.g. "(F43.20260331, ...)" → "43". */
+function extractFedoraVersion(title: string): string | null {
+  const m = title.match(/\(F(\d+)\./);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract CentOS base version from title, e.g. "(c10s, #...)" → "c10s".
+ * Present in LTS releases (CentOS Stream base).
+ */
+function extractCentosVersion(title: string): string | null {
+  const m = title.match(/\(([a-z0-9]+s),\s*#/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract the release tag from the title.
+ * Examples:
+ *   "stable-20260331: Stable (...)"   → "stable-20260331"
+ *   "bluefin-lts LTS: 20251223 (...)" → "lts-20251223"
+ *   "lts.20251223: ..."               → "lts-20251223"
+ */
+function extractTag(title: string, stream: OsStream): string {
+  // Standard prefix format: "stable-YYYYMMDD:", "lts-YYYYMMDD:", "lts.YYYYMMDD:"
+  const prefixMatch = title.match(/^([a-z]+-[\d.]+)/i);
+  if (prefixMatch) {
+    return prefixMatch[1].toLowerCase().replace(/^lts\.(\d{8})$/, "lts-$1");
+  }
+  // LTS alternative format: "bluefin-lts LTS: YYYYMMDD (...)"
+  const ltsAltMatch = title.match(/LTS:\s*(\d{8})/i);
+  if (ltsAltMatch) return `lts-${ltsAltMatch[1]}`;
+  return stream;
+}
+
+// ── Section extraction ────────────────────────────────────────────────────────
+
+/**
+ * Extract named sections from the release HTML.
+ * The feed HTML is structured as: <h3>Heading</h3><table>...</table> blocks.
+ * Returns a Map of section heading text → table HTML string.
+ *
+ * Table count per item varies (5–6 tables). This approach identifies each
+ * table by its preceding heading rather than by position index.
+ */
+function extractSections(html: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const sectionRe = /<h3[^>]*>([\s\S]*?)<\/h3>\s*(<table[\s\S]*?<\/table>)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = sectionRe.exec(html)) !== null) {
+    const heading = stripHtml(m[1]);
+    sections.set(heading, m[2]);
+  }
+  return sections;
+}
+
+// ── Table parsers ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a 2-column [Name, Version] table into major package entries.
+ * Version cells may contain "old ➡️ new" for changed packages.
+ * The ➡️ split uses a tolerant regex to handle Unicode/spacing variants.
+ */
+function parseTwoColTable(tableHtml: string): ParsedMajorPackage[] {
+  const results: ParsedMajorPackage[] = [];
+  const rowRe = /<tr>\s*<td[^>]*>([\s\S]*?)<\/td>\s*<td[^>]*>([\s\S]*?)<\/td>\s*<\/tr>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(tableHtml)) !== null) {
+    const name = stripHtml(m[1]);
+    if (!name || name === "Name") continue;
+    const versionRaw = stripHtml(m[2]);
+    // Tolerant split on ➡️ with optional surrounding whitespace
+    const parts = versionRaw.split(/\s*➡️?\s*/u).map((s) => s.trim());
+    if (parts.length >= 2 && parts[0] && parts[parts.length - 1]) {
+      results.push({
+        name,
+        version: parts[parts.length - 1],
+        prevVersion: parts[0],
+      });
+    } else {
+      results.push({ name, version: versionRaw, prevVersion: null });
+    }
+  }
+  return results;
+}
+
+/**
+ * Parse the Commits table.
+ * Stable feed: 3 columns [Hash, Subject, Author].
+ * LTS feed: 2 columns [Hash, Subject] — author is optional.
+ *
+ * Commit href URLs are allow-listed to https://github.com/ only.
+ */
+function parseCommitsTable(tableHtml: string): ParsedCommit[] {
+  const results: ParsedCommit[] = [];
+  const rowRe = /<tr>([\s\S]*?)<\/tr>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(tableHtml)) !== null) {
+    const rowInner = m[1];
+    const cells: string[] = [];
+    const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+    let cm: RegExpExecArray | null;
+    while ((cm = cellRe.exec(rowInner)) !== null) {
+      cells.push(cm[1]);
+    }
+    if (cells.length < 2) continue;
+
+    // Hash cell: extract short hash text and GitHub commit URL (allow-listed)
+    const hashHtml = cells[0];
+    const urlMatch = hashHtml.match(/href="(https:\/\/github\.com\/[^"]+)"/i);
+    const url = urlMatch ? urlMatch[1] : null;
+    const hash = stripHtml(hashHtml).trim();
+    if (!hash || hash === "Hash") continue;
+
+    const subject = stripHtml(cells[1]).trim();
+    if (!subject) continue;
+
+    const author = cells[2] ? stripHtml(cells[2]).trim() || null : null;
+
+    results.push({ hash, url, subject, author });
+  }
+  return results;
+}
+
+/**
+ * Parse a 4-column [emoji, Name, Previous, New] full package diff table.
+ * Emoji indicators: ✨ = added, 🔄 = changed, ❌ = removed.
+ * Indicator falls back to presence/absence of version fields.
+ */
+function parseFourColDiffTable(tableHtml: string): ParsedDiffEntry[] {
+  const results: ParsedDiffEntry[] = [];
+  const rowRe = /<tr>([\s\S]*?)<\/tr>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(tableHtml)) !== null) {
+    const rowInner = m[1];
+    const cells: string[] = [];
+    const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+    let cm: RegExpExecArray | null;
+    while ((cm = cellRe.exec(rowInner)) !== null) {
+      cells.push(cm[1]);
+    }
+    if (cells.length < 4) continue;
+
+    const emojiText = stripHtml(cells[0]).trim();
+    const name = stripHtml(cells[1]).trim();
+    if (!name || name === "Name") continue;
+
+    const prevVersion = stripHtml(cells[2]).trim() || null;
+    const newVersion = stripHtml(cells[3]).trim() || null;
+
+    let indicator: ParsedDiffEntry["indicator"] = "changed";
+    if (emojiText.includes("✨") || (!prevVersion && newVersion)) {
+      indicator = "added";
+    } else if (emojiText.includes("❌") || (prevVersion && !newVersion)) {
+      indicator = "removed";
+    }
+
+    results.push({ indicator, name, prevVersion, newVersion });
+  }
+  return results;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a single OS feed item into a structured ParsedOsRelease.
+ *
+ * Returns null if:
+ *  - The item is a retired GTS release (title starts with "gts-").
+ *  - The stream cannot be detected from the title.
+ *  - The HTML contains no major packages AND no full diff entries
+ *    (structural failure — the release is not useful to display).
+ *
+ * Missing sections produce empty arrays, not null.
+ *
+ * @param item       Raw feed item.
+ * @param streamHint Override stream detection — pass when the source file
+ *                   already identifies the stream (e.g. "lts" for items from
+ *                   bluefin-lts-releases.json).
+ */
+export function parseOsRelease(
+  item: OsFeedItem,
+  streamHint?: OsStream,
+): ParsedOsRelease | null {
+  const stream = streamHint ?? detectStream(item.title);
+  if (!stream) return null;
+
+  const sections = extractSections(item.content);
+
+  const majorPackages = parseTwoColTable(sections.get("Major packages") ?? "");
+
+  const dxTableHtml =
+    sections.get("Major DX packages") ??
+    sections.get("Major GDX packages") ??
+    "";
+  const dxPackages = parseTwoColTable(dxTableHtml);
+
+  const commitsHtml = sections.get("Commits") ?? "";
+  const commits = commitsHtml ? parseCommitsTable(commitsHtml) : [];
+
+  const fullDiffSectionNames = ["All Images", "Base Images", "Dev Experience Images"];
+  const fullDiff: ParsedDiffEntry[] = [];
+  for (const heading of fullDiffSectionNames) {
+    const tableHtml = sections.get(heading);
+    if (tableHtml) {
+      fullDiff.push(...parseFourColDiffTable(tableHtml));
+    }
+  }
+
+  if (majorPackages.length === 0 && fullDiff.length === 0) return null;
+
+  const tag = extractTag(item.title, stream);
+
+  return {
+    stream,
+    tag,
+    githubUrl: item.link,
+    fedoraVersion: extractFedoraVersion(item.title),
+    centosVersion: extractCentosVersion(item.title),
+    majorPackages,
+    dxPackages,
+    commits,
+    fullDiff,
+  };
+}


### PR DESCRIPTION
- Parse bluefin-releases.json and bluefin-lts-releases.json at module scope into OsReleaseEvent[] — stable and LTS streams interleaved chronologically with app release events
- New OsReleaseCard component: mascot art, version chip, stream badge, collapsible major packages diff, commits section — styled to match ImagesCatalog visual language
- FirehoseFeed render loop restructured: UniqueApp[] + OsReleaseEvent[] merged into FlatTimelineEvent[] sorted by dateMs; OS cards use OsReleaseCard, app cards continue using FirehoseCard
- FirehoseFilters: 'Show OS releases' checkbox toggle
- FirehoseFilterState: showOsReleases boolean (default true)
- Statistics panel shows OS release count
- osHiddenNotice when date filter hides OS events
- GTS entries skipped in parser (stream retired, issue #68 tracks cleanup)
- Typecheck: 0 errors. Build: success (all warnings pre-existing)

Closes #68 related work

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot