### PR TITLE
feat(changelogs): collapse app cards by default in updates stream

### DIFF
--- a/src/components/FirehoseCard.module.css
+++ b/src/components/FirehoseCard.module.css
@@ -27,6 +27,38 @@
   margin-bottom: 0.75rem;
 }
 
+.releaseHeaderCollapsed {
+  margin-bottom: 0;
+}
+
+/* ── Collapse toggle ──────────────────────────────────────────────────────── */
+
+.collapseToggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-500);
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.collapseToggle:hover {
+  color: var(--ifm-color-primary);
+}
+
+.collapseChevron {
+  font-size: 1.1rem;
+  transition: transform 0.2s;
+  display: inline-block;
+}
+
+.collapseChevronOpen {
+  transform: rotate(90deg);
+}
+
 .releaseIcon {
   width: 48px;
   height: 48px;

--- a/src/components/FirehoseCard.tsx
+++ b/src/components/FirehoseCard.tsx
@@ -10,6 +10,7 @@ import styles from "./FirehoseCard.module.css";
 
 interface FirehoseCardProps {
   app: FirehoseApp;
+  defaultCollapsed?: boolean;
 }
 
 function formatDate(iso: string): string {
@@ -172,8 +173,9 @@ function OsPackageDiff({ diff }: { diff: FirehosePackageDiff }) {
   );
 }
 
-const FirehoseCard: React.FC<FirehoseCardProps> = ({ app }) => {
+const FirehoseCard: React.FC<FirehoseCardProps> = ({ app, defaultCollapsed = false }) => {
   const [showOlder, setShowOlder] = useState(false);
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   const latestRelease = app.releases?.[0];
   const olderReleases = app.releases?.slice(1) ?? [];
@@ -251,7 +253,7 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app }) => {
     >
       <div className={styles.mainRelease}>
         {/* ── Header: icon + title section ── */}
-        <div className={styles.releaseHeader}>
+        <div className={`${styles.releaseHeader} ${collapsed ? styles.releaseHeaderCollapsed : ""}`}>
           {app.icon ? (
             <img
               src={app.icon}
@@ -305,84 +307,97 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app }) => {
               </div>
             </div>
           </div>
+          <button
+            className={styles.collapseToggle}
+            onClick={() => setCollapsed((v) => !v)}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand" : "Collapse"}
+          >
+            <span className={`${styles.collapseChevron} ${collapsed ? "" : styles.collapseChevronOpen}`}>›</span>
+          </button>
         </div>
 
-        {/* ── App ID (flatpak only) ── */}
-        {app.packageType === "flatpak" && app.id && (
-          <p className={styles.releaseAppId}>{app.id.replace(/^flatpak-/, "")}</p>
-        )}
-
-        {/* ── Homebrew install row ── */}
-        {brewInstall && (
-          <div className={styles.brewInstallRow}>
-            <code className={styles.brewCommand}>{brewInstall}</code>
-            <CopyButton command={brewInstall} />
-          </div>
-        )}
-
-        {/* ── Summary ── */}
-        {app.summary && (
-          <p className={styles.releaseSummary}>{app.summary}</p>
-        )}
-
-        {/* ── OS package version chips ── */}
-        {app.packageType === "os" && app.osInfo && (
-          <div className={styles.releaseNotes}>
-            <OsPackageChips
-              versions={{
-                fedora: app.osInfo.fedoraVersion ?? null,
-                kernel: app.osInfo.kernelVersion ?? null,
-                gnome: app.osInfo.gnomeVersion ?? null,
-                mesa: app.osInfo.mesaVersion ?? null,
-                podman: app.osInfo.majorPackages?.["Podman"] ?? null,
-                systemd: app.osInfo.majorPackages?.["systemd"] ?? null,
-                bootc: app.osInfo.majorPackages?.["bootc"] ?? null,
-              }}
-            />
-            {latestRelease?.packageDiff && (
-              <OsPackageDiff diff={latestRelease.packageDiff} />
+        {/* ── Body (hidden when collapsed) ── */}
+        {!collapsed && (
+          <>
+            {/* ── App ID (flatpak only) ── */}
+            {app.packageType === "flatpak" && app.id && (
+              <p className={styles.releaseAppId}>{app.id.replace(/^flatpak-/, "")}</p>
             )}
-            {latestRelease?.url && (
-              <a
-                href={latestRelease.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.releaseLink}
-              >
-                View Releases on GitHub →
-              </a>
-            )}
-          </div>
-        )}
 
-        {/* ── Release notes (non-OS) ── */}
-        {app.packageType !== "os" && latestRelease?.description ? (
-          <div className={styles.releaseNotes}>
-            <div
-              className={styles.releaseDescription}
-              dangerouslySetInnerHTML={{ __html: latestRelease.description }}
-            />
-            {latestRelease.url && (
-              <a
-                href={latestRelease.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.releaseLink}
-              >
-                View Full Release →
-              </a>
+            {/* ── Homebrew install row ── */}
+            {brewInstall && (
+              <div className={styles.brewInstallRow}>
+                <code className={styles.brewCommand}>{brewInstall}</code>
+                <CopyButton command={brewInstall} />
+              </div>
             )}
-          </div>
-        ) : app.packageType !== "os" && app.description && !latestRelease ? (
-          /* For apps with no release history, show package description if available */
-          <div className={styles.releaseNotes}>
-            <p className={styles.releaseDescription}>{app.description}</p>
-          </div>
-        ) : null}
+
+            {/* ── Summary ── */}
+            {app.summary && (
+              <p className={styles.releaseSummary}>{app.summary}</p>
+            )}
+
+            {/* ── OS package version chips ── */}
+            {app.packageType === "os" && app.osInfo && (
+              <div className={styles.releaseNotes}>
+                <OsPackageChips
+                  versions={{
+                    fedora: app.osInfo.fedoraVersion ?? null,
+                    kernel: app.osInfo.kernelVersion ?? null,
+                    gnome: app.osInfo.gnomeVersion ?? null,
+                    mesa: app.osInfo.mesaVersion ?? null,
+                    podman: app.osInfo.majorPackages?.["Podman"] ?? null,
+                    systemd: app.osInfo.majorPackages?.["systemd"] ?? null,
+                    bootc: app.osInfo.majorPackages?.["bootc"] ?? null,
+                  }}
+                />
+                {latestRelease?.packageDiff && (
+                  <OsPackageDiff diff={latestRelease.packageDiff} />
+                )}
+                {latestRelease?.url && (
+                  <a
+                    href={latestRelease.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.releaseLink}
+                  >
+                    View Releases on GitHub →
+                  </a>
+                )}
+              </div>
+            )}
+
+            {/* ── Release notes (non-OS) ── */}
+            {app.packageType !== "os" && latestRelease?.description ? (
+              <div className={styles.releaseNotes}>
+                <div
+                  className={styles.releaseDescription}
+                  dangerouslySetInnerHTML={{ __html: latestRelease.description }}
+                />
+                {latestRelease.url && (
+                  <a
+                    href={latestRelease.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.releaseLink}
+                  >
+                    View Full Release →
+                  </a>
+                )}
+              </div>
+            ) : app.packageType !== "os" && app.description && !latestRelease ? (
+              /* For apps with no release history, show package description if available */
+              <div className={styles.releaseNotes}>
+                <p className={styles.releaseDescription}>{app.description}</p>
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
 
       {/* ── Older releases ── */}
-      {olderReleases.length > 0 && (
+      {!collapsed && olderReleases.length > 0 && (
         <div className={styles.olderReleasesSection}>
           <button
             className={styles.olderReleasesToggle}

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -685,7 +685,7 @@ const FirehoseFeed: React.FC = () => {
                     <OsReleaseCard key={`stream-${event.release.tag}-${event.dateMs}`} event={event} />
                   ) : (
                     <div key={event.app.id} className={styles.appEntry}>
-                      <FirehoseCard app={event.app} />
+                      <FirehoseCard app={event.app} defaultCollapsed={true} />
                     </div>
                   ),
                 )}


### PR DESCRIPTION
App (flatpak/homebrew) cards in the Updates Stream now start collapsed, showing only icon + name + version + date + badge in the header row. A chevron toggle expands the full card body (summary, release notes, install command, older releases). Bluefin OS release cards remain expanded and are the primary focus of the page.