### PR TITLE
fix(changelogs): SBOM null-fallback, GHCR tag enumeration, cache key …

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,12 +54,15 @@ jobs:
             github-data-
 
       - name: Restore SBOM attestation cache (overrides general data cache)
+        # Primary key will never match (update-sbom-cache.yml runs as a separate workflow
+        # with a different run_id). The restore-keys fallback always applies, fetching
+        # the most recent nightly SBOM cache saved by update-sbom-cache.yml.
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             static/data/sbom-attestations.json
             static/data/sbom-attestations-frontend.json
-          key: github-data-sbom-fresh-${{ github.run_id }}
+          key: github-data-sbom-${{ github.run_id }}
           restore-keys: |
             github-data-sbom-
 

--- a/scripts/enrichment.test.js
+++ b/scripts/enrichment.test.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for enrichFromSbom null-version fallback behavior.
+ *
+ * These tests use the logic from generate-card-images.mjs extracted as pure
+ * functions. The same logic exists in FirehoseFeed.tsx — fix both files.
+ */
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Replicate the logic from generate-card-images.mjs / FirehoseFeed.tsx
+// so we can unit-test it without importing ESM or TS files.
+
+const CHIP_TO_SBOM = [
+  { chipName: "kernel",   displayName: "Kernel",   field: "kernel" },
+  { chipName: "gnome",    displayName: "Gnome",    field: "gnome" },
+  { chipName: "mesa",     displayName: "Mesa",     field: "mesa" },
+  { chipName: "podman",   displayName: "Podman",   field: "podman" },
+  { chipName: "bootc",    displayName: "bootc",    field: "bootc" },
+  { chipName: "systemd",  displayName: "systemd",  field: "systemd" },
+  { chipName: "pipewire", displayName: "pipewire", field: "pipewire" },
+  { chipName: "flatpak",  displayName: "flatpak",  field: "flatpak" },
+];
+
+/** Current (buggy) implementation — chip disappears when SBOM has null */
+function enrichFromSbomBuggy(release, packages) {
+  const sbomChipNames = new Set(CHIP_TO_SBOM.map(({ chipName }) => chipName));
+  const nonSbomPackages = release.majorPackages.filter(
+    (p) => !sbomChipNames.has(p.name.toLowerCase()),
+  );
+  const sbomPackages = [];
+  for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+    const version = packages[field];
+    if (!version) continue; // BUG: drops chip when null; release notes fallback also excluded
+    const fromNotes = release.majorPackages.find((p) => p.name.toLowerCase() === chipName);
+    sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
+  }
+  if (sbomPackages.length === 0) return release;
+  return { ...release, majorPackages: [...sbomPackages, ...nonSbomPackages] };
+}
+
+/** Fixed implementation — falls back to release notes when SBOM has null */
+function enrichFromSbomFixed(release, packages) {
+  const sbomChipNames = new Set(CHIP_TO_SBOM.map(({ chipName }) => chipName));
+  const nonSbomPackages = release.majorPackages.filter(
+    (p) => !sbomChipNames.has(p.name.toLowerCase()),
+  );
+  const sbomPackages = [];
+  for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+    const sbomVersion = packages[field];
+    const fromNotes = release.majorPackages.find((p) => p.name.toLowerCase() === chipName);
+    const version = sbomVersion ?? fromNotes?.version ?? null;
+    if (!version) continue; // neither SBOM nor release notes has this package
+    sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
+  }
+  if (sbomPackages.length === 0) return release;
+  return { ...release, majorPackages: [...sbomPackages, ...nonSbomPackages] };
+}
+
+// Mock release with kernel + flatpak in release notes
+const mockRelease = {
+  tag: "stable-20260331",
+  majorPackages: [
+    { name: "Kernel", version: "6.17.0-200.fc41", prevVersion: null },
+    { name: "Nvidia", version: "570.86", prevVersion: null },
+    { name: "flatpak", version: "1.14.0", prevVersion: null },
+  ],
+};
+
+// SBOM with kernel present but flatpak null
+const partialSbomPackages = {
+  kernel: "6.17.0-200.fc41.x86_64",
+  gnome: "49.4-1.fc41",
+  mesa: "25.0.3-1.fc41",
+  podman: "5.5.0-1.fc41",
+  bootc: "1.1.0-1.fc41",
+  systemd: "257.2-1.fc41",
+  pipewire: "1.2.0-1.fc41",
+  flatpak: null,   // ← null: not found in SBOM RPM database
+};
+
+test("buggy: flatpak chip disappears when SBOM has null (documents the bug)", () => {
+  const result = enrichFromSbomBuggy(mockRelease, partialSbomPackages);
+  const flatpakChip = result.majorPackages.find((p) => p.name.toLowerCase() === "flatpak");
+  // The buggy implementation drops flatpak: it's excluded from nonSbomPackages
+  // (CHIP_TO_SBOM package) AND skipped from sbomPackages (null version).
+  assert.equal(flatpakChip, undefined, "buggy implementation drops the flatpak chip when SBOM has null");
+});
+
+test("fixed: flatpak chip uses release notes fallback when SBOM has null", () => {
+  const result = enrichFromSbomFixed(mockRelease, partialSbomPackages);
+  const flatpakChip = result.majorPackages.find((p) => p.name.toLowerCase() === "flatpak");
+  assert.ok(flatpakChip, "flatpak chip must be present with release notes fallback version");
+  assert.equal(flatpakChip.version, "1.14.0", "fallback version must come from release notes");
+});
+
+test("fixed: SBOM version wins over release notes when both present", () => {
+  const result = enrichFromSbomFixed(mockRelease, partialSbomPackages);
+  const kernelChip = result.majorPackages.find((p) => p.name.toLowerCase() === "kernel");
+  assert.ok(kernelChip, "kernel chip must be present");
+  assert.equal(kernelChip.version, "6.17.0-200.fc41.x86_64", "SBOM version must win over release notes");
+});
+
+test("fixed: chip absent from both SBOM and release notes is still omitted", () => {
+  const sbomWithNullGnome = { ...partialSbomPackages, gnome: null };
+  const releaseWithoutGnome = {
+    ...mockRelease,
+    majorPackages: mockRelease.majorPackages.filter((p) => p.name.toLowerCase() !== "gnome"),
+  };
+  const result = enrichFromSbomFixed(releaseWithoutGnome, sbomWithNullGnome);
+  const gnomeChip = result.majorPackages.find((p) => p.name.toLowerCase() === "gnome");
+  assert.equal(gnomeChip, undefined, "gnome chip must be absent when neither SBOM nor notes has it");
+});
+
+test("fixed: non-SBOM chips (Nvidia) are preserved unchanged", () => {
+  const result = enrichFromSbomFixed(mockRelease, partialSbomPackages);
+  const nvidiaChip = result.majorPackages.find((p) => p.name.toLowerCase() === "nvidia");
+  assert.ok(nvidiaChip, "Nvidia chip (non-SBOM) must be preserved");
+  assert.equal(nvidiaChip.version, "570.86");
+});

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -248,6 +248,67 @@ async function fetchReleaseTags(owner, repo) {
 }
 
 // ---------------------------------------------------------------------------
