### PR TITLE
fix(ci): restore artwork.json from checkout after data cache restore

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,13 @@ jobs:
             github-data-sbom-
             github-data-
 
+      - name: Restore curated artwork metadata (cache must not overwrite)
+        # The github-data cache restores the entire static/data/ directory, which
+        # overwrites artwork.json with a stale cached copy and loses manually curated
+        # fields (e.g. coAuthor). Restore the committed version from the checkout so
+        # hand-edited credits are always included in the build.
+        run: git checkout -- static/data/artwork.json
+
       - name: Restore SBOM attestation cache (overrides general data cache)
         # Primary key will never match (update-sbom-cache.yml runs as a separate workflow
         # with a different run_id). The restore-keys fallback always applies, fetching


### PR DESCRIPTION
The github-data cache restores the entire static/data/ directory, overwriting artwork.json with a stale cached copy. This silently discards manually curated fields like coAuthor/coAuthorLink, causing Delphic Melody's credits to disappear from the live artwork page even though they are committed in the repo.

Add a git checkout step immediately after the data cache restore to re-apply the committed artwork.json, ensuring hand-edited credits survive the cache restore.


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot