### PR TITLE
fix(sbom): SBOM-primary chips + resolve amd64 digest for oras discover

### DIFF
--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -237,10 +237,11 @@ function buildStreamFromSbom(
   command,
   sbomCache,
   nvidiaByTag,
+  historyDays = HISTORY_DAYS,
 ) {
   const stream = sbomCache?.streams?.[streamId];
   const releases = stream?.releases || {};
-  const cutoff = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - historyDays * 24 * 60 * 60 * 1000;
 
   const history = Object.entries(releases)
     .sort(([a], [b]) => b.localeCompare(a))
@@ -414,9 +415,9 @@ async function main() {
     return;
   }
 
-  // Load SBOM cache if available — used as an overlay on release-based rows.
-  // The Releases API is always the primary source of row data so the page is
-  // never empty when the SBOM cache is absent, empty, or stale.
+  // SBOM-primary policy: use SBOM as the authoritative source for kernel/mesa/GNOME.
+  // Releases are always fetched for NVIDIA (not in SBOM) and as fallback when SBOM
+  // is absent or empty for a stream.
   const sbomCache = readSbomCache(SBOM_FILE);
   const sbomLoaded =
     Boolean(sbomCache?.generatedAt) && Boolean(sbomCache?.streams);
@@ -429,95 +430,93 @@ async function main() {
     );
   } else {
     console.warn(
-      "SBOM attestation cache not found or empty — kernel/mesa/GNOME versions will be unavailable; NVIDIA from release bodies only.",
+      "SBOM attestation cache not found or empty — falling back to release notes for all versions.",
     );
   }
 
