### PR TITLE
fix(lint): remove unused chipName destructuring in loadStableDailyEve…

### DIFF
--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -208,7 +208,7 @@ function loadStableDailyEventsFromSbom(): OsReleaseEvent[] {
 
     const packages = releaseData.packageVersions;
     const majorPackages: ParsedMajorPackage[] = [];
-    for (const { chipName, displayName, field } of CHIP_TO_SBOM) {
+    for (const { displayName, field } of CHIP_TO_SBOM) {
       const version = packages[field] as string | null | undefined;
       if (!version) continue;
       majorPackages.push({ name: displayName, version, prevVersion: null });


### PR DESCRIPTION
…ntsFromSbom

In the stable-daily SBOM loader loop, chipName was destructured from CHIP_TO_SBOM but not used — displayName and field are sufficient. This unblocks the ESLint error that failed CI after PR #744.