### PR TITLE
fix(embed): use picture element for dark/light mode card snippet

### DIFF
--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -241,8 +241,12 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
   const { siteConfig } = useDocusaurusContext();
   const BASE_URL = siteConfig.url;
   const embedSnippet = [
-    `[![${cardAlt}](${BASE_URL}/img/cards/${cardSlug}-light.png#gh-light-mode-only)](${BASE_URL}/changelogs)`,
-    `[![${cardAlt}](${BASE_URL}/img/cards/${cardSlug}-dark.png#gh-dark-mode-only)](${BASE_URL}/changelogs)`,
+    `<a href="${BASE_URL}/changelogs">`,
+    `  <picture>`,
+    `    <source media="(prefers-color-scheme: dark)" srcset="${BASE_URL}/img/cards/${cardSlug}-dark.png">`,
+    `    <img src="${BASE_URL}/img/cards/${cardSlug}-light.png" alt="${cardAlt}" width="800">`,
+    `  </picture>`,
+    `</a>`,
   ].join("\n");
 
   return (


### PR DESCRIPTION
The #gh-light-mode-only / #gh-dark-mode-only fragment approach fails when images are served from an external domain — GitHub's Camo proxy rewrites image URLs, stripping the fragment from the rendered src attribute so GitHub's CSS dark/light selector can't match. Both cards show stacked simultaneously.

Replace the generated embed snippet with the official GitHub-documented <picture> + prefers-color-scheme approach, which works correctly with external URLs through Camo.