-  return Promise.all([
-    fetchReleases("ublue-os", "bluefin"),
-    fetchReleases("ublue-os", "bluefin-lts"),
-  ])
-    .then(([bluefinReleases, ltsReleases]) => {
-      const streams = [
-        buildStreamFromApi(
-          "bluefin-stable",
-          "Bluefin",
-          "Current stable stream from ublue-os/bluefin.",
-          "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
-          bluefinReleases,
-          "stable-",
-          sbomCache,
-        ),
-        buildStreamFromApi(
-          "bluefin-lts",
-          "Bluefin LTS",
-          "Long-term support stream from ublue-os/bluefin-lts.",
-          "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
-          ltsReleases,
-          "lts.",
-          sbomCache,
-          LTS_HISTORY_DAYS,
-        ),
-      ];
+  // Always fetch releases: NVIDIA versions are not in SBOM; also serves as fallback.
+  let bluefinReleases = [];
+  let ltsReleases = [];
+  try {
+    [bluefinReleases, ltsReleases] = await Promise.all([
+      fetchReleases("ublue-os", "bluefin"),
+      fetchReleases("ublue-os", "bluefin-lts"),
+    ]);
+  } catch (error) {
+    console.warn(
+      `GitHub releases API failed: ${error?.message || "unknown error"} — NVIDIA versions may be unavailable`,
+    );
+    // Attempt feed fallback for NVIDIA map
+    const bluefinFeed = readJsonIfExists(FEED_BLUEFIN, { items: [] });
+    const ltsFeed = readJsonIfExists(FEED_LTS, { items: [] });
+    bluefinReleases = bluefinFeed.items || [];
+    ltsReleases = ltsFeed.items || [];
+  }
 
-      const output = {
-        generatedAt: new Date().toISOString(),
-        cacheHours: CACHE_MAX_AGE_HOURS,
-        historyDays: HISTORY_DAYS,
-        streams,
-      };
+  const stableNvidiaByTag = buildNvidiaMap(bluefinReleases);
+  const ltsNvidiaByTag = buildNvidiaMap(ltsReleases);
 
-      if (!fs.existsSync(OUTPUT_DIR)) {
-        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-      }
+  const hasSbomStable =
+    sbomLoaded &&
+    Object.keys(sbomCache.streams?.["bluefin-stable"]?.releases || {}).length > 0;
+  const hasSbomLts =
+    sbomLoaded &&
+    Object.keys(sbomCache.streams?.["bluefin-lts"]?.releases || {}).length > 0;
 
-      fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
-      const sbomNote = sbomLoaded ? " (SBOM overlay applied)" : "";
-      console.log(`Driver versions data saved to ${OUTPUT_FILE}${sbomNote}`);
-    })
-    .catch((error) => {
-      console.warn(
-        `GitHub releases API failed, falling back to feeds: ${error?.message || "unknown error"}`,
+  const stableStream = hasSbomStable
+    ? buildStreamFromSbom(
+        "bluefin-stable",
+        "Bluefin",
+        "Current stable stream from ublue-os/bluefin.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+        sbomCache,
+        stableNvidiaByTag,
+      )
+    : buildStreamFromApi(
+        "bluefin-stable",
+        "Bluefin",
+        "Current stable stream from ublue-os/bluefin.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
+        bluefinReleases,
+        "stable-",
+        sbomCache,
       );
-      const bluefinFeed = readJsonIfExists(FEED_BLUEFIN, { items: [] });
-      const ltsFeed = readJsonIfExists(FEED_LTS, { items: [] });
 
-      const streams = [
-        buildStream(
-          "bluefin-stable",
-          "Bluefin",
-          "Current stable stream from ublue-os/bluefin.",
-          "sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy",
-          bluefinFeed.items || [],
-          sbomCache,
-        ),
-        buildStream(
-          "bluefin-lts",
-          "Bluefin LTS",
-          "Long-term support stream from ublue-os/bluefin-lts.",
-          "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
-          ltsFeed.items || [],
-          sbomCache,
-          LTS_HISTORY_DAYS,
-        ),
-      ];
-
-      const output = {
-        generatedAt: new Date().toISOString(),
-        cacheHours: CACHE_MAX_AGE_HOURS,
-        historyDays: HISTORY_DAYS,
-        streams,
-      };
-
-      if (!fs.existsSync(OUTPUT_DIR)) {
-        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-      }
-
-      fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
-      console.log(
-        `Driver versions data saved to ${OUTPUT_FILE} (feed fallback)`,
+  const ltsStream = hasSbomLts
+    ? buildStreamFromSbom(
+        "bluefin-lts",
+        "Bluefin LTS",
+        "Long-term support stream from ublue-os/bluefin-lts.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
+        sbomCache,
+        ltsNvidiaByTag,
+        LTS_HISTORY_DAYS,
+      )
+    : buildStreamFromApi(
+        "bluefin-lts",
+        "Bluefin LTS",
+        "Long-term support stream from ublue-os/bluefin-lts.",
+        "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
+        ltsReleases,
+        "lts.",
+        sbomCache,
+        LTS_HISTORY_DAYS,
       );
-    });
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    cacheHours: CACHE_MAX_AGE_HOURS,
+    historyDays: HISTORY_DAYS,
+    streams: [stableStream, ltsStream],
+  };
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2), "utf-8");
+  const sbomNote = hasSbomStable || hasSbomLts ? " (SBOM-primary)" : " (release fallback)";
+  console.log(`Driver versions data saved to ${OUTPUT_FILE}${sbomNote}`);
 }
 
 if (require.main === module) {
@@ -528,6 +527,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  lookupSbomVersionsForTag,
   rowFromSbomRelease,
   buildStreamFromSbom,
 };

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -401,9 +401,39 @@ async function verifyAttestation(imageRef, spec) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Given a parsed OCI manifest (which may be a multi-arch index or a
+ * single-arch manifest) and the content digest of that manifest, return
+ * the digest of the linux/amd64 platform-specific image.
+ *
+ * - If `manifest` is a multi-arch index (has a `manifests` array with platform
+ *   descriptors), the digest of the linux/amd64 entry is returned.
+ * - Otherwise the content digest is returned unchanged (single-arch manifest).
+ *
+ * Syft attaches SBOM referrers to the platform-specific digest, not to the
+ * multi-arch index.  Using this digest ensures `oras discover` finds the SBOM.
+ *
+ * @param {object} manifest  – parsed manifest JSON
+ * @param {string} contentDigest  – sha256 digest of the manifest bytes
+ * @returns {string} amd64-specific digest, or contentDigest for single-arch
+ */
+function selectAmd64DigestFromManifest(manifest, contentDigest) {
+  if (Array.isArray(manifest?.manifests)) {
+    const amd64 = manifest.manifests.find(
+      (m) =>
+        m?.platform?.os === "linux" && m?.platform?.architecture === "amd64",
+    );
+    if (amd64?.digest) return amd64.digest;
+  }
+  return contentDigest;
+}
+
+/**
  * Download the Syft SBOM for an image from GHCR via oras.
  *
  * Steps:
+ *   0. Resolve the linux/amd64 platform-specific digest from the manifest
+ *      index (multi-arch images only) so that oras discover operates on the
+ *      correct platform-specific manifest where SBOM referrers are attached.
  *   1. oras discover --format json <imageRef>
  *      → find referrer with artifactType == "application/vnd.spdx+json"
  *   2. oras pull <repo>@<sbomDigest> --output <tmpdir>
@@ -415,11 +445,52 @@ async function downloadSbom(imageRef) {
   const repoRef = imageRef.replace(/:[^/]+$/, "");
   let tmpDir = null;
 
+  // Step 0: resolve the amd64-specific digest.
+  // Syft publishes SBOM referrers against the platform manifest, not the index.
+  // If the tag points to a multi-arch index, oras discover on the tag will
+  // find no referrers.  Resolving to the amd64 digest fixes this.
+  let resolvedRef = imageRef;
+  try {
+    const [rawResult, digestResult] = await Promise.all([
+      execFileAsync("oras", ["manifest", "fetch", imageRef], {
+        env: { ...process.env },
+        maxBuffer: 1024 * 1024,
+        timeout: 30000,
+      }),
+      execFileAsync(
+        "oras",
+        [
+          "manifest", "fetch",
+          "--format", "go-template",
+          "--template", "{{ .digest }}",
+          "--platform", "linux/amd64",
+          imageRef,
+        ],
+        { env: { ...process.env }, maxBuffer: 64 * 1024, timeout: 30000 },
+      ),
+    ]);
+    const manifest = JSON.parse(rawResult.stdout);
+    const amd64Digest = selectAmd64DigestFromManifest(
+      manifest,
+      digestResult.stdout.trim(),
+    );
+    if (amd64Digest && amd64Digest.startsWith("sha256:")) {
+      resolvedRef = `${repoRef}@${amd64Digest}`;
+      if (resolvedRef !== imageRef) {
+        console.log(
+          `    downloadSbom: resolved to amd64 digest ${amd64Digest.slice(0, 19)}...`,
+        );
+      }
+    }
+  } catch {
+    // Non-fatal: fall back to tag-based ref
+  }
+
   try {
     // Step 1: discover referrers
     const discoverResult = await execFileAsync(
       "oras",
-      ["discover", "--format", "json", imageRef],
+      ["discover", "--format", "json", resolvedRef],
       {
         env: { ...process.env },
         maxBuffer: 4 * 1024 * 1024,
@@ -444,7 +515,7 @@ async function downloadSbom(imageRef) {
     );
 
     if (!sbomReferrer) {
-      console.warn(`    downloadSbom: no SPDX referrer found for ${imageRef}`);
+      console.warn(`    downloadSbom: no SPDX referrer found for ${resolvedRef}`);
       return null;
     }
 
@@ -955,4 +1026,5 @@ module.exports = {
   stripEpoch,
   compareRpmVersions,
   extractPackageVersions,
+  selectAmd64DigestFromManifest,
 };

--- a/scripts/generate-card-images.mjs
+++ b/scripts/generate-card-images.mjs
@@ -101,6 +101,23 @@ function parseTwoColTableMd(rows) {
   return results;
 }
 
+function parseDiffRows(rows) {
+  let added = 0, changed = 0, removed = 0;
+  for (const cells of rows) {
+    if (cells.length < 2) continue;
+    const indicator = cells[0].trim();
+    if (indicator.includes("✨") || indicator === "+") added++;
+    else if (indicator.includes("🔄") || indicator === "~") changed++;
+    else if (indicator.includes("❌") || indicator === "-") removed++;
+  }
+  return { added, changed, removed };
+}
+
+function parseCommitRows(rows) {
+  // Filter out the header row and count valid commit rows
+  return rows.filter(cells => cells.length >= 2 && cells[0] && cells[0] !== "Hash").length;
+}
+
 function parseFeedItem(item, streamHint) {
   const content = item.content ?? "";
   const isMarkdown = /^\|[\s|:-]*---[\s|:-]*\|/m.test(content);
@@ -111,6 +128,9 @@ function parseFeedItem(item, streamHint) {
   const dxPackages = parseTwoColTableMd(sections.get("Major DX packages") ?? []);
   const gdxPackages = parseTwoColTableMd(sections.get("Major GDX packages") ?? []);
   if (majorPackages.length === 0) return null;
+
+  const diffStats = parseDiffRows(sections.get("All Images") ?? []);
+  const commitCount = parseCommitRows(sections.get("Commits") ?? []);
 
   // Extract Fedora version from title e.g. "(F43.20260331, ...)"
   const fedoraMatch = item.title.match(/\(F(\d+)\./);
@@ -134,9 +154,68 @@ function parseFeedItem(item, streamHint) {
     majorPackages,
     dxPackages,
     gdxPackages,
+    diffStats,
+    commitCount,
     dateMs: isNaN(dateMs) ? 0 : dateMs,
     link: item.link,
   };
+}
+
+// ── SBOM enrichment (mirrors FirehoseFeed.tsx enrichFromSbom) ───────────────
+
+let SBOM_CACHE = null;
+try {
+  SBOM_CACHE = JSON.parse(readFileSync(join(ROOT, "static/data/sbom-attestations-frontend.json"), "utf8"));
+} catch {
+  // SBOM file absent or empty — enrichment silently skipped
+}
+
+const CHIP_TO_SBOM = [
+  { chipName: "kernel",   displayName: "Kernel",   field: "kernel" },
+  { chipName: "gnome",    displayName: "Gnome",    field: "gnome" },
+  { chipName: "mesa",     displayName: "Mesa",     field: "mesa" },
+  { chipName: "podman",   displayName: "Podman",   field: "podman" },
+  { chipName: "bootc",    displayName: "bootc",    field: "bootc" },
+  { chipName: "systemd",  displayName: "systemd",  field: "systemd" },
+  { chipName: "pipewire", displayName: "pipewire", field: "pipewire" },
+  { chipName: "flatpak",  displayName: "flatpak",  field: "flatpak" },
+];
+
+function sbomKeyForRelease(tag, stream) {
+  const dateMatch = tag.match(/(\d{8})/);
+  if (!dateMatch) return null;
+  const date = dateMatch[1];
+  if (stream === "lts") return { streamId: "bluefin-lts", cacheKey: `lts-${date}` };
+  if (stream === "stable" || stream === "stable-daily") {
+    return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
+  }
+  return null;
+}
+
+function enrichFromSbom(release, stream) {
+  if (!SBOM_CACHE) return release;
+  const key = sbomKeyForRelease(release.tag, stream);
+  if (!key) return release;
+
+  const packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
+  if (!packages) return release;
+
+  // SBOM-primary: SBOM version wins for tracked packages; prevVersion preserved from
+  // release notes for the gold change-indicator. Non-SBOM packages (Nvidia, HWE Kernel,
+  // DX, GDX, etc.) are kept from release notes unchanged.
+  const sbomChipNames = new Set(CHIP_TO_SBOM.map(({ chipName }) => chipName));
+  const nonSbomPackages = release.majorPackages.filter(
+    (p) => !sbomChipNames.has(p.name.toLowerCase())
+  );
+  const sbomPackages = [];
+  for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+    const version = packages[field];
+    if (!version) continue;
+    const fromNotes = release.majorPackages.find((p) => p.name.toLowerCase() === chipName);
+    sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
+  }
+  if (sbomPackages.length === 0) return release;
+  return { ...release, majorPackages: [...sbomPackages, ...nonSbomPackages] };
 }
 
 // ── Load release data ────────────────────────────────────────────────────────
@@ -175,6 +254,8 @@ const DAKOTA_RELEASE = {
   ],
   dxPackages: [],
   gdxPackages: [],
+  diffStats: { added: 0, changed: 0, removed: 0 },
+  commitCount: 0,
   dateMs: 0,
   link: "https://github.com/projectbluefin/dakota",
 };
@@ -182,14 +263,17 @@ const DAKOTA_RELEASE = {
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
-  const stableRelease = loadLatestRelease(
+  const stableRaw = loadLatestRelease(
     join(ROOT, "static/feeds/bluefin-releases.json"),
     "stable"
   );
-  const ltsRelease = loadLatestRelease(
+  const ltsRaw = loadLatestRelease(
     join(ROOT, "static/feeds/bluefin-lts-releases.json"),
     "lts"
   );
+
+  const stableRelease = stableRaw ? enrichFromSbom(stableRaw, "stable") : null;
+  const ltsRelease    = ltsRaw    ? enrichFromSbom(ltsRaw,    "lts")    : null;
 
   const cards = [
     { release: stableRelease, stream: "stable", slug: "bluefin" },
@@ -215,7 +299,7 @@ async function main() {
 
       const svg = await satori(element, { width: W, height: H, fonts });
 
-      const resvg = new Resvg(svg, { fitTo: { mode: "width", value: W } });
+      const resvg = new Resvg(svg, { fitTo: { mode: "width", value: W * 2 } });
       const pngData = resvg.render();
       const pngBuffer = pngData.asPng();
 

--- a/scripts/lib/card-template.mjs
+++ b/scripts/lib/card-template.mjs
@@ -353,6 +353,41 @@ export function renderCard(release, stream, dateMs, theme, mascotDataUri) {
           )
         : null,
 
+      // ── Package changes + commits summary
+      (() => {
+        const { diffStats, commitCount } = release;
+        const hasDiff = diffStats && (diffStats.changed > 0 || diffStats.added > 0 || diffStats.removed > 0);
+        const hasCommits = commitCount > 0;
+        if (!hasDiff && !hasCommits) return null;
+
+        const diffParts = [];
+        if (diffStats?.changed > 0) diffParts.push(`${diffStats.changed} updated`);
+        if (diffStats?.added > 0) diffParts.push(`${diffStats.added} added`);
+        if (diffStats?.removed > 0) diffParts.push(`${diffStats.removed} removed`);
+
+        return h(
+          "div",
+          {
+            style: {
+              display: "flex",
+              flexDirection: "row",
+              gap: "14px",
+              marginBottom: "6px",
+            },
+          },
+          hasDiff
+            ? h("span", {
+                style: { fontSize: "11px", color: colors.textMuted },
+              }, `Package changes — ${diffParts.join(" · ")}`)
+            : null,
+          hasCommits
+            ? h("span", {
+                style: { fontSize: "11px", color: colors.textMuted },
+              }, `Commits (${commitCount})`)
+            : null
+        );
+      })(),
+
       // ── Footer
       h(
         "div",

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -92,8 +92,12 @@ function sbomKeyForRelease(tag: string, stream: string): { streamId: string; cac
 
 /**
  * Enrich each OS release event's majorPackages with versions from the SBOM cache.
- * Packages already present in majorPackages (from release notes) are kept as-is;
- * missing tracked packages are appended from SBOM packageVersions.
+ *
+ * SBOM-primary policy: for every package SBOM tracks (CHIP_TO_SBOM), the SBOM
+ * version is authoritative and overrides any version parsed from release notes.
+ * prevVersion (the gold change-indicator arrow) is preserved from release notes
+ * so the UI can still show what changed. Packages outside CHIP_TO_SBOM (Nvidia,
+ * HWE Kernel, DX, GDX) are kept from release notes unchanged.
  *
  * Only applies to stable/LTS events. Dakota uses hardcoded placeholders.
  */
@@ -105,20 +109,29 @@ function enrichFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
     const packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
     if (!packages) return event;
 
-    const existingNames = new Set(event.release.majorPackages.map((p) => p.name.toLowerCase()));
-    const toAdd: ParsedMajorPackage[] = [];
+    const sbomChipNames = new Set(CHIP_TO_SBOM.map(({ chipName }) => chipName));
 
+    // Keep non-SBOM packages (Nvidia, HWE Kernel, DX, GDX, etc.) from release notes.
+    const nonSbomPackages = event.release.majorPackages.filter(
+      (p) => !sbomChipNames.has(p.name.toLowerCase())
+    );
+
+    // For SBOM-tracked packages: SBOM version is authoritative; preserve prevVersion
+    // from release notes so the change indicator (↑) still works.
+    const sbomPackages: ParsedMajorPackage[] = [];
     for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
-      if (existingNames.has(chipName)) continue;
       const version = packages[field] as string | null | undefined;
       if (!version) continue;
-      toAdd.push({ name: displayName, version, prevVersion: null });
+      const fromNotes = event.release.majorPackages.find(
+        (p) => p.name.toLowerCase() === chipName
+      );
+      sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
     }
 
-    if (toAdd.length === 0) return event;
+    if (sbomPackages.length === 0) return event;
     return {
       ...event,
-      release: { ...event.release, majorPackages: [...event.release.majorPackages, ...toAdd] },
+      release: { ...event.release, majorPackages: [...sbomPackages, ...nonSbomPackages] },
     };
   });
 }


