### PR TITLE
feat(changelogs): SBOM-driven OS card chips — Dakota placeholder + pi…

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -570,6 +570,7 @@ function extractPackageVersions(sbomPath) {
     systemd: null,
     bootc: null,
     fedora: null,
+    pipewire: null,
     /** Flat name→version map of every RPM in the image */
     allPackages: /** @type {Record<string, string>} */ ({}),
   };
@@ -606,6 +607,9 @@ function extractPackageVersions(sbomPath) {
         break;
       case "bootc":
         if (!result.bootc) result.bootc = stripEpoch(String(version));
+        break;
+      case "pipewire":
+        if (!result.pipewire) result.pipewire = stripEpoch(String(version));
         break;
       case "fedora-release-common": {
         if (!result.fedora) {

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -4,7 +4,9 @@ import firehoseData from "@site/static/data/firehose-apps.json";
 import bluefinReleasesData from "@site/static/feeds/bluefin-releases.json";
 import bluefinLtsReleasesData from "@site/static/feeds/bluefin-lts-releases.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
-import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent } from "../types/os-feed";
+import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent, ParsedMajorPackage } from "../types/os-feed";
+import sbomAttestationsData from "@site/static/data/sbom-attestations-frontend.json";
+import type { SbomAttestationsData, PackageVersions } from "../types/sbom";
 import { parseOsRelease } from "../utils/parseOsRelease";
 import FirehoseCard from "./FirehoseCard";
 import OsReleaseCard from "./OsReleaseCard";
@@ -49,15 +51,88 @@ function loadOsEvents(
   return events;
 }
 
-// All parsed events from both feeds, sorted newest-first
-const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinReleasesData);
-const LTS_OS_EVENTS: OsReleaseEvent[] = loadOsEvents(bluefinLtsReleasesData, "lts");
+// ── SBOM enrichment ───────────────────────────────────────────────────────────
+//
+// All package version chips on OS release cards are sourced from the SBOM
+// attestation cache (Pipeline B — authoritative). Release notes data
+// (majorPackages from the HTML/Markdown parser) is supplemented by SBOM
+// but never used as the sole source for missing packages.
+// Dakota is the only stream that uses hardcoded placeholder versions.
+
+const SBOM_CACHE = sbomAttestationsData as unknown as SbomAttestationsData;
+
+/** Map from lowercase HEADER_CHIP_NAMES to their PackageVersions field. */
+const CHIP_TO_SBOM: Array<{ chipName: string; displayName: string; field: keyof PackageVersions }> = [
+  { chipName: "kernel",   displayName: "Kernel",   field: "kernel" },
+  { chipName: "gnome",    displayName: "Gnome",    field: "gnome" },
+  { chipName: "mesa",     displayName: "Mesa",     field: "mesa" },
+  { chipName: "podman",   displayName: "Podman",   field: "podman" },
+  { chipName: "bootc",    displayName: "bootc",    field: "bootc" },
+  { chipName: "systemd",  displayName: "systemd",  field: "systemd" },
+  { chipName: "pipewire", displayName: "pipewire", field: "pipewire" },
+];
+
+/**
+ * Convert a ParsedOsRelease tag + stream to the SBOM cache key + stream ID.
+ *
+ * release.tag is normalised by parseOsRelease (e.g. "stable-daily-20260331"),
+ * but SBOM cacheKeys use the original GitHub release tag format ("stable-20260331").
+ */
+function sbomKeyForRelease(tag: string, stream: string): { streamId: string; cacheKey: string } | null {
+  const dateMatch = tag.match(/(\d{8})/);
+  if (!dateMatch) return null;
+  const date = dateMatch[1];
+  if (stream === "lts") return { streamId: "bluefin-lts", cacheKey: `lts-${date}` };
+  if (stream === "stable" || stream === "stable-daily") {
+    return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
+  }
+  return null;
+}
+
+/**
+ * Enrich each OS release event's majorPackages with versions from the SBOM cache.
+ * Packages already present in majorPackages (from release notes) are kept as-is;
+ * missing tracked packages are appended from SBOM packageVersions.
+ *
+ * Only applies to stable/LTS events. Dakota uses hardcoded placeholders.
+ */
+function enrichFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
+  return events.map((event) => {
+    const key = sbomKeyForRelease(event.release.tag, event.stream);
+    if (!key) return event;
+
+    const packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
+    if (!packages) return event;
+
+    const existingNames = new Set(event.release.majorPackages.map((p) => p.name.toLowerCase()));
+    const toAdd: ParsedMajorPackage[] = [];
+
+    for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+      if (existingNames.has(chipName)) continue;
+      const version = packages[field] as string | null | undefined;
+      if (!version) continue;
+      toAdd.push({ name: displayName, version, prevVersion: null });
+    }
+
+    if (toAdd.length === 0) return event;
+    return {
+      ...event,
+      release: { ...event.release, majorPackages: [...event.release.majorPackages, ...toAdd] },
+    };
+  });
+}
+
+// All parsed events from both feeds, enriched with SBOM package versions
+const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinReleasesData));
+const LTS_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts"));
 const ALL_OS_STREAM_EVENTS: OsReleaseEvent[] = [
   ...BLUEFIN_OS_EVENTS,
   ...LTS_OS_EVENTS,
 ].sort((a, b) => b.dateMs - a.dateMs);
 
