### PR TITLE
fix(artwork): remove duplicate Duality (Ultrawide) entry

### DIFF
--- a/static/data/artwork.json
+++ b/static/data/artwork.json
@@ -281,21 +281,6 @@
               "previewNightUrl": null
             },
             {
-              "id": "duality-ultrawide",
-              "title": "Duality (Ultrawide)",
-              "author": "Dr. Natalia Jagielska",
-              "authorLicense": "https://natalia-jagielska.weebly.com/",
-              "coAuthor": "Delphic Melody",
-              "coAuthorLink": "https://ko-fi.com/melodyofdelphi",
-              "previewUrl": null,
-              "dayUrl": "https://raw.githubusercontent.com/ublue-os/artwork/main/wallpapers/duality-ultrawide/duality-ultrawide-day.svg",
-              "nightUrl": "https://raw.githubusercontent.com/ublue-os/artwork/main/wallpapers/duality-ultrawide/duality-ultrawide-night.svg",
-              "jxlUrl": null,
-              "primaryFormat": "svg",
-              "hasLightbox": true,
-              "previewNightUrl": null
-            },
-            {
               "id": "collapse",
               "title": "Collapse",
               "author": "Dr. Natalia Jagielska",


### PR DESCRIPTION
The `duality-ultrawide` entry in `artwork.json` was a duplicate of the existing `duality` entry (same artwork, same author/credits). Removing to keep the gallery clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>