### PR TITLE
feat(changelogs,ui): SBOM-driven chips, Dakota placeholder, pipewire/…

### DIFF
--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -171,11 +171,11 @@ function buildRow(item, streamId) {
     releaseUrl: item?.link || null,
     publishedAt: parseDate(item?.pubDate || item?.updated || null),
     versions: {
-      kernel: null,
-      hweKernel: null,
-      mesa: null,
+      kernel: extractVersionFromMarkdown(content, ["Kernel"]),
+      hweKernel: extractVersionFromMarkdown(content, ["HWE Kernel"]),
+      mesa: extractVersionFromMarkdown(content, ["Mesa"]),
       nvidia: extractVersionFromMarkdown(content, ["Nvidia", "NVIDIA"]),
-      gnome: null,
+      gnome: extractVersionFromMarkdown(content, ["Gnome", "GNOME"]),
     },
   };
 }
@@ -195,7 +195,7 @@ function buildRowFromApiRelease(release, streamId) {
       hweKernel: null,
       mesa: null,
       nvidia: extractVersionFromMarkdown(body, ["Nvidia", "NVIDIA"]),
-      gnome: null,
+      gnome: extractVersionFromMarkdown(body, ["Gnome", "GNOME"]),
     },
   };
 }

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -571,6 +571,7 @@ function extractPackageVersions(sbomPath) {
     bootc: null,
     fedora: null,
     pipewire: null,
+    flatpak: null,
     /** Flat name→version map of every RPM in the image */
     allPackages: /** @type {Record<string, string>} */ ({}),
   };
