### PR TITLE
feat(changelogs): show all apps by default; click header to expand card

### DIFF
--- a/src/components/FirehoseCard.module.css
+++ b/src/components/FirehoseCard.module.css
@@ -31,28 +31,25 @@
   margin-bottom: 0;
 }
 
-/* ── Collapse toggle ──────────────────────────────────────────────────────── */
+/* ── Clickable header (collapse / expand) ─────────────────────────────────── */
 
-.collapseToggle {
-  background: transparent;
-  border: none;
+.releaseHeaderClickable {
   cursor: pointer;
-  color: var(--ifm-color-emphasis-500);
-  padding: 0.25rem;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  align-self: center;
 }
 
-.collapseToggle:hover {
-  color: var(--ifm-color-primary);
+.releaseHeaderClickable:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .collapseChevron {
   font-size: 1.1rem;
   transition: transform 0.2s;
   display: inline-block;
+  flex-shrink: 0;
+  align-self: center;
+  color: var(--ifm-color-emphasis-500);
 }
 
 .collapseChevronOpen {

--- a/src/components/FirehoseCard.tsx
+++ b/src/components/FirehoseCard.tsx
@@ -252,8 +252,15 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app, defaultCollapsed = fal
       data-package-type={app.packageType}
     >
       <div className={styles.mainRelease}>
-        {/* ── Header: icon + title section ── */}
-        <div className={`${styles.releaseHeader} ${collapsed ? styles.releaseHeaderCollapsed : ""}`}>
+        {/* ── Header: icon + title section — clicking anywhere toggles collapsed ── */}
+        <div
+          className={`${styles.releaseHeader} ${collapsed ? styles.releaseHeaderCollapsed : ""} ${styles.releaseHeaderClickable}`}
+          onClick={() => setCollapsed((v) => !v)}
+          role="button"
+          tabIndex={0}
+          aria-expanded={!collapsed}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setCollapsed((v) => !v); } }}
+        >
           {app.icon ? (
             <img
               src={app.icon}
@@ -274,7 +281,7 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app, defaultCollapsed = fal
               {/* Name + version — left */}
               <h3 className={styles.releaseName}>
                 {primaryHref ? (
-                  <a href={primaryHref} target="_blank" rel="noopener noreferrer">
+                  <a href={primaryHref} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
                     {app.name}
                     {displayVersion && (
                       <span className={styles.versionInline}> {displayVersion}</span>
@@ -299,7 +306,7 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app, defaultCollapsed = fal
                     —
                   </span>
                 )}
-                <div className={styles.metaBadges}>
+                <div className={styles.metaBadges} onClick={(e) => e.stopPropagation()}>
                   <PackageBadge type={app.packageType} />
                   {flathubIconLink}
                   {sourceIconLink}
@@ -307,14 +314,7 @@ const FirehoseCard: React.FC<FirehoseCardProps> = ({ app, defaultCollapsed = fal
               </div>
             </div>
           </div>
-          <button
-            className={styles.collapseToggle}
-            onClick={() => setCollapsed((v) => !v)}
-            aria-expanded={!collapsed}
-            aria-label={collapsed ? "Expand" : "Collapse"}
-          >
-            <span className={`${styles.collapseChevron} ${collapsed ? "" : styles.collapseChevronOpen}`}>›</span>
-          </button>
+          <span className={`${styles.collapseChevron} ${collapsed ? "" : styles.collapseChevronOpen}`} aria-hidden="true">›</span>
         </div>
 
         {/* ── Body (hidden when collapsed) ── */}

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -564,8 +564,7 @@ const FirehoseFeed: React.FC = () => {
 
   // ── Unified "Updates Stream" ───────────────────────────────────────────────
   //
-  // OS releases are always primary. App entries (flatpak/homebrew) are shown
-  // only when showEverything is true OR when a specific app type filter is active.
+  // OS releases and app entries (flatpak/homebrew) are always shown together.
 
   const appSection = useMemo(
     () =>
@@ -575,21 +574,11 @@ const FirehoseFeed: React.FC = () => {
     [filteredUniqueApps],
   );
 
-  // Apps appear when: showEverything is on, OR a specific app type is selected
-  const showApps =
-    filters.showEverything ||
-    filters.packageType === "flatpak" ||
-    filters.packageType === "homebrew";
-
   const unifiedStream = useMemo((): FlatTimelineEvent[] => {
-    const items: FlatTimelineEvent[] = [];
-    if (showApps) {
-      items.push(...appSection);
-    }
-    items.push(...filteredOsStreamEvents);
+    const items: FlatTimelineEvent[] = [...appSection, ...filteredOsStreamEvents];
     items.sort((a, b) => b.dateMs - a.dateMs);
     return items;
-  }, [filteredOsStreamEvents, appSection, showApps]);
+  }, [filteredOsStreamEvents, appSection]);
 
   const isEmpty = allEvents.length === 0 && ALL_OS_STREAM_EVENTS.length === 0;
   const feedEmpty = unifiedStream.length === 0;
@@ -675,9 +664,7 @@ const FirehoseFeed: React.FC = () => {
                 <div className={styles.appSectionDivider}>
                   <Heading as="h2" className={styles.feedSectionHeading}>Updates Stream</Heading>
                   <span className={styles.appSectionHint}>
-                    {showApps
-                      ? "OS releases, Flatpak & Homebrew packages included in Bluefin"
-                      : "OS releases · check \"Show Everything\" to include Flatpak & Homebrew"}
+                    OS releases, Flatpak &amp; Homebrew packages included in Bluefin
                   </span>
                 </div>
                 {unifiedStream.map((event) =>

--- a/src/components/FirehoseFilters.tsx
+++ b/src/components/FirehoseFilters.tsx
@@ -173,19 +173,6 @@ const FirehoseFilters: React.FC<FirehoseFiltersProps> = ({
         </select>
       </section>
 
-      {/* Show Everything toggle */}
-      <section className={styles.filterSection}>
-        <label className={styles.checkLabel}>
-          <input
-            type="checkbox"
-            checked={filters.showEverything}
-            onChange={(e) =>
-              onFiltersChange({ ...filters, showEverything: e.target.checked })
-            }
-          />
-          <span>Show Everything</span>
-        </label>
-      </section>
     </aside>
   );
 };

--- a/src/types/firehose.ts
+++ b/src/types/firehose.ts
@@ -127,7 +127,5 @@ export interface FirehoseFilterState {
   updatedWithin: "all" | "1d" | "7d" | "30d" | "90d";
   verifiedOnly: boolean;
   unverifiedOnly: boolean;
-  /** When false (default), only OS releases are shown in the Updates Stream.
-   *  When true, Flatpak and Homebrew app entries are also included. */
   showEverything: boolean;
 }


### PR DESCRIPTION
- Remove "Show Everything" toggle — apps are always visible in the updates stream
- Make the entire collapsed card header row clickable (not just the chevron)
- Inner links (app name, Flathub, GitHub) stop propagation so they still navigate correctly
- Remove unused collapseToggle button styles; add focus-visible ring on header