### PR TITLE
feat(sbom): add stable-daily GHCR stream to SBOM pipeline and changelogs

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -108,6 +108,15 @@ const STREAM_SPECS = [
     keyless: true,
   },
   {
+    id: "bluefin-stable-daily",
+    label: "Bluefin Stable Daily",
+    org: "ublue-os",
+    package: "bluefin",
+    streamPrefix: "stable-daily",
+    keyRepo: "ublue-os/bluefin",
+    keyless: true,
+  },
+  {
     id: "bluefin-latest",
     label: "Bluefin Latest",
     org: "ublue-os",

--- a/scripts/fetch-github-sbom.test.js
+++ b/scripts/fetch-github-sbom.test.js
@@ -59,6 +59,14 @@ const MOCK_STABLE_SPEC = {
   keyless: true,
 };
 
+const MOCK_STABLE_DAILY_SPEC = {
+  id: "bluefin-stable-daily",
+  org: "ublue-os",
+  package: "bluefin",
+  streamPrefix: "stable-daily",
+  keyless: true,
+};
+
 // Fixed reference date used across all time-sensitive tests to avoid flakiness.
 // Must stay within LOOKBACK_DAYS (90 days) of any future test run — update when stale.
 const FIXED_RECENT_DATE = "20260412";
@@ -87,4 +95,27 @@ test("findRecentTagsForStream: deduplicates same date", () => {
   const ghcrTags = [`stable-${FIXED_RECENT_DATE}`, `stable-${FIXED_RECENT_DATE}`]; // duplicate
   const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
   assert.equal(result.length, 1, "duplicates must be removed");
+});
+
+test("findRecentTagsForStream: picks stable-daily-YYYYMMDD tags for stable-daily spec", () => {
+  const ghcrTags = [
+    `stable-daily-${FIXED_RECENT_DATE}`,
+    `stable-${FIXED_RECENT_DATE}`,              // different prefix (weekly stable) — must be excluded
+    `stable-daily-${FIXED_RECENT_DATE}-hwe`,    // non-canonical suffix — must be excluded
+    "latest-20260101",                          // unrelated prefix — must be excluded
+  ];
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_DAILY_SPEC);
+  assert.equal(result.length, 1, "only the canonical stable-daily-YYYYMMDD tag should be found");
+  assert.equal(result[0].tag, `stable-daily-${FIXED_RECENT_DATE}`);
+  assert.equal(result[0].cacheKey, `stable-daily-${FIXED_RECENT_DATE}`);
+});
+
+test("findRecentTagsForStream: stable spec does not pick stable-daily tags", () => {
+  const ghcrTags = [
+    `stable-daily-${FIXED_RECENT_DATE}`,
+    `stable-${FIXED_RECENT_DATE}`,
+  ];
+  const result = findRecentTagsForStream(ghcrTags, MOCK_STABLE_SPEC);
+  assert.equal(result.length, 1, "stable spec must not pick stable-daily tags");
+  assert.equal(result[0].tag, `stable-${FIXED_RECENT_DATE}`);
 });

--- a/scripts/generate-card-images.mjs
+++ b/scripts/generate-card-images.mjs
@@ -186,9 +186,8 @@ function sbomKeyForRelease(tag, stream) {
   if (!dateMatch) return null;
   const date = dateMatch[1];
   if (stream === "lts") return { streamId: "bluefin-lts", cacheKey: `lts-${date}` };
-  if (stream === "stable" || stream === "stable-daily") {
-    return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
-  }
+  if (stream === "stable-daily") return { streamId: "bluefin-stable-daily", cacheKey: `stable-daily-${date}` };
+  if (stream === "stable") return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
   return null;
 }
 

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -84,9 +84,8 @@ function sbomKeyForRelease(tag: string, stream: string): { streamId: string; cac
   if (!dateMatch) return null;
   const date = dateMatch[1];
   if (stream === "lts") return { streamId: "bluefin-lts", cacheKey: `lts-${date}` };
-  if (stream === "stable" || stream === "stable-daily") {
-    return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
-  }
+  if (stream === "stable-daily") return { streamId: "bluefin-stable-daily", cacheKey: `stable-daily-${date}` };
+  if (stream === "stable") return { streamId: "bluefin-stable", cacheKey: `stable-${date}` };
   return null;
 }
 
@@ -182,11 +181,69 @@ function enrichLtsFromHistory(events: OsReleaseEvent[]): OsReleaseEvent[] {
   return enriched.sort((a, b) => b.dateMs - a.dateMs);
 }
 
