### PR TITLE
feat(changelogs): unified OS releases stream with stable-daily, LTS, …

### DIFF
--- a/scripts/fetch-feeds.js
+++ b/scripts/fetch-feeds.js
@@ -2,12 +2,20 @@ const fs = require("fs");
 const path = require("path");
 
 /**
- * Fetch releases from the GitHub Releases API (paginated).
- * Falls back to the Atom feed if the API is unavailable or token is missing.
- *
- * Uses up to 100 releases per repo (covers ~3 months of daily + weekly releases).
- * Atom feed was limited to ~10 items, which caused stable releases to be pushed
- * out of the feed when daily releases dominated.
+ * Parse the `Link` response header and return the URL for rel="next", or null.
+ * Example header: <https://api.github.com/...?page=2>; rel="next", <...>; rel="last"
+ */
+function parseLinkNext(linkHeader) {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Fetch releases from the GitHub Releases API with full pagination.
+ * Follows Link rel="next" headers until all pages are retrieved or the
+ * MAX_RELEASES cap is reached. Falls back to the Atom feed if the API is
+ * unavailable or token is missing.
  */
 async function fetchReleasesFromApi(owner, repo) {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
@@ -17,27 +25,36 @@ async function fetchReleasesFromApi(owner, repo) {
   }
 
   const fetch = (await import("node-fetch")).default;
-  const perPage = 100;
-  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${perPage}`;
+  const MAX_RELEASES = 500;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
 
-  console.log(`Fetching releases API: ${url}`);
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
+  let allReleases = [];
+  let nextUrl = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
 
-  if (!response.ok) {
-    console.warn(`GitHub API returned ${response.status} for ${owner}/${repo} — falling back to Atom`);
-    return null;
+  while (nextUrl && allReleases.length < MAX_RELEASES) {
+    console.log(`Fetching releases API: ${nextUrl}`);
+    const response = await fetch(nextUrl, { headers });
+
+    if (!response.ok) {
+      console.warn(`GitHub API returned ${response.status} for ${owner}/${repo} — falling back to Atom`);
+      return null;
+    }
+
+    const page = await response.json();
+    allReleases = allReleases.concat(page);
+    nextUrl = parseLinkNext(response.headers.get("link"));
   }
 
-  const releases = await response.json();
+  if (allReleases.length >= MAX_RELEASES) {
+    console.warn(`${owner}/${repo}: reached ${MAX_RELEASES}-release cap — some older releases may be omitted`);
+  }
 
   // Map GitHub API response to the same OsFeedItem shape used by the parsers
-  return releases
+  return allReleases
     .filter((r) => !r.draft)
     .map((r) => ({
       title: r.tag_name ?? "Unknown Release",

--- a/scripts/fetch-feeds.js
+++ b/scripts/fetch-feeds.js
@@ -1,109 +1,168 @@
 const fs = require("fs");
 const path = require("path");
-const { parseString } = require("xml2js");
 
-async function fetchAndParseFeed(url, filename) {
-  try {
-    const fetch = (await import("node-fetch")).default;
-    console.log(`Fetching ${url}...`);
-
-    const response = await fetch(url);
-    const xmlText = await response.text();
-
-    // Parse XML to JSON
-    return new Promise((resolve, reject) => {
-      parseString(xmlText, (err, result) => {
-        if (err) {
-          console.error(`Error parsing XML from ${url}:`, err);
-          reject(err);
-          return;
-        }
-
-        // Extract feed entries and convert to simple format
-        const feed = result.feed;
-        const entries = feed.entry || [];
-
-        const releases = entries.map((entry) => {
-          // Find the HTML link
-          let link = "#";
-          if (entry.link && Array.isArray(entry.link)) {
-            const htmlLink = entry.link.find(
-              (l) => l.$ && l.$.type === "text/html",
-            );
-            link = htmlLink ? htmlLink.$.href : entry.link[0].$.href;
-          }
-
-          // Handle content safely
-          let content = "";
-          let contentSnippet = "";
-          if (
-            entry.content &&
-            Array.isArray(entry.content) &&
-            entry.content[0]
-          ) {
-            if (typeof entry.content[0] === "string") {
-              content = entry.content[0];
-              contentSnippet = content.substring(0, 200) + "...";
-            } else if (
-              entry.content[0]._ &&
-              typeof entry.content[0]._ === "string"
-            ) {
-              content = entry.content[0]._;
-              contentSnippet = content.substring(0, 200) + "...";
-            }
-          }
-
-          return {
-            title: entry.title ? entry.title[0] : "Unknown Release",
-            link,
-            pubDate: entry.updated ? entry.updated[0] : "",
-            contentSnippet,
-            content,
-          };
-        });
-
-        const feedsDir = path.join(__dirname, "..", "static", "feeds");
-        if (!fs.existsSync(feedsDir)) {
-          fs.mkdirSync(feedsDir, { recursive: true });
-        }
-
-        // Save as JSON
-        const jsonPath = path.join(feedsDir, filename.replace(".xml", ".json"));
-        fs.writeFileSync(
-          jsonPath,
-          JSON.stringify(
-            {
-              title: feed.title ? feed.title[0] : "Releases",
-              items: releases,
-            },
-            null,
-            2,
-          ),
-        );
-
-        console.log(`Converted and saved to ${jsonPath}`);
-        resolve(releases);
-      });
-    });
-  } catch (error) {
-    console.error(`Error fetching ${url}:`, error);
+/**
+ * Fetch releases from the GitHub Releases API (paginated).
+ * Falls back to the Atom feed if the API is unavailable or token is missing.
+ *
+ * Uses up to 100 releases per repo (covers ~3 months of daily + weekly releases).
+ * Atom feed was limited to ~10 items, which caused stable releases to be pushed
+ * out of the feed when daily releases dominated.
+ */
+async function fetchReleasesFromApi(owner, repo) {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    console.warn(`No GITHUB_TOKEN — falling back to Atom feed for ${owner}/${repo}`);
     return null;
+  }
+
+  const fetch = (await import("node-fetch")).default;
+  const perPage = 100;
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${perPage}`;
+
+  console.log(`Fetching releases API: ${url}`);
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    console.warn(`GitHub API returned ${response.status} for ${owner}/${repo} — falling back to Atom`);
+    return null;
+  }
+
+  const releases = await response.json();
+
+  // Map GitHub API response to the same OsFeedItem shape used by the parsers
+  return releases
+    .filter((r) => !r.draft)
+    .map((r) => ({
+      title: r.tag_name ?? "Unknown Release",
+      link: r.html_url ?? "#",
+      pubDate: r.published_at ?? "",
+      contentSnippet: (r.body ?? "").substring(0, 200) + "...",
+      content: r.body ?? "",
+    }));
+}
+
+/**
+ * Fallback: fetch and parse the GitHub Atom XML feed.
+ * Limited to ~10 most recent releases.
+ */
+async function fetchReleasesFromAtom(owner, repo) {
+  const { parseString } = require("xml2js");
+  const fetch = (await import("node-fetch")).default;
+  const url = `https://github.com/${owner}/${repo}/releases.atom`;
+
+  console.log(`Fetching Atom feed: ${url}`);
+  const response = await fetch(url);
+  const xmlText = await response.text();
+
+  return new Promise((resolve, reject) => {
+    parseString(xmlText, (err, result) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const feed = result.feed;
+      const entries = feed.entry || [];
+
+      const releases = entries.map((entry) => {
+        let link = "#";
+        if (entry.link && Array.isArray(entry.link)) {
+          const htmlLink = entry.link.find(
+            (l) => l.$ && l.$.type === "text/html",
+          );
+          link = htmlLink ? htmlLink.$.href : entry.link[0].$.href;
+        }
+
+        let content = "";
+        let contentSnippet = "";
+        if (
+          entry.content &&
+          Array.isArray(entry.content) &&
+          entry.content[0]
+        ) {
+          if (typeof entry.content[0] === "string") {
+            content = entry.content[0];
+            contentSnippet = content.substring(0, 200) + "...";
+          } else if (
+            entry.content[0]._ &&
+            typeof entry.content[0]._ === "string"
+          ) {
+            content = entry.content[0]._;
+            contentSnippet = content.substring(0, 200) + "...";
+          }
+        }
+
+        return {
+          title: entry.title ? entry.title[0] : "Unknown Release",
+          link,
+          pubDate: entry.updated ? entry.updated[0] : "",
+          contentSnippet,
+          content,
+        };
+      });
+
+      resolve(releases);
+    });
+  });
+}
+
+async function fetchAndSaveFeed(owner, repo, filename) {
+  const feedsDir = path.join(__dirname, "..", "static", "feeds");
+  const jsonPath = path.join(feedsDir, filename);
+
+  // 24-hour file-mtime cache: skip if output is recent enough
+  if (fs.existsSync(jsonPath)) {
+    const stat = fs.statSync(jsonPath);
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs < 24 * 60 * 60 * 1000 && !process.argv.includes("--force")) {
+      console.log(`Cache hit: ${filename} (${Math.round(ageMs / 3600000)}h old) — skipping fetch`);
+      return;
+    }
+  }
+
+  try {
+    // Try GitHub API first; fall back to Atom feed
+    let items = await fetchReleasesFromApi(owner, repo);
+    if (!items) {
+      items = await fetchReleasesFromAtom(owner, repo);
+    }
+
+    if (!fs.existsSync(feedsDir)) {
+      fs.mkdirSync(feedsDir, { recursive: true });
+    }
+
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify(
+        {
+          title: `${owner}/${repo} Releases`,
+          items,
+        },
+        null,
+        2,
+      ),
+    );
+
+    console.log(`Saved ${items.length} releases to ${jsonPath}`);
+  } catch (error) {
+    console.error(`Error fetching ${owner}/${repo}:`, error);
   }
 }
 
 async function main() {
-  await fetchAndParseFeed(
-    "https://github.com/ublue-os/bluefin/releases.atom",
-    "bluefin-releases.xml",
-  );
-  await fetchAndParseFeed(
-    "https://github.com/ublue-os/bluefin-lts/releases.atom",
-    "bluefin-lts-releases.xml",
-  );
+  await fetchAndSaveFeed("ublue-os", "bluefin", "bluefin-releases.json");
+  await fetchAndSaveFeed("ublue-os", "bluefin-lts", "bluefin-lts-releases.json");
 }
 
 if (require.main === module) {
   main().catch(console.error);
 }
 
