### PR TITLE
fix(images): force per-product refresh on every build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,8 +71,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           # Always re-fetch image metadata on every build so hasAttestation,
-          # versions, and security info stay current.
+          # versions, and security info stay current. IMAGES_REFRESH_HOURS: "0"
+          # forces the per-product inner cache to also refresh (it defaults to
+          # 336h and would otherwise serve stale nvidia tag data from GHA cache).
           IMAGES_CACHE_HOURS: "0"
+          IMAGES_REFRESH_HOURS: "0"
           # Always re-fetch driver versions on every build so GNOME/kernel/mesa
           # versions stay current. The data is small (GitHub API call) and the
           # script's internal 168h TTL would otherwise serve stale cached data.


### PR DESCRIPTION
IMAGES_CACHE_HOURS: "0" bypasses the outer file-age check in fetch-github-images.js, but the inner per-product shouldRefresh check uses REFRESH_HOURS (default 336h). When actions/cache restores images.json, its mtime is "now" (~0h old), so shouldRefresh evaluates to false and cached product data is returned without re-fetching nvidia tags from GHCR.

The nvidia beta tag (bluefin-nvidia-open:beta) was published 2026-04-03 but every build since has returned the stale cache entry with nvidiaCommand: null because per-product data was never re-fetched.

Setting IMAGES_REFRESH_HOURS: "0" ensures ageHours (≈0) >= 0 is always true, so every product is re-fetched on every build.