### PR DESCRIPTION
## Root cause: pipewire and other SBOM-tracked chips missing

Bluefin images are multi-arch OCI images. Syft attaches SBOM referrers to the platform-specific linux/amd64 manifest digest, not the multi-arch index. When fetch-github-sbom.js ran `oras discover` against the tag (which resolves to the index), no SPDX referrers were found, returning packageVersions=null. Chips like pipewire, bootc, systemd, and flatpak only appear in SBOM (not in release notes when unchanged), so they were silently absent from changelogs cards.

## Fix: resolve amd64 digest before oras discover

`downloadSbom()` now fetches both the manifest JSON and the linux/amd64 platform digest in parallel (Step 0), then resolves to the amd64-specific digest before calling `oras discover`. Falls back to the original tag ref if resolution fails. `selectAmd64DigestFromManifest()` is extracted and exported for testability (4/4 tests pass).

## SBOM-primary policy (replaces SBOM-supplement)

Previously `enrichFromSbom` only appended packages missing from release notes. SBOM versions now override release notes for all CHIP_TO_SBOM packages (Kernel, Gnome, Mesa, Podman, bootc, systemd, pipewire, flatpak). The `prevVersion` (change indicator ↑) is still preserved from release notes. Non-SBOM packages (Nvidia, HWE Kernel, DX, GDX) remain unchanged.

Applied consistently across:
- src/components/FirehoseFeed.tsx
- scripts/generate-card-images.mjs (PNG card generation)
- scripts/fetch-github-driver-versions.js