+/**
+ * Synthesise OsReleaseEvent entries for stable-daily builds that exist only in
+ * GHCR (no GitHub Release). These are GHCR nightly builds tagged
+ * "stable-daily-YYYYMMDD" — they never appear in bluefin-releases.json so they
+ * would otherwise be invisible on the changelogs page.
+ *
+ * Package versions come directly from the SBOM cache so no enrichFromSbom pass
+ * is needed; the events are already fully populated.
+ */
+function loadStableDailyEventsFromSbom(): OsReleaseEvent[] {
+  const stream = SBOM_CACHE?.streams?.["bluefin-stable-daily"];
+  if (!stream?.releases) return [];
+
+  const events: OsReleaseEvent[] = [];
+  for (const [cacheKey, releaseData] of Object.entries(stream.releases)) {
+    if (!releaseData.packageVersions) continue;
+
+    const dateMatch = cacheKey.match(/(\d{8})$/);
+    if (!dateMatch) continue;
+    const dateStr = dateMatch[1];
+    const dateMs = Date.parse(
+      `${dateStr.slice(0, 4)}-${dateStr.slice(4, 6)}-${dateStr.slice(6, 8)}T00:00:00Z`,
+    );
+    if (isNaN(dateMs)) continue;
+
+    const packages = releaseData.packageVersions;
+    const majorPackages: ParsedMajorPackage[] = [];
+    for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+      const version = packages[field] as string | null | undefined;
+      if (!version) continue;
+      majorPackages.push({ name: displayName, version, prevVersion: null });
+    }
+    if (majorPackages.length === 0) continue;
+
+    events.push({
+      kind: "os",
+      stream: "stable-daily",
+      dateMs,
+      release: {
+        stream: "stable-daily",
+        tag: cacheKey,
+        githubUrl: "https://github.com/orgs/ublue-os/packages/container/package/bluefin",
+        fedoraVersion: packages.fedora ? packages.fedora.replace(/^F/, "") : null,
+        centosVersion: null,
+        majorPackages,
+        dxPackages: [],
+        gdxPackages: [],
+        commits: [],
+        fullDiff: [],
+      },
+    });
+  }
+
+  return events;
+}
+
 // All parsed events from both feeds, enriched with SBOM package versions
 const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinReleasesData));
+const STABLE_DAILY_OS_EVENTS: OsReleaseEvent[] = loadStableDailyEventsFromSbom();
 const LTS_OS_EVENTS: OsReleaseEvent[] = enrichLtsFromHistory(enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts")));
 const ALL_OS_STREAM_EVENTS: OsReleaseEvent[] = [
   ...BLUEFIN_OS_EVENTS,
+  ...STABLE_DAILY_OS_EVENTS,
   ...LTS_OS_EVENTS,
 ].sort((a, b) => b.dateMs - a.dateMs);
 

--- a/src/utils/parseOsRelease.ts
+++ b/src/utils/parseOsRelease.ts
@@ -53,6 +53,7 @@ function isGtsItem(title: string): boolean {
 function detectStream(title: string): OsStream | null {
   if (isGtsItem(title)) return null;
   if (/^lts[.-]/i.test(title) || /\bLTS:/i.test(title)) return "lts";
+  if (/^stable-daily-/i.test(title)) return "stable-daily";
   if (/^(stable|beta)-/i.test(title)) return "stable";
   if (/^latest-/i.test(title)) return "stable-daily";
   return null;
@@ -83,6 +84,10 @@ function extractCentosVersion(title: string): string | null {
  *   "lts.20251223: ..."               → "lts-20251223"
  */
 function extractTag(title: string, stream: OsStream): string {
+  // Compound prefix format: "stable-daily-YYYYMMDD" (two word segments before the date)
+  const compoundMatch = title.match(/^([a-z]+-[a-z]+-\d{8})/i);
+  if (compoundMatch) return compoundMatch[1].toLowerCase();
+
   // Standard prefix format: "stable-YYYYMMDD", "lts-YYYYMMDD", "lts.YYYYMMDD", "latest-YYYYMMDD"
   const prefixMatch = title.match(/^([a-z]+-[\d.]+)/i);
   if (prefixMatch) {


### PR DESCRIPTION
Bluefin stable-daily-YYYYMMDD builds are pushed to GHCR without a corresponding GitHub Release. They were invisible on the changelogs page because the SBOM pipeline only tracked streams whose tags appear in GitHub Releases, and the feed parser couldn't produce entries for GHCR-only tags.

Changes:
- fetch-github-sbom.js: add bluefin-stable-daily stream spec (streamPrefix: "stable-daily") so the nightly GHCR tags are picked up by findRecentTagsForStream and their SBOMs are fetched and cached.
- parseOsRelease.ts: fix detectStream() to check ^stable-daily- before the broader ^(stable|beta)- guard so compound prefixes aren't misdetected as "stable". Fix extractTag() to handle compound prefixes (word-word-YYYYMMDD) via a dedicated regex before the standard single-word check.
- FirehoseFeed.tsx: update sbomKeyForRelease() to route stable-daily events to bluefin-stable-daily stream (was incorrectly routing to bluefin-stable). Add loadStableDailyEventsFromSbom() which synthesises OsReleaseEvent entries directly from the SBOM cache for GHCR-only daily builds — these never appear in bluefin-releases.json so they need a separate code path. Include STABLE_DAILY_OS_EVENTS in ALL_OS_STREAM_EVENTS.
- generate-card-images.mjs: same sbomKeyForRelease() fix for consistency.
- fetch-github-sbom.test.js: 2 new tests verifying stable-daily tag filtering and that stable spec does not accidentally match stable-daily.