@@ -610,6 +611,9 @@ function extractPackageVersions(sbomPath) {
         break;
       case "pipewire":
         if (!result.pipewire) result.pipewire = stripEpoch(String(version));
+        break;
+      case "flatpak":
+        if (!result.flatpak) result.flatpak = stripEpoch(String(version));
         break;
       case "fedora-release-common": {
         if (!result.fedora) {

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -164,7 +164,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -208,7 +208,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -247,7 +247,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -286,7 +286,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -322,7 +322,7 @@
   line-height: 1.2;
   font-weight: 800;
   color: var(--ifm-color-emphasis-900);
-  overflow-wrap: anywhere;
+  word-break: break-word;
   position: relative;
   z-index: 2;
 }
@@ -422,7 +422,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -461,7 +461,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -537,7 +537,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -576,7 +576,7 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  mix-blend-mode: overlay;
+  mix-blend-mode: color-dodge;
   z-index: 1;
   background-image: linear-gradient(
     115deg,
@@ -645,7 +645,7 @@
 
 .rebaseInline code {
   display: block;
-  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .commandBlock :global(.theme-code-block) {
@@ -658,7 +658,7 @@
 .commandBlock :global(pre) {
   margin: 0;
   white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  word-break: break-word;
   /* padding-right handled globally in custom.css */
 }
 
@@ -704,17 +704,5 @@
 .rebaseList code {
   display: inline-block;
   margin-top: 0.3rem;
-  overflow-wrap: anywhere;
-}
-
-/* Dark mode: restore color-dodge for maximum shimmer on dark backgrounds */
-[data-theme="dark"] .majorBump::after,
-[data-theme="dark"] .nvidiaMajorBump::after,
-[data-theme="dark"] .nvidiaMinorBump::after,
-[data-theme="dark"] .minorBump::after,
-[data-theme="dark"] .mesaMajorBump::after,
-[data-theme="dark"] .mesaMinorBump::after,
-[data-theme="dark"] .gnomeMajorBump::after,
-[data-theme="dark"] .gnomeMinorBump::after {
-  mix-blend-mode: color-dodge;
+  word-break: break-word;
 }

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -52,6 +52,10 @@ function formatDate(value: string | null | undefined) {
   });
 }
 
+function valueOrFallback(value: string | null | undefined, fallback = "N/A") {
+  return value || fallback;
+}
+
 function VersionValue({ value }: { value: string | null | undefined }) {
   if (!value) {
     return <span className={`${styles.majorVersionValue} ${styles.versionMissing}`}>N/A</span>;
@@ -77,7 +81,7 @@ function majorMinor(value: string | null | undefined) {
 
 function rebaseCommandForTag(tag: string) {
   const safeTag = /^[a-z0-9][a-z0-9._-]*$/i.test(tag) ? tag : "stable";
-  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.["image-name"]' /usr/share/ublue-os/image-info.json):${safeTag}"`;
+  return `sudo bootc switch --enforce-container-sigpolicy "ghcr.io/$(jq -r '.\"image-name\"' /usr/share/ublue-os/image-info.json):${safeTag}"`;
 }
 
 function ReleaseNode({
@@ -89,7 +93,11 @@ function ReleaseNode({
   previousRow?: DriverRow;
   emphasize: boolean;
 }) {
+  const kernel = valueOrFallback(row.versions.kernel);
+  const nvidia = valueOrFallback(row.versions.nvidia);
+  const mesa = valueOrFallback(row.versions.mesa);
   const hwe = row.versions.hweKernel;
+  const gnome = valueOrFallback(row.versions.gnome);
 
   const kernelMajor = majorNumber(row.versions.kernel);
   const previousKernelMajor = majorNumber(previousRow?.versions.kernel);
@@ -184,7 +192,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>Kernel</span>
-            <VersionValue value={row.versions.kernel} />
+            <VersionValue value={kernel} />
             {kernelMajorBump && <span className={styles.bumpTag}>Major bump</span>}
             {kernelMinorBump && <span className={styles.minorTag}>Minor bump</span>}
           </div>
@@ -204,7 +212,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>NVIDIA</span>
-            <VersionValue value={row.versions.nvidia} />
+            <VersionValue value={nvidia} />
             {nvidiaMajorBump && <span className={styles.nvidiaBumpTag}>Major bump</span>}
             {nvidiaMinorBump && <span className={styles.nvidiaMinorTag}>Minor bump</span>}
           </div>
@@ -218,7 +226,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>Mesa</span>
-            <VersionValue value={row.versions.mesa} />
+            <VersionValue value={mesa} />
             {mesaMajorBump && <span className={styles.mesaBumpTag}>Major bump</span>}
             {mesaMinorBump && <span className={styles.mesaMinorTag}>Minor bump</span>}
           </div>
@@ -232,7 +240,7 @@ function ReleaseNode({
             }
           >
             <span className={styles.majorVersionLabel}>GNOME</span>
-            <VersionValue value={row.versions.gnome} />
+            <VersionValue value={gnome} />
             {gnomeMajorBump && <span className={styles.gnomeBumpTag}>Major bump</span>}
             {gnomeMinorBump && <span className={styles.gnomeMinorTag}>Minor bump</span>}
           </div>

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -70,6 +70,7 @@ const CHIP_TO_SBOM: Array<{ chipName: string; displayName: string; field: keyof 
   { chipName: "bootc",    displayName: "bootc",    field: "bootc" },
   { chipName: "systemd",  displayName: "systemd",  field: "systemd" },
   { chipName: "pipewire", displayName: "pipewire", field: "pipewire" },
+  { chipName: "flatpak",  displayName: "flatpak",  field: "flatpak" },
 ];
 
 /**
@@ -122,9 +123,46 @@ function enrichFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
   });
 }
 
+/**
+ * LTS has no SBOM pipeline. Carry forward package versions last seen in fullDiff
+ * across the release history so each LTS card shows its most-recently-observed version.
+ * Processes events oldest→newest, maintaining a running "last known" state per package,
+ * then restores the original newest-first order.
+ */
+function enrichLtsFromHistory(events: OsReleaseEvent[]): OsReleaseEvent[] {
+  const TRACKED = ["systemd", "bootc", "pipewire", "flatpak"];
+  const sorted = [...events].sort((a, b) => a.dateMs - b.dateMs);
+  const running: Record<string, string> = {};
+
+  const enriched = sorted.map((event) => {
+    // Update running state from majorPackages listed in release notes
+    for (const pkg of event.release.majorPackages) {
+      const lower = pkg.name.toLowerCase();
+      if (TRACKED.includes(lower)) running[lower] = pkg.version;
+    }
+    // Update from fullDiff (packages that changed in this release)
+    for (const entry of event.release.fullDiff) {
+      const lower = entry.name.toLowerCase();
+      if (TRACKED.includes(lower) && entry.newVersion) running[lower] = entry.newVersion;
+    }
+
+    const existingNames = new Set(event.release.majorPackages.map((p) => p.name.toLowerCase()));
+    const toAdd: ParsedMajorPackage[] = [];
+    for (const name of TRACKED) {
+      if (!existingNames.has(name) && running[name]) {
+        toAdd.push({ name, version: running[name], prevVersion: null });
+      }
+    }
+    if (toAdd.length === 0) return event;
+    return { ...event, release: { ...event.release, majorPackages: [...event.release.majorPackages, ...toAdd] } };
+  });
+
+  return enriched.sort((a, b) => b.dateMs - a.dateMs);
+}
+
 // All parsed events from both feeds, enriched with SBOM package versions
 const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinReleasesData));
-const LTS_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts"));
+const LTS_OS_EVENTS: OsReleaseEvent[] = enrichLtsFromHistory(enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts")));
 const ALL_OS_STREAM_EVENTS: OsReleaseEvent[] = [
   ...BLUEFIN_OS_EVENTS,
   ...LTS_OS_EVENTS,
@@ -155,6 +193,7 @@ const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
       { name: "uutils-coreutils", version: "e7f2fd9", prevVersion: null },
     ],
     dxPackages: [],
+    gdxPackages: [],
     commits: [],
     fullDiff: [],
   },
@@ -164,10 +203,10 @@ const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
 // All bluefin releases are stable-daily; synthesise a "stable"-streamed clone for
 // the pinned card so it shows the "Stable" badge while the stream shows "Daily".
 const PINNED_OS_EVENTS: OsReleaseEvent[] = (() => {
-  // Pinned Bluefin card: latest from the bluefin feed, displayed as "stable" stream
-  const pinnedStable: OsReleaseEvent | undefined = BLUEFIN_OS_EVENTS.length > 0
-    ? { ...BLUEFIN_OS_EVENTS[0], stream: "stable", release: { ...BLUEFIN_OS_EVENTS[0].release, stream: "stable" } }
-    : undefined;
+  // Pinned Bluefin card: most recent weekly stable release (stream === "stable").
+  // stable-daily builds (latest-YYYYMMDD, if published) appear in the timeline only.
+  const pinnedStable: OsReleaseEvent | undefined =
+    BLUEFIN_OS_EVENTS.find((e) => e.stream === "stable") ?? BLUEFIN_OS_EVENTS[0];
   // Pinned LTS card: latest from LTS feed
   const pinnedLts: OsReleaseEvent | undefined = LTS_OS_EVENTS.length > 0 ? LTS_OS_EVENTS[0] : undefined;
   return [pinnedStable, pinnedLts, DAKOTA_PLACEHOLDER_EVENT]

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -26,6 +26,10 @@ interface Product {
   org: string;
   summary: string;
   artwork: "bluefin" | "achillobator" | "dakotaraptor";
+  downloads: {
+    display: string;
+    source: "live" | "cache" | "unavailable";
+  };
   packagePageUrl: string;
   isoSectionLink?: string | null;
   streams: StreamInfo[];
@@ -62,6 +66,17 @@ interface ImagesCatalog {
   products: Product[];
 }
 
+function sourceText(source: "live" | "cache" | "unavailable", kind: string) {
+  if (source === "live") return `${kind}: live`;
+  if (source === "cache") return `${kind}: cache`;
+  return `${kind}: unavailable`;
+}
+
+function sourceClass(source: "live" | "cache" | "unavailable") {
+  if (source === "cache") return `${styles.statChip} ${styles.chipCache}`;
+  if (source === "unavailable") return `${styles.statChip} ${styles.chipUnavailable}`;
+  return styles.statChip;
+}
 
 function StreamList({
   streams,
@@ -257,6 +272,18 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
           </section>
 
           <p className={styles.summary}>{product.summary}</p>
+
+          <div className={styles.statsRow}>
+            <span className={styles.statChip}>
+              <strong>Pulls:</strong> {product.downloads.display}
+            </span>
+            <span className={sourceClass(product.downloads.source)}>
+              {sourceText(product.downloads.source, "Downloads")}
+            </span>
+            <span className={sourceClass(product.metadataSource)}>
+              {sourceText(product.metadataSource, "Metadata")}
+            </span>
+          </div>
 
           <p className={styles.validationMeta}>
             Last validated: <strong>{lastValidated}</strong> · Last published: <strong>{lastPublished}</strong>

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -165,7 +165,7 @@ function VersionChip({ pkg }: { pkg: ParsedMajorPackage }) {
 
 // ── Chip labels we surface in the header chips row ────────────────────────────
 
-const HEADER_CHIP_NAMES = ["Kernel", "HWE Kernel", "Gnome", "Mesa", "Podman", "Nvidia", "bootc", "systemd", "pipewire", "sudo-rs", "uutils-coreutils"];
+const HEADER_CHIP_NAMES = ["Kernel", "HWE Kernel", "Gnome", "Mesa", "Podman", "Nvidia", "bootc", "systemd", "pipewire", "flatpak", "sudo-rs", "uutils-coreutils"];
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -182,14 +182,6 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
   const streamLabel = isLts ? "LTS" : isDaily ? "Daily" : isDakota ? "Dakota" : "Stable";
   const cardVariantClass = isLts ? styles.cardLts : isDakota ? styles.cardDakota : styles.cardStable;
   const cardClass = `${styles.card} ${cardVariantClass}`;
-
-  const badgeClass = isLts
-    ? styles.badgeLts
-    : isDaily
-      ? styles.badgeDaily
-      : isDakota
-        ? styles.badgeDakota
-        : styles.badgeStable;
 
   // Key package chips (header row): subset of well-known packages.
   // Falls back to fullDiff when a name isn't in the curated majorPackages table.
@@ -231,7 +223,6 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
       <div className={styles.cardHeader}>
         <div className={styles.titleRow}>
           <Heading as="h2" className={styles.cardTitle}>{cardTitle}</Heading>
-          <span className={`${styles.streamBadge} ${badgeClass}`}>{streamLabel}</span>
         </div>
 
         <div className={styles.metaRow}>
@@ -260,6 +251,16 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
         <div className={styles.dxRow}>
           <span className={styles.dxLabel}>DX</span>
           {release.dxPackages.map((pkg) => (
+            <VersionChip key={pkg.name} pkg={pkg} />
+          ))}
+        </div>
+      )}
+
+      {/* ── GDX packages (LTS only — Nvidia, CUDA) ── */}
+      {release.gdxPackages.length > 0 && (
+        <div className={styles.dxRow}>
+          <span className={styles.dxLabel}>GDX</span>
+          {release.gdxPackages.map((pkg) => (
             <VersionChip key={pkg.name} pkg={pkg} />
           ))}
         </div>

--- a/src/types/os-feed.ts
+++ b/src/types/os-feed.ts
@@ -81,8 +81,10 @@ export interface ParsedOsRelease {
   centosVersion: string | null;
   /** Entries from the "Major packages" table. */
   majorPackages: ParsedMajorPackage[];
-  /** Entries from the "Major DX packages" (or "Major GDX packages") table. */
+  /** Entries from the "Major DX packages" table (dev tools: Docker, VSCode, etc.). */
   dxPackages: ParsedMajorPackage[];
+  /** Entries from the "Major GDX packages" table (GPU extras: Nvidia, CUDA). Present on LTS only. */
+  gdxPackages: ParsedMajorPackage[];
   /** Commit list. Empty array if no commits section is present. */
   commits: ParsedCommit[];
   /**

--- a/src/types/sbom.ts
+++ b/src/types/sbom.ts
@@ -58,6 +58,8 @@ export interface PackageVersions {
   fedora: string | null;
   /** e.g. "1.6.1-1.fc43" from the `pipewire` RPM */
   pipewire: string | null;
+  /** e.g. "1.17.3-1.fc43" from the `flatpak` RPM */
+  flatpak: string | null;
   /**
    * Flat name→version map of every RPM artifact in the image.
    * Used by fetch-firehose.js to compute per-release package diffs.

--- a/src/utils/parseOsRelease.ts
+++ b/src/utils/parseOsRelease.ts
@@ -45,15 +45,16 @@ function isGtsItem(title: string): boolean {
  * Detect the release stream from the item title.
  * Returns null for retired GTS items or unrecognized title formats.
  *
- * Bluefin publishes daily automated builds tagged "stable-YYYYMMDD".
- * All stable-* tags are mapped to "stable-daily" so they appear in the stream.
- * The pinned "Current Versions" card synthesises a "stable" display from the
- * latest stable-daily event in FirehoseFeed.tsx.
+ * Bluefin publishes weekly builds tagged "stable-YYYYMMDD" (GitHub Releases).
+ * These map to the "stable" stream.
+ * "stable-daily" is reserved for if/when a separate daily-tagged release
+ * series is published.
  */
 function detectStream(title: string): OsStream | null {
   if (isGtsItem(title)) return null;
   if (/^lts[.-]/i.test(title) || /\bLTS:/i.test(title)) return "lts";
-  if (/^(stable|latest|beta)-/i.test(title)) return "stable-daily";
+  if (/^(stable|beta)-/i.test(title)) return "stable";
+  if (/^latest-/i.test(title)) return "stable-daily";
   return null;
 }
 
@@ -90,8 +91,6 @@ function extractTag(title: string, stream: OsStream): string {
     tag = tag.replace(/^lts\.(\d{8})$/, "lts-$1");
     // Normalize latest- prefix → stable-daily-YYYYMMDD
     tag = tag.replace(/^latest-(\d{8})$/, "stable-daily-$1");
-    // Normalize stable-YYYYMMDD → stable-daily-YYYYMMDD (matches OCI image tag :stable-daily)
-    tag = tag.replace(/^(?:stable|beta)-(\d{8}(\.\d+)?)$/, "stable-daily-$1");
     return tag;
   }
   // LTS alternative format: "bluefin-lts LTS: YYYYMMDD (...)"
@@ -149,7 +148,7 @@ function isMdSeparatorRow(cells: string[]): boolean {
  */
 function extractSectionsMd(content: string): Map<string, string[][]> {
   const sections = new Map<string, string[][]>();
-  const lines = content.split("\n");
+  const lines = content.split(/\r?\n/);
   let currentHeading: string | null = null;
   let currentRows: string[][] = [];
 
@@ -367,15 +366,15 @@ export function parseOsRelease(
 
   let majorPackages: ParsedMajorPackage[];
   let dxPackages: ParsedMajorPackage[];
+  let gdxPackages: ParsedMajorPackage[];
   let commits: ParsedCommit[];
   const fullDiff: ParsedDiffEntry[] = [];
 
   if (isMarkdown) {
     const mdSections = extractSectionsMd(item.content);
     majorPackages = parseTwoColTableMd(mdSections.get("Major packages") ?? []);
-    dxPackages = parseTwoColTableMd(
-      mdSections.get("Major DX packages") ?? mdSections.get("Major GDX packages") ?? [],
-    );
+    dxPackages = parseTwoColTableMd(mdSections.get("Major DX packages") ?? []);
+    gdxPackages = parseTwoColTableMd(mdSections.get("Major GDX packages") ?? []);
     commits = parseCommitsTableMd(mdSections.get("Commits") ?? []);
     for (const heading of ["All Images", "Base Images", "Dev Experience Images"]) {
       const rows = mdSections.get(heading);
@@ -384,9 +383,8 @@ export function parseOsRelease(
   } else {
     const sections = extractSections(item.content);
     majorPackages = parseTwoColTable(sections.get("Major packages") ?? "");
-    dxPackages = parseTwoColTable(
-      sections.get("Major DX packages") ?? sections.get("Major GDX packages") ?? "",
-    );
+    dxPackages = parseTwoColTable(sections.get("Major DX packages") ?? "");
+    gdxPackages = parseTwoColTable(sections.get("Major GDX packages") ?? "");
     const commitsHtml = sections.get("Commits") ?? "";
     commits = commitsHtml ? parseCommitsTable(commitsHtml) : [];
     for (const heading of ["All Images", "Base Images", "Dev Experience Images"]) {
@@ -400,7 +398,7 @@ export function parseOsRelease(
   // Backfill: any majorPackage or dxPackage that changed but is absent from fullDiff
   // gets a synthetic "changed" entry so the collapsible list shows the full upgrade path.
   const fullDiffNames = new Set(fullDiff.map((e) => e.name.toLowerCase()));
-  for (const pkg of [...majorPackages, ...dxPackages]) {
+  for (const pkg of [...majorPackages, ...dxPackages, ...gdxPackages]) {
     if (pkg.prevVersion && !fullDiffNames.has(pkg.name.toLowerCase())) {
       fullDiff.unshift({
         indicator: "changed",
@@ -422,6 +420,7 @@ export function parseOsRelease(
     centosVersion: extractCentosVersion(item.title),
     majorPackages,
     dxPackages,
+    gdxPackages,
     commits,
     fullDiff,
   };


### PR DESCRIPTION
…flatpak, driver foil cards

- Add pipewire and flatpak to SBOM extraction pipeline (fetch-github-sbom.js)
- Add pipewire and flatpak fields to PackageVersions type (sbom.ts)
- Add pipewire and flatpak to CHIP_TO_SBOM mapping in FirehoseFeed.tsx
- Add enrichLtsFromHistory() to carry forward systemd/bootc/pipewire/flatpak versions for LTS releases that lack direct SBOM data
- Add Dakota placeholder card (BuildStream junction pins, no SBOM pipeline)
- Add GDX package row (Nvidia/CUDA) to OsReleaseCard for LTS stream
- Add flatpak to HEADER_CHIP_NAMES in OsReleaseCard
- Extract kernel/mesa/gnome versions in fetch-github-driver-versions.js
- Add foil card effects (gold/silver gradients) for major/minor driver version bumps
- Add GNOME and Mesa bump tags to DriverVersionsCatalog with destructured variables
- Add sourceText/sourceClass helpers and statsRow to ImagesCatalog showing pulls count, downloads source, and metadata source indicators

Closes #57 (partial), #66, #70, #81