+// GHCR OCI distribution API — tag listing
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a GHCR bearer token for the given org/package.
+ * Uses GITHUB_TOKEN/GH_TOKEN if available; falls back to anonymous (public images).
+ */
+async function getGhcrToken(org, pkg) {
+  const headers = { "User-Agent": "BluefinDocsSBOM/1.0" };
+  const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (ghToken) {
+    const b64 = Buffer.from(`x-access-token:${ghToken}`).toString("base64");
+    headers.Authorization = `Basic ${b64}`;
+  }
+  const url = `https://ghcr.io/token?scope=repository:${org}/${pkg}:pull&service=ghcr.io`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GHCR token exchange failed: HTTP ${res.status} — ${url}`);
+  }
+  const body = await res.json();
+  return body.token;
+}
+
+/**
+ * Fetch ALL tags for a GHCR package using the OCI distribution spec.
+ * Handles pagination via Link header.
+ *
+ * @param {string} org   GitHub org (e.g. "ublue-os")
+ * @param {string} pkg   Package name (e.g. "bluefin")
+ * @returns {Promise<string[]>} Full list of tag strings
+ */
+async function fetchGhcrTags(org, pkg) {
+  const token = await getGhcrToken(org, pkg);
+  const allTags = [];
+  let url = `https://ghcr.io/v2/${org}/${pkg}/tags/list?n=1000`;
+
+  while (url) {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "BluefinDocsSBOM/1.0",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GHCR tags/list failed: HTTP ${res.status} — ${url}`);
+    }
+    const body = await res.json();
+    if (Array.isArray(body.tags)) allTags.push(...body.tags);
+
+    // Follow pagination Link header per RFC 5988 / OCI distribution spec.
+    // Use a flexible regex (parameters in any order, optional quoting, case-insensitive)
+    // and resolve relative URLs against the response URL for spec compliance.
+    const linkHeader = res.headers.get("link") || "";
+    const nextMatch = linkHeader.match(/<([^>]+)>;[^<]*\brel=("?)next\2\b/i);
+    url = nextMatch ? new URL(nextMatch[1], res.url).href : null;
+  }
+
+  return allTags;
+}
+
+// ---------------------------------------------------------------------------
 // Tag filtering helpers
 // ---------------------------------------------------------------------------
 
@@ -728,41 +789,41 @@ function extractPackageVersions(sbomPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * Find recent dated tags for a given stream prefix.
+/**
+ * Filter a list of GHCR tag strings to find recent dated tags for a given stream.
  *
- * @param {Array<{tagName: string, publishedAt: string|null}>} releaseTags
- *   Release tags from the GitHub Releases API (fetchReleaseTags output).
- * @param {object} spec  Stream spec from STREAM_SPECS.
- * @returns {Array<{tag: string, cacheKey: string, dateStr: string, imageRef: string, publishedAt: string|null}>}
- *   Most-recent first, limited to MAX_RELEASES within LOOKBACK_DAYS.
+ * @param {string[]} ghcrTags  Raw tag strings from fetchGhcrTags().
+ * @param {object}   spec      Stream spec from STREAM_SPECS.
+ * @returns {Array<{tag, cacheKey, dateStr, imageRef, publishedAt}>}
  */
-function findRecentTagsForStream(releaseTags, spec) {
+function findRecentTagsForStream(ghcrTags, spec) {
   const cutoff = Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
   const found = [];
 
-  for (const { tagName, publishedAt } of releaseTags) {
-    const publishedMs = publishedAt ? Date.parse(publishedAt) : null;
-    if (publishedMs !== null && publishedMs < cutoff) continue;
-
+  for (const tagName of ghcrTags) {
     const normalised = normaliseLtsTag(tagName.toLowerCase());
     if (!normalised.startsWith(`${spec.streamPrefix}-`)) continue;
     const dateStr = extractDateFromTag(normalised);
     if (!dateStr) continue;
 
     // Enforce canonical tag: only exact `<streamPrefix>-YYYYMMDD` is accepted.
-    // Non-canonical variants like lts-hwe-testing-20260331 would normalise to
-    // lts-20260331 and silently overwrite valid canonical entries.
     const expectedCanonical = `${spec.streamPrefix}-${dateStr}`;
     if (normalised !== expectedCanonical) continue;
+
+    // Tags from GHCR have no publishedAt — derive from the date string.
+    const year = dateStr.slice(0, 4);
+    const month = dateStr.slice(4, 6);
+    const day = dateStr.slice(6, 8);
+    const publishedAt = `${year}-${month}-${day}T00:00:00Z`;
+    const publishedMs = Date.parse(publishedAt);
+    if (isNaN(publishedMs) || publishedMs < cutoff) continue;
 
     found.push({
       tag: normalised,
       cacheKey: buildCacheKey(spec.streamPrefix, dateStr),
       dateStr,
-      // Use the original tag name (not lowercased normalised) for the image ref
-      // so the GHCR manifest lookup uses the exact published tag.
       imageRef: `ghcr.io/${spec.org}/${spec.package}:${tagName}`,
-      publishedAt: publishedAt || null,
+      publishedAt,
     });
   }
 
@@ -776,8 +837,9 @@ function findRecentTagsForStream(releaseTags, spec) {
     }
   }
 
-  // Sort descending by date string (YYYYMMDD sorts lexicographically)
+  // Sort descending by dateStr (YYYYMMDD sorts lexicographically)
   unique.sort((a, b) => b.dateStr.localeCompare(a.dateStr));
+
   return unique.slice(0, MAX_RELEASES);
 }
 
@@ -785,24 +847,25 @@ function findRecentTagsForStream(releaseTags, spec) {
  * Build the result object for a single stream.
  *
  * @param {object} spec  Stream spec from STREAM_SPECS.
- * @param {Map<string, Array<{tagName: string, publishedAt: string|null}>>} releaseTagsByRepo
- *   Pre-fetched release tags keyed by "owner/repo" (spec.releasesRepo).
+ * @param {Map<string, string[]>} ghcrTagsByImage
+ *   Pre-fetched GHCR tag strings keyed by "org/package".
  * @param {object|null} existing  Existing cache for incremental updates.
  */
-async function processStream(spec, releaseTagsByRepo, existing) {
-  // If the releases repo fetch failed — preserve existing cache.
-  if (!releaseTagsByRepo.has(spec.releasesRepo)) {
+async function processStream(spec, ghcrTagsByImage, existing) {
+  const imageKey = `${spec.org}/${spec.package}`;
+  // If the GHCR tag fetch failed — preserve existing cache.
+  if (!ghcrTagsByImage.has(imageKey)) {
     if (existing?.streams?.[spec.id]) {
       console.log(
-        `  ${spec.id}: Releases API unavailable — keeping existing cache`,
+        `  ${spec.id}: GHCR tags unavailable — keeping existing cache`,
       );
       return existing.streams[spec.id];
     }
     // No existing cache to fall back to; return empty stream.
     return { id: spec.id, label: spec.label, org: spec.org, package: spec.package, streamPrefix: spec.streamPrefix, keyRepo: spec.keyRepo, keyless: spec.keyless, releases: {} };
   }
-  const releaseTags = releaseTagsByRepo.get(spec.releasesRepo);
-  const recentTags = findRecentTagsForStream(releaseTags, spec);
+  const ghcrTags = ghcrTagsByImage.get(imageKey);
+  const recentTags = findRecentTagsForStream(ghcrTags, spec);
 
   console.log(
     `  ${spec.id}: found ${recentTags.length} recent tagged releases`,
@@ -926,24 +989,24 @@ async function main() {
     }
   }
 
-  // Deduplicate releasesRepo values — multiple streams share the same repo
-  // (e.g. bluefin-stable and bluefin-dx-stable both use ublue-os/bluefin).
-  const uniqueRepos = new Set(STREAM_SPECS.map((s) => s.releasesRepo));
+  // Deduplicate by GHCR image — multiple streams share the same image
+  // (e.g. bluefin-stable and bluefin-dx-stable both pull from ublue-os/bluefin).
+  const uniqueImages = new Set(STREAM_SPECS.map((s) => `${s.org}/${s.package}`));
 
   console.log(
-    `Fetching release tags for ${uniqueRepos.size} repo(s)...`,
+    `Fetching GHCR tags for ${uniqueImages.size} image(s)...`,
   );
-  const releaseTagsByRepo = new Map();
-  for (const repoPath of uniqueRepos) {
-    const [owner, repo] = repoPath.split("/");
-    console.log(`  ${repoPath}`);
+  const ghcrTagsByImage = new Map();
+  for (const imageKey of uniqueImages) {
+    const [org, pkg] = imageKey.split("/");
+    console.log(`  ghcr.io/${imageKey}`);
     try {
-      const tags = await fetchReleaseTags(owner, repo);
-      releaseTagsByRepo.set(repoPath, tags);
-      console.log(`    ${tags.length} release tags fetched`);
+      const tags = await fetchGhcrTags(org, pkg);
+      ghcrTagsByImage.set(imageKey, tags);
+      console.log(`    ${tags.length} GHCR tags fetched`);
     } catch (err) {
-      console.error(`  Failed to fetch releases for ${repoPath}: ${err.message}`);
-      // Leave the key absent so processStream detects the fetch failure
+      console.error(`  Failed to fetch GHCR tags for ${imageKey}: ${err.message}`);
+      // Leave the key absent so processStream detects the failure
       // and preserves the existing cache instead of producing an empty stream.
     }
   }
@@ -953,7 +1016,7 @@ async function main() {
   for (const spec of STREAM_SPECS) {
     console.log(`\nProcessing stream: ${spec.id}`);
     try {
-      const result = await processStream(spec, releaseTagsByRepo, existing);
+      const result = await processStream(spec, ghcrTagsByImage, existing);
       streams[spec.id] = result;
     } catch (err) {
       console.error(`  Error processing ${spec.id}: ${err.message}`);
@@ -1027,4 +1090,6 @@ module.exports = {
   compareRpmVersions,
   extractPackageVersions,
   selectAmd64DigestFromManifest,
+  findRecentTagsForStream,
+  fetchGhcrTags,   // exported for integration testing
 };

--- a/scripts/fetch-github-sbom.test.js
+++ b/scripts/fetch-github-sbom.test.js
@@ -5,6 +5,7 @@ const {
   selectAmd64DigestFromManifest,
   stripEpoch,
   compareRpmVersions,
+  findRecentTagsForStream,
 } = require("./fetch-github-sbom.js");
 
 test("selectAmd64DigestFromManifest picks linux/amd64 from multi-arch index", () => {
@@ -48,4 +49,42 @@ test("compareRpmVersions compares numeric segments correctly", () => {
   assert.ok(compareRpmVersions("6.18.2-200", "6.18.13-200") < 0);
   assert.ok(compareRpmVersions("6.18.13-200", "6.18.2-200") > 0);
   assert.equal(compareRpmVersions("6.18.13-200", "6.18.13-200"), 0);
+});
+
+const MOCK_STABLE_SPEC = {
+  id: "bluefin-stable",
+  org: "ublue-os",
+  package: "bluefin",
+  streamPrefix: "stable",
+  keyless: true,
+};
+
+// Fixed reference date used across all time-sensitive tests to avoid flakiness.
+// Must stay within LOOKBACK_DAYS (90 days) of any future test run — update when stale.
+const FIXED_RECENT_DATE = "20260412";
+
+test("findRecentTagsForStream: picks stable-YYYYMMDD tags from GHCR list", () => {
+  const ghcrTags = [
+    `stable-${FIXED_RECENT_DATE}`,
+    "latest-20260101",                        // different stream prefix — must be excluded
+    `stable-${FIXED_RECENT_DATE}-hwe`,        // non-canonical suffix — must be excluded
+    "v1.0.0",                                 // no date — must be excluded
+  ];
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(result.length, 1, "only the canonical stable-YYYYMMDD tag should be found");
+  assert.equal(result[0].tag, `stable-${FIXED_RECENT_DATE}`);
+  assert.equal(result[0].cacheKey, `stable-${FIXED_RECENT_DATE}`);
+});
+
+test("findRecentTagsForStream: excludes tags older than LOOKBACK_DAYS", () => {
+  const oldDate = "20200101"; // way in the past
+  const ghcrTags = [`stable-${oldDate}`];
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(result.length, 0, "old tags must be excluded");
+});
+
+test("findRecentTagsForStream: deduplicates same date", () => {
+  const ghcrTags = [`stable-${FIXED_RECENT_DATE}`, `stable-${FIXED_RECENT_DATE}`]; // duplicate
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(result.length, 1, "duplicates must be removed");
 });

--- a/scripts/generate-card-images.mjs
+++ b/scripts/generate-card-images.mjs
@@ -209,9 +209,10 @@ function enrichFromSbom(release, stream) {
   );
   const sbomPackages = [];
   for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
-    const version = packages[field];
-    if (!version) continue;
+    const sbomVersion = packages[field];
     const fromNotes = release.majorPackages.find((p) => p.name.toLowerCase() === chipName);
+    const version = sbomVersion ?? fromNotes?.version ?? null;
+    if (!version) continue; // neither SBOM nor release notes has this package
     sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
   }
   if (sbomPackages.length === 0) return release;

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -107,7 +107,14 @@ function enrichFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
     if (!key) return event;
 
     const packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
-    if (!packages) return event;
+    if (!packages) {
+      // Expected during local dev (empty seed file) and for releases older than LOOKBACK_DAYS.
+      // In CI with a populated SBOM cache this should be rare — check update-sbom-cache.yml if frequent.
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[SBOM] No cache entry for ${key.streamId}/${key.cacheKey} — using release notes`);
+      }
+      return event;
+    }
 
     const sbomChipNames = new Set(CHIP_TO_SBOM.map(({ chipName }) => chipName));
 