-module.exports = { fetchAndParseFeed };
+module.exports = { fetchAndSaveFeed };

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useMemo, useEffect } from "react";
+import Heading from "@theme/Heading";
 import firehoseData from "@site/static/data/firehose-apps.json";
 import bluefinReleasesData from "@site/static/feeds/bluefin-releases.json";
 import bluefinLtsReleasesData from "@site/static/feeds/bluefin-lts-releases.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
-import type { OsReleaseEvent, AppTimelineEvent } from "../types/os-feed";
+import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent } from "../types/os-feed";
 import { parseOsRelease } from "../utils/parseOsRelease";
 import FirehoseCard from "./FirehoseCard";
 import OsReleaseCard from "./OsReleaseCard";
@@ -28,29 +29,69 @@ export interface FlatRelease {
 
 // ── OS release events (parsed once at module scope) ───────────────────────────
 
+/**
+ * Parse all items from a feed into OsReleaseEvent[].
+ * streamHint overrides per-item stream detection (used for LTS feed which lacks
+ * stream-identifying prefixes on some historical entries).
+ */
 function loadOsEvents(
   feedData: typeof bluefinReleasesData,
-  stream: "stable" | "lts",
+  streamHint?: "lts",
 ): OsReleaseEvent[] {
   const events: OsReleaseEvent[] = [];
   for (const item of feedData.items ?? []) {
-    const release = parseOsRelease(item, stream);
-    if (!release) continue; // GTS entry or parse failure — skip
+    const release = parseOsRelease(item, streamHint);
+    if (!release) continue; // GTS entry or unrecognized format — skip
     const dateMs = new Date(item.pubDate).getTime();
     if (isNaN(dateMs)) continue;
-    events.push({ kind: "os", stream, dateMs, release });
+    events.push({ kind: "os", stream: release.stream, dateMs, release });
   }
   return events;
 }
 
-const STABLE_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinReleasesData, "stable");
+// All parsed events from both feeds, sorted newest-first
+const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinReleasesData);
 const LTS_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinLtsReleasesData, "lts");