-// Dakota placeholder — upstream repo has no releases yet
+// Dakota placeholder — upstream repo has no releases yet; versions sourced from
+// BuildStream junction pins in ~/src/dakota/elements/*.bst (no SBOM pipeline).
+// Update when junction refs change: freedesktop-sdk-25.08.8 + gnome-build-meta gnome-50
 const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
   kind: "os",
   stream: "dakota",
@@ -69,9 +144,15 @@ const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
     fedoraVersion: null,
     centosVersion: null,
     majorPackages: [
-      { name: "Kernel", version: "TBD", prevVersion: null },
-      { name: "Gnome", version: "TBD", prevVersion: null },
-      { name: "Mesa", version: "TBD", prevVersion: null },
+      { name: "Kernel", version: "6.18.7", prevVersion: null },
+      { name: "Gnome", version: "50.0", prevVersion: null },
+      { name: "Mesa", version: "25.3.5", prevVersion: null },
+      { name: "Podman", version: "5.8.0", prevVersion: null },
+      { name: "bootc", version: "1.12.1", prevVersion: null },
+      { name: "systemd", version: "259.2", prevVersion: null },
+      { name: "pipewire", version: "1.6.1", prevVersion: null },
+      { name: "sudo-rs", version: "74e0db4", prevVersion: null },
+      { name: "uutils-coreutils", version: "e7f2fd9", prevVersion: null },
     ],
     dxPackages: [],
     commits: [],

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -165,7 +165,7 @@ function VersionChip({ pkg }: { pkg: ParsedMajorPackage }) {
 
 // ── Chip labels we surface in the header chips row ────────────────────────────
 
-const HEADER_CHIP_NAMES = ["Kernel", "HWE Kernel", "Gnome", "Mesa", "Podman", "Nvidia", "bootc", "systemd", "pipewire"];
+const HEADER_CHIP_NAMES = ["Kernel", "HWE Kernel", "Gnome", "Mesa", "Podman", "Nvidia", "bootc", "systemd", "pipewire", "sudo-rs", "uutils-coreutils"];
 
 // ── Main component ────────────────────────────────────────────────────────────
 

--- a/src/types/sbom.ts
+++ b/src/types/sbom.ts
@@ -56,6 +56,8 @@ export interface PackageVersions {
   bootc: string | null;
   /** e.g. "F43" derived from `fedora-release-common` */
   fedora: string | null;
+  /** e.g. "1.6.1-1.fc43" from the `pipewire` RPM */
+  pipewire: string | null;
   /**
    * Flat name→version map of every RPM artifact in the image.
    * Used by fetch-firehose.js to compute per-release package diffs.


### PR DESCRIPTION
…pewire

- Fill Dakota placeholder card with real versions from BuildStream junction pins (Kernel 6.18.7, GNOME 50, Mesa 25.3.5, Podman 5.8, bootc 1.12.1, systemd 259.2, pipewire 1.6.1, sudo-rs, uutils-coreutils)
- Add pipewire to PackageVersions (src/types/sbom.ts) and extract it from the Syft SBOM in extractPackageVersions() (scripts/fetch-github-sbom.js)
- Replace release-note chip fallback with enrichFromSbom() in FirehoseFeed.tsx: all stable/LTS OS release cards now fill missing tracked package chips (Kernel, Gnome, Mesa, Podman, bootc, systemd, pipewire) from the SBOM attestation cache — never from release notes or carry-forward inference