@@ -116,15 +123,17 @@ function enrichFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
       (p) => !sbomChipNames.has(p.name.toLowerCase())
     );
 
-    // For SBOM-tracked packages: SBOM version is authoritative; preserve prevVersion
-    // from release notes so the change indicator (↑) still works.
+    // For SBOM-tracked packages: SBOM version is authoritative; fall back to
+    // release notes version if SBOM has null (package not found in RPM database).
+    // Preserves prevVersion from release notes so the change indicator (↑) works.
     const sbomPackages: ParsedMajorPackage[] = [];
     for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
-      const version = packages[field] as string | null | undefined;
-      if (!version) continue;
+      const sbomVersion = packages[field] as string | null | undefined;
       const fromNotes = event.release.majorPackages.find(
         (p) => p.name.toLowerCase() === chipName
       );
+      const version = sbomVersion ?? fromNotes?.version ?? null;
+      if (!version) continue; // neither SBOM nor release notes has this package — omit chip
       sbomPackages.push({ name: displayName, version, prevVersion: fromNotes?.prevVersion ?? null });
     }
 

--- a/tests/e2e/changelogs.spec.ts
+++ b/tests/e2e/changelogs.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Changelogs page — chip consistency", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/changelogs");
+    // Wait for the pinned cards section to load
+    await page.waitForSelector('[data-testid="pinned-os-cards"], .card, article', {
+      timeout: 15_000,
+    });
+  });
+
+  test("pinned Bluefin stable card renders with version chips", async ({ page }) => {
+    // The pinned stable card is always the first OsReleaseCard rendered
+    const stableCard = page.locator("article").first();
+    await expect(stableCard).toBeVisible();
+
+    // The chips row must not be empty
+    const chipsRow = stableCard.locator(".chipsRow, [class*='chipsRow']");
+    await expect(chipsRow).toBeVisible();
+
+    // Kernel and Gnome chips must always be present — both are in release notes
+    // and in CHIP_TO_SBOM. If enrichFromSbom null-fallback bug exists, they
+    // could disappear when SBOM has partial data.
+    const chips = chipsRow.locator("[class*='versionChip']");
+    const chipCount = await chips.count();
+    expect(chipCount, "stable card must have at least 2 version chips").toBeGreaterThanOrEqual(2);
+  });
+
+  test("pinned stable card shows Kernel chip with a non-empty version", async ({ page }) => {
+    const stableCard = page.locator("article").first();
+    const chipsRow = stableCard.locator("[class*='chipsRow']");
+
+    // Find a chip whose label contains "Kernel"
+    const kernelChip = chipsRow.locator("[class*='chipLabel']", { hasText: /^kernel$/i })
+      .locator("..")
+      .locator("[class*='chipValue']");
+    await expect(kernelChip).toBeVisible();
+    const version = await kernelChip.textContent();
+    expect(version, "Kernel chip must have a non-empty version string").toBeTruthy();
+    expect(version!.trim().length, "Kernel version must not be empty").toBeGreaterThan(0);
+  });
+
+  test("pinned stable card shows Gnome chip with a non-empty version", async ({ page }) => {
+    const stableCard = page.locator("article").first();
+    const chipsRow = stableCard.locator("[class*='chipsRow']");
+
+    const gnomeChip = chipsRow.locator("[class*='chipLabel']", { hasText: /^gnome$/i })
+      .locator("..")
+      .locator("[class*='chipValue']");
+    await expect(gnomeChip).toBeVisible();
+    const version = await gnomeChip.textContent();
+    expect(version, "Gnome chip must have a non-empty version string").toBeTruthy();
+    expect(version!.trim().length, "Gnome version must not be empty").toBeGreaterThan(0);
+  });
+
+  test("changelogs page has an updates stream with at least one entry", async ({ page }) => {
+    // The updates stream (timeline below pinned cards) must render entries
+    // This catches a total data pipeline failure (empty feed)
+    const timeline = page.locator("[class*='firehoseList'], [class*='timelineList'], [class*='feedList']");
+    if (await timeline.isVisible()) {
+      const items = timeline.locator(":scope > *");
+      const count = await items.count();
+      expect(count, "updates stream must have at least one entry").toBeGreaterThan(0);
+    }
+    // If no timeline found, at least verify the page loaded (not a blank error)
+    const heading = page.locator("h1, h2").first();
+    await expect(heading).toBeVisible();
+  });
+});


### PR DESCRIPTION
…alignment

- Fix enrichFromSbom null-fallback bug in FirehoseFeed.tsx and generate-card-images.mjs: SBOM null now falls back to release notes version rather than silently dropping the chip (fixes pipewire and other stable packages disappearing from cards)
- Replace GitHub Releases API with GHCR OCI distribution API in fetch-github-sbom.js so daily builds without a GitHub Release are included in the SBOM pipeline
- Remove dead -fresh- prefix from pages.yml SBOM cache restore key, aligning it with the key saved by update-sbom-cache.yml
- Add Playwright e2e tests for changelogs chip consistency
- Add unit tests (enrichment.test.js) documenting the null-fallback bug and validating the fix; add 3 tests for findRecentTagsForStream