-const ALL_OS_EVENTS: OsReleaseEvent[] = [
-  // Most recent stable release only
-  ...(STABLE_OS_EVENTS.length > 0 ? [STABLE_OS_EVENTS[0]] : []),
-  // Most recent LTS release only
-  ...(LTS_OS_EVENTS.length > 0 ? [LTS_OS_EVENTS[0]] : []),
+const ALL_OS_STREAM_EVENTS: OsReleaseEvent[] = [
+  ...BLUEFIN_OS_EVENTS,
+  ...LTS_OS_EVENTS,
 ].sort((a, b) => b.dateMs - a.dateMs);
+
+// Dakota placeholder — upstream repo has no releases yet
+const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
+  kind: "os",
+  stream: "dakota",
+  dateMs: 0, // no date — placeholder
+  release: {
+    stream: "dakota",
+    tag: "dakota-alpha",
+    githubUrl: "https://github.com/projectbluefin/dakota",
+    fedoraVersion: null,
+    centosVersion: null,
+    majorPackages: [
+      { name: "Kernel", version: "TBD", prevVersion: null },
+      { name: "Gnome", version: "TBD", prevVersion: null },
+      { name: "Mesa", version: "TBD", prevVersion: null },
+    ],
+    dxPackages: [],
+    commits: [],
+    fullDiff: [],
+  },
+};
+
+// Pinned "Current Versions" cards: latest stable + latest LTS + Dakota placeholder.
+// All bluefin releases are stable-daily; synthesise a "stable"-streamed clone for
+// the pinned card so it shows the "Stable" badge while the stream shows "Daily".
+const PINNED_OS_EVENTS: OsReleaseEvent[] = (() => {
+  // Pinned Bluefin card: latest from the bluefin feed, displayed as "stable" stream
+  const pinnedStable: OsReleaseEvent | undefined = BLUEFIN_OS_EVENTS.length > 0
+    ? { ...BLUEFIN_OS_EVENTS[0], stream: "stable", release: { ...BLUEFIN_OS_EVENTS[0].release, stream: "stable" } }
+    : undefined;
+  // Pinned LTS card: latest from LTS feed
+  const pinnedLts: OsReleaseEvent | undefined = LTS_OS_EVENTS.length > 0 ? LTS_OS_EVENTS[0] : undefined;
+  return [pinnedStable, pinnedLts, DAKOTA_PLACEHOLDER_EVENT]
+    .filter((e): e is OsReleaseEvent => e !== undefined);
+})();
 
 /**
  * Flatten every app's releases array into individual events.
@@ -178,7 +219,7 @@ function Statistics({
         ))}
         {osEventCount > 0 && (
           <>
-            <dt>OS Releases</dt>
+            <dt>OS Releases in stream</dt>
             <dd>{osEventCount}</dd>
           </>
         )}
@@ -300,38 +341,55 @@ const FirehoseFeed: React.FC = () => {
     setFeaturedApp(getFeaturedApp(uniqueApps));
   }, [uniqueApps]);
 
-  // ── OS release events ───────────────────────────────────────────────────────
+  // ── OS stream events (filtered) ────────────────────────────────────────────
+  // All OS events for the Updates Stream (all streams, date-filtered).
+  // When packageType==="os", only OS events are shown (no apps).
+  // When showOsReleases===false, OS events are excluded from the stream.
 
-  const filteredOsEvents = useMemo((): OsReleaseEvent[] => {
-    if (!filters.showOsReleases) return [];
-    if (filters.updatedWithin === "all") return ALL_OS_EVENTS;
+  const showOsInStream = filters.showOsReleases || filters.packageType === "os";
+
+  const filteredOsStreamEvents = useMemo((): OsReleaseEvent[] => {
+    if (!showOsInStream) return [];
+    if (filters.updatedWithin === "all") return ALL_OS_STREAM_EVENTS;
     const maxAge = DAYS_MS[filters.updatedWithin];
     const now = Date.now();
-    return ALL_OS_EVENTS.filter((e) => now - e.dateMs <= maxAge);
-  }, [filters.showOsReleases, filters.updatedWithin]);
+    return ALL_OS_STREAM_EVENTS.filter((e) => e.dateMs > 0 && now - e.dateMs <= maxAge);
+  }, [showOsInStream, filters.updatedWithin]);
 
-  // How many OS events are hidden by the date filter (for inline notice)
+  // How many stream OS events are hidden by the date filter
   const hiddenOsCount = useMemo(
     () =>
-      filters.showOsReleases && filters.updatedWithin !== "all"
-        ? ALL_OS_EVENTS.length - filteredOsEvents.length
+      showOsInStream && filters.updatedWithin !== "all"
+        ? ALL_OS_STREAM_EVENTS.filter((e) => e.dateMs > 0).length - filteredOsStreamEvents.length
         : 0,
-    [filteredOsEvents, filters.showOsReleases, filters.updatedWithin],
+    [filteredOsStreamEvents, showOsInStream, filters.updatedWithin],
   );
 
-  // ── Grouped sections ───────────────────────────────────────────────────────
+  // ── Unified "Updates Stream" ───────────────────────────────────────────────
   //
-  // OS releases are pinned as the featured section. App updates follow as a
-  // secondary section, separated by a visual divider. Each section is sorted
-  // by date independently.
+  // OS releases and app updates merged into one chronological list.
+  // packageType==="os" shows only OS events; otherwise interleaved.
 
-  const osSection = filteredOsEvents; // already sorted by dateMs desc
-  const appSection = filteredUniqueApps
-    .map(({ app, latestMs }): AppTimelineEvent => ({ kind: "app", app, dateMs: latestMs }))
-    .sort((a, b) => b.dateMs - a.dateMs);
+  const appSection = useMemo(
+    () =>
+      filteredUniqueApps
+        .map(({ app, latestMs }): AppTimelineEvent => ({ kind: "app", app, dateMs: latestMs }))
+        .sort((a, b) => b.dateMs - a.dateMs),
+    [filteredUniqueApps],
+  );
 
-  const isEmpty = allEvents.length === 0 && ALL_OS_EVENTS.length === 0;
-  const feedEmpty = osSection.length === 0 && appSection.length === 0;
+  const unifiedStream = useMemo((): FlatTimelineEvent[] => {
+    const items: FlatTimelineEvent[] = [];
+    if (filters.packageType !== "os") {
+      items.push(...appSection);
+    }
+    items.push(...filteredOsStreamEvents);
+    items.sort((a, b) => b.dateMs - a.dateMs);
+    return items;
+  }, [filteredOsStreamEvents, appSection, filters.packageType]);
+
+  const isEmpty = allEvents.length === 0 && ALL_OS_STREAM_EVENTS.length === 0;
+  const feedEmpty = unifiedStream.length === 0;
 
   return (
     <div className={styles.layout}>
@@ -354,7 +412,7 @@ const FirehoseFeed: React.FC = () => {
           matchCount={filteredUniqueApps.length}
         />
         {!isEmpty && (
-          <Statistics uniqueApps={uniqueApps} osEventCount={ALL_OS_EVENTS.length} />
+          <Statistics uniqueApps={uniqueApps} osEventCount={ALL_OS_STREAM_EVENTS.length} />
         )}
       </aside>
 
@@ -388,40 +446,42 @@ const FirehoseFeed: React.FC = () => {
               pipeline runs every 6 hours — check back soon.
             </p>
           </div>
-        ) : feedEmpty ? (
-          <div className={styles.emptyState}>
-            <p>No items match the current filters.</p>
-            <button
-              className={styles.clearFiltersBtn}
-              onClick={() => setFilters(DEFAULT_FILTERS)}
-            >
-              Clear filters
-            </button>
-          </div>
         ) : (
           <>
-            {/* ── OS Releases — featured section ── */}
-            {osSection.length > 0 && (
-              <section className={styles.feedSection}>
-                <h2 className={styles.feedSectionHeading}>Bluefin OS Releases</h2>
-                {osSection.map((event) => (
-                  <OsReleaseCard key={`os-${event.release.tag}`} event={event} />
-                ))}
-              </section>
-            )}
+            {/* ── Current Versions — pinned cards, always visible ── */}
+            <section className={styles.feedSection}>
+              <Heading as="h2" className={styles.feedSectionHeading}>Current Versions</Heading>
+              {PINNED_OS_EVENTS.map((event) => (
+                <OsReleaseCard key={`pinned-${event.release.tag}`} event={event} />
+              ))}
+            </section>
 
-            {/* ── App Updates — secondary section ── */}
-            {appSection.length > 0 && (
+            {/* ── Updates Stream — unified chronological feed ── */}
+            {feedEmpty ? (
+              <div className={styles.emptyState}>
+                <p>No items match the current filters.</p>
+                <button
+                  className={styles.clearFiltersBtn}
+                  onClick={() => setFilters(DEFAULT_FILTERS)}
+                >
+                  Clear filters
+                </button>
+              </div>
+            ) : (
               <section className={styles.feedSection}>
                 <div className={styles.appSectionDivider}>
-                  <h2 className={styles.feedSectionHeading}>App Updates</h2>
+                  <Heading as="h2" className={styles.feedSectionHeading}>Updates Stream</Heading>
                   <span className={styles.appSectionHint}>
-                    Flatpak &amp; Homebrew packages included in Bluefin
+                    OS releases, Flatpak &amp; Homebrew packages included in Bluefin
                   </span>
                 </div>
-                {appSection.map((event) => (
-                  <FirehoseCard key={event.app.id} app={event.app} />
-                ))}
+                {unifiedStream.map((event) =>
+                  event.kind === "os" ? (
+                    <OsReleaseCard key={`stream-${event.release.tag}-${event.dateMs}`} event={event} />
+                  ) : (
+                    <FirehoseCard key={event.app.id} app={event.app} />
+                  ),
+                )}
               </section>
             )}
           </>

--- a/src/components/OsReleaseCard.module.css
+++ b/src/components/OsReleaseCard.module.css
@@ -18,7 +18,8 @@
 /* ── Mascot art (::after pseudo, matching ImagesCatalog pattern) ── */
 
 .cardStable::after,
-.cardLts::after {
+.cardLts::after,
+.cardDakota::after {
   content: "";
   position: absolute;
   right: 1rem;
@@ -40,6 +41,10 @@
   background-image: url("/img/characters/achillobator.webp");
 }
 
+.cardDakota::after {
+  background-image: url("/img/characters/dakotaraptor.webp");
+}
+
 /* ── Stream accent borders ── */
 
 .cardStable {
@@ -48,6 +53,10 @@
 
 .cardLts {
   border-left: 3px solid #d97706;
+}
+
+.cardDakota {
+  border-left: 3px solid #7c3aed;
 }
 
 /* ── Header ────────────────────────────────────────────────────────────────── */
@@ -118,6 +127,18 @@
   border: 1px solid rgba(217, 119, 6, 0.35);
 }
 
+.badgeDaily {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.badgeDakota {
+  background: rgba(124, 58, 237, 0.15);
+  color: #6d28d9;
+  border: 1px solid rgba(124, 58, 237, 0.35);
+}
+
 /* ── Base version chip (Fedora / CentOS) ─────────────────────────────────────── */
 
 .baseChip {
@@ -138,6 +159,8 @@
   flex-wrap: wrap;
   gap: 0.45rem;
   margin-bottom: 0.6rem;
+  /* Leave room for mascot art on the right, matching .cardHeader */
+  padding-right: 130px;
 }
 
 .dxRow {
@@ -148,6 +171,8 @@
   align-items: center;
   gap: 0.45rem;
   margin-bottom: 0.75rem;
+  /* Leave room for mascot art on the right, matching .cardHeader */
+  padding-right: 130px;
 }
 
 .dxLabel {
@@ -429,7 +454,8 @@
   }
 
   .cardStable::after,
-  .cardLts::after {
+  .cardLts::after,
+  .cardDakota::after {
     width: 70px;
     height: 70px;
     opacity: 1;
@@ -442,5 +468,6 @@
   .chipsRow,
   .dxRow {
     gap: 0.35rem;
+    padding-right: 80px;
   }
 }

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Heading from "@theme/Heading";
 import type {
   OsReleaseEvent,
   ParsedMajorPackage,
@@ -175,8 +176,20 @@ interface OsReleaseCardProps {
 const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
   const { release, dateMs, stream } = event;
   const isLts = stream === "lts";
-  const streamLabel = isLts ? "LTS" : "Stable";
-  const cardClass = `${styles.card} ${isLts ? styles.cardLts : styles.cardStable}`;
+  const isDaily = stream === "stable-daily";
+  const isDakota = stream === "dakota";
+
+  const streamLabel = isLts ? "LTS" : isDaily ? "Daily" : isDakota ? "Dakota" : "Stable";
+  const cardVariantClass = isLts ? styles.cardLts : isDakota ? styles.cardDakota : styles.cardStable;
+  const cardClass = `${styles.card} ${cardVariantClass}`;
+
+  const badgeClass = isLts
+    ? styles.badgeLts
+    : isDaily
+      ? styles.badgeDaily
+      : isDakota
+        ? styles.badgeDakota
+        : styles.badgeStable;
 
   // Key package chips (header row): subset of well-known packages.
   // Falls back to fullDiff when a name isn't in the curated majorPackages table.
@@ -206,6 +219,9 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
 
   const cardId = `os-release-${release.tag}`;
 
+  const cardTitle = isLts ? "Bluefin LTS" : isDakota ? "Bluefin Dakota" : "Bluefin";
+  const imagesAnchor = isLts ? "bluefin-lts" : isDakota ? "bluefin-dakota" : "bluefin-stable";
+
   return (
     <article
       className={cardClass}
@@ -214,12 +230,13 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
       {/* ── Header ── */}
       <div className={styles.cardHeader}>
         <div className={styles.titleRow}>
-          <h2 className={styles.cardTitle}>{isLts ? "Bluefin LTS" : "Bluefin"}</h2>
+          <Heading as="h2" className={styles.cardTitle}>{cardTitle}</Heading>
+          <span className={`${styles.streamBadge} ${badgeClass}`}>{streamLabel}</span>
         </div>
 
         <div className={styles.metaRow}>
           <span className={styles.releaseTag}>{release.tag}</span>
-          <span className={styles.releaseDate}>{formatDate(dateMs)}</span>
+          {dateMs > 0 && <span className={styles.releaseDate}>{formatDate(dateMs)}</span>}
           {release.fedoraVersion && (
             <span className={styles.baseChip}>Fedora {release.fedoraVersion}</span>
           )}
@@ -277,7 +294,7 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
           View on GitHub →
         </a>
         <a
-          href={`/images#${isLts ? "bluefin-lts" : "bluefin-stable"}`}
+          href={`/images#${imagesAnchor}`}
           className={styles.viewLink}
         >
           Image details →

--- a/src/types/os-feed.ts
+++ b/src/types/os-feed.ts
@@ -30,8 +30,8 @@ export interface OsFeedData {
 
 // ── Parsed structures ─────────────────────────────────────────────────────────
 
-/** The two active Bluefin release streams. GTS is retired — skipped in parser. */
-export type OsStream = "stable" | "lts";
+/** The active Bluefin release streams. GTS is retired — skipped in parser. */
+export type OsStream = "stable" | "stable-daily" | "lts" | "dakota";
 
 /**
  * A package entry from the "Major packages" or "Major DX packages" section.

--- a/src/utils/parseOsRelease.ts
+++ b/src/utils/parseOsRelease.ts
@@ -44,11 +44,16 @@ function isGtsItem(title: string): boolean {
 /**
  * Detect the release stream from the item title.
  * Returns null for retired GTS items or unrecognized title formats.
+ *
+ * Bluefin publishes daily automated builds tagged "stable-YYYYMMDD".
+ * All stable-* tags are mapped to "stable-daily" so they appear in the stream.
+ * The pinned "Current Versions" card synthesises a "stable" display from the
+ * latest stable-daily event in FirehoseFeed.tsx.
  */
 function detectStream(title: string): OsStream | null {
   if (isGtsItem(title)) return null;
   if (/^lts[.-]/i.test(title) || /\bLTS:/i.test(title)) return "lts";
-  if (/^(stable|beta|latest)-/i.test(title)) return "stable";
+  if (/^(stable|latest|beta)-/i.test(title)) return "stable-daily";
   return null;
 }
 
@@ -77,10 +82,17 @@ function extractCentosVersion(title: string): string | null {
  *   "lts.20251223: ..."               → "lts-20251223"
  */
 function extractTag(title: string, stream: OsStream): string {
-  // Standard prefix format: "stable-YYYYMMDD:", "lts-YYYYMMDD:", "lts.YYYYMMDD:"
+  // Standard prefix format: "stable-YYYYMMDD", "lts-YYYYMMDD", "lts.YYYYMMDD", "latest-YYYYMMDD"
   const prefixMatch = title.match(/^([a-z]+-[\d.]+)/i);
   if (prefixMatch) {
-    return prefixMatch[1].toLowerCase().replace(/^lts\.(\d{8})$/, "lts-$1");
+    let tag = prefixMatch[1].toLowerCase();
+    // Normalize legacy dot format
+    tag = tag.replace(/^lts\.(\d{8})$/, "lts-$1");
+    // Normalize latest- prefix → stable-daily-YYYYMMDD
+    tag = tag.replace(/^latest-(\d{8})$/, "stable-daily-$1");
+    // Normalize stable-YYYYMMDD → stable-daily-YYYYMMDD (matches OCI image tag :stable-daily)
+    tag = tag.replace(/^(?:stable|beta)-(\d{8}(\.\d+)?)$/, "stable-daily-$1");
+    return tag;
   }
   // LTS alternative format: "bluefin-lts LTS: YYYYMMDD (...)"
   const ltsAltMatch = title.match(/LTS:\s*(\d{8})/i);
@@ -88,7 +100,7 @@ function extractTag(title: string, stream: OsStream): string {
   return stream;
 }
 
-// ── Section extraction ────────────────────────────────────────────────────────
+// ── Section extraction (HTML) ─────────────────────────────────────────────────
 
 /**
  * Extract named sections from the release HTML.
@@ -107,6 +119,115 @@ function extractSections(html: string): Map<string, string> {
     sections.set(heading, m[2]);
   }
   return sections;
+}
+
+// ── Markdown parsers ──────────────────────────────────────────────────────────
+
+/** Strip Markdown inline formatting: bold, links, inline code. */
+function stripMd(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // [text](url) → text
+    .replace(/\*\*([^*]*)\*\*/g, "$1")        // **bold** → text
+    .replace(/`([^`]+)`/g, "$1")              // `code` → text
+    .trim();
+}
+
+/** Split a Markdown table row into trimmed cell strings. */
+function splitMdRow(line: string): string[] {
+  return line.replace(/^\||\|$/g, "").split("|").map((s) => s.trim());
+}
+
+/** Returns true if a row is a separator line (| --- | --- |). */
+function isMdSeparatorRow(cells: string[]): boolean {
+  return cells.every((c) => /^:?-+:?$/.test(c));
+}
+
+/**
+ * Extract named sections from Markdown release body.
+ * Returns a Map of section heading text → array of cell-arrays (one per data row).
+ * Heading links are stripped: "### [Dev Experience Images](url)" → "Dev Experience Images".
+ */
+function extractSectionsMd(content: string): Map<string, string[][]> {
+  const sections = new Map<string, string[][]>();
+  const lines = content.split("\n");
+  let currentHeading: string | null = null;
+  let currentRows: string[][] = [];
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^###\s+(.*)/);
+    if (headingMatch) {
+      if (currentHeading !== null && currentRows.length > 0) {
+        sections.set(currentHeading, currentRows);
+      }
+      currentHeading = stripMd(headingMatch[1]);
+      currentRows = [];
+      continue;
+    }
+    if (currentHeading !== null && line.startsWith("|")) {
+      const cells = splitMdRow(line);
+      if (isMdSeparatorRow(cells)) continue; // skip | --- | rows
+      currentRows.push(cells);
+    }
+  }
+  if (currentHeading !== null && currentRows.length > 0) {
+    sections.set(currentHeading, currentRows);
+  }
+  return sections;
+}
+
+/** Parse Markdown 2-column [Name, Version] rows. */
+function parseTwoColTableMd(rows: string[][]): ParsedMajorPackage[] {
+  const results: ParsedMajorPackage[] = [];
+  for (const cells of rows) {
+    if (cells.length < 2) continue;
+    const name = stripMd(cells[0]);
+    if (!name || name === "Name") continue;
+    const versionRaw = stripMd(cells[1]);
+    const parts = versionRaw.split(/\s*➡️?\s*/u).map((s) => s.trim());
+    if (parts.length >= 2 && parts[0] && parts[parts.length - 1]) {
+      results.push({ name, version: parts[parts.length - 1], prevVersion: parts[0] });
+    } else {
+      results.push({ name, version: versionRaw, prevVersion: null });
+    }
+  }
+  return results;
+}
+
+/** Parse Markdown commits rows: [Hash, Subject] or [Hash, Subject, Author]. */
+function parseCommitsTableMd(rows: string[][]): ParsedCommit[] {
+  const results: ParsedCommit[] = [];
+  for (const cells of rows) {
+    if (cells.length < 2) continue;
+    const hashCell = cells[0];
+    // Extract URL from [text](url) in hash cell
+    const urlMatch = hashCell.match(/\(https:\/\/github\.com\/([^)]+)\)/);
+    const url = urlMatch ? `https://github.com/${urlMatch[1]}` : null;
+    const hash = stripMd(hashCell);
+    if (!hash || hash === "Hash") continue;
+    const subject = stripMd(cells[1]);
+    if (!subject) continue;
+    const author = cells[2] ? stripMd(cells[2]) || null : null;
+    results.push({ hash, url, subject, author });
+  }
+  return results;
+}
+
+/** Parse Markdown 4-column [emoji, Name, Previous, New] diff rows. */
+function parseFourColDiffTableMd(rows: string[][]): ParsedDiffEntry[] {
+  const results: ParsedDiffEntry[] = [];
+  for (const cells of rows) {
+    if (cells.length < 4) continue;
+    const emojiText = cells[0].trim();
+    const name = stripMd(cells[1]);
+    if (!name || name === "Name") continue;
+    const prevVersion = stripMd(cells[2]) || null;
+    const newVersion = stripMd(cells[3]) || null;
+    let indicator: ParsedDiffEntry["indicator"] = "changed";
+    if (emojiText.includes("✨") || (!prevVersion && newVersion)) indicator = "added";
+    else if (emojiText.includes("❌") || (prevVersion && !newVersion)) indicator = "removed";
+    results.push({ indicator, name, prevVersion, newVersion });
+  }
+  return results;
 }
 
 // ── Table parsers ─────────────────────────────────────────────────────────────
@@ -240,25 +361,37 @@ export function parseOsRelease(
   const stream = streamHint ?? detectStream(item.title);
   if (!stream) return null;
 
-  const sections = extractSections(item.content);
+  // GitHub Releases API returns Markdown; Atom feed returns HTML.
+  // Detect by presence of Markdown table separator rows.
+  const isMarkdown = /^\|[\s|:-]*---[\s|:-]*\|/m.test(item.content);
 
-  const majorPackages = parseTwoColTable(sections.get("Major packages") ?? "");
-
-  const dxTableHtml =
-    sections.get("Major DX packages") ??
-    sections.get("Major GDX packages") ??
-    "";
-  const dxPackages = parseTwoColTable(dxTableHtml);
-
-  const commitsHtml = sections.get("Commits") ?? "";
-  const commits = commitsHtml ? parseCommitsTable(commitsHtml) : [];
-
-  const fullDiffSectionNames = ["All Images", "Base Images", "Dev Experience Images"];
+  let majorPackages: ParsedMajorPackage[];
+  let dxPackages: ParsedMajorPackage[];
+  let commits: ParsedCommit[];
   const fullDiff: ParsedDiffEntry[] = [];
-  for (const heading of fullDiffSectionNames) {
-    const tableHtml = sections.get(heading);
-    if (tableHtml) {
-      fullDiff.push(...parseFourColDiffTable(tableHtml));
+
+  if (isMarkdown) {
+    const mdSections = extractSectionsMd(item.content);
+    majorPackages = parseTwoColTableMd(mdSections.get("Major packages") ?? []);
+    dxPackages = parseTwoColTableMd(
+      mdSections.get("Major DX packages") ?? mdSections.get("Major GDX packages") ?? [],
+    );
+    commits = parseCommitsTableMd(mdSections.get("Commits") ?? []);
+    for (const heading of ["All Images", "Base Images", "Dev Experience Images"]) {
+      const rows = mdSections.get(heading);
+      if (rows) fullDiff.push(...parseFourColDiffTableMd(rows));
+    }
+  } else {
+    const sections = extractSections(item.content);
+    majorPackages = parseTwoColTable(sections.get("Major packages") ?? "");
+    dxPackages = parseTwoColTable(
+      sections.get("Major DX packages") ?? sections.get("Major GDX packages") ?? "",
+    );
+    const commitsHtml = sections.get("Commits") ?? "";
+    commits = commitsHtml ? parseCommitsTable(commitsHtml) : [];
+    for (const heading of ["All Images", "Base Images", "Dev Experience Images"]) {
+      const tableHtml = sections.get(heading);
+      if (tableHtml) fullDiff.push(...parseFourColDiffTable(tableHtml));
     }
   }
 


### PR DESCRIPTION
…Dakota placeholder

- Upgrade fetch-feeds.js from Atom XML (~10 items) to GitHub Releases API (100 items paginated) with GITHUB_TOKEN auth and 24h file-mtime cache
- Add dual-mode Markdown/HTML parser in parseOsRelease.ts — GitHub API returns Markdown bodies; Atom feed returns HTML; format auto-detected
- Extend OsStream type: "stable" | "stable-daily" | "lts" | "dakota"
- detectStream() maps stable-* prefixed tags to "stable-daily"
- FirehoseFeed.tsx: pinned "Current Versions" section with Bluefin stable, Bluefin LTS, and Bluefin Dakota placeholder cards at top of changelogs
- Unified "Updates Stream" interleaves OS releases with app updates
- OsReleaseCard.tsx: stream-aware title, badge, and mascot per stream
- OsReleaseCard.module.css: Dakota card (purple accent + dakotaraptor), badgeDaily, badgeDakota; fix chip/mascot overlap with padding-right