### PR TITLE
fix(sbom): fix GHCR tag pagination regex — \b fails after closing quote

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -311,10 +311,13 @@ async function fetchGhcrTags(org, pkg) {
     if (Array.isArray(body.tags)) allTags.push(...body.tags);
 
     // Follow pagination Link header per RFC 5988 / OCI distribution spec.
-    // Use a flexible regex (parameters in any order, optional quoting, case-insensitive)
-    // and resolve relative URLs against the response URL for spec compliance.
+    // GHCR returns: </v2/.../tags/list?last=...&n=1000>; rel="next"
+    // The trailing \b after the optional quote fails to match because " is non-word
+    // and end-of-string is also non-word — so \b never fires, breaking pagination.
+    // Use a literal rel="next" match with an optional unquoted fallback.
     const linkHeader = res.headers.get("link") || "";
-    const nextMatch = linkHeader.match(/<([^>]+)>;[^<]*\brel=("?)next\2\b/i);
+    const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/i)
+      ?? linkHeader.match(/<([^>]+)>;\s*rel=next(?:[^a-z]|$)/i);
     url = nextMatch ? new URL(nextMatch[1], res.url).href : null;
   }
 


### PR DESCRIPTION
## Problem

`fetchGhcrTags()` only ever returned the first 1000 GHCR tags and stopped paginating.

`ghcr.io/ublue-os/bluefin` has **4,912 tags** (5 pages of 1000). The LTS tags `lts.20260414`, `lts.20260407`, etc. are in pages 4–5 alphabetically, so they were never seen by the SBOM pipeline.

## Root cause

The Link header GHCR returns is:
```
</v2/ublue-os/bluefin/tags/list?last=sha256-xxx.sig&n=1000>; rel="next"
```

The previous regex `/<([^>]+)>;[^<]*\brel=("?)next\2\b/i` failed because:
- `\b` (word-boundary) after the closing `"` can never fire — `"` is non-word and end-of-string is also non-word, so there is no word/non-word boundary

Result: `url = null` on the first page → pagination stops → only 1000 tags fetched.

## Fix

Replace with a literal `rel="next"` match (GHCR always quotes it) with a fallback for unquoted `rel=next`:

```js
const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/i)
  ?? linkHeader.match(/<([^>]+)>;\s*rel=next(?:[^a-z]|$)/i);
```

## Impact

Once merged and `update-sbom-cache.yml` reruns, the LTS card on /changelogs will show `lts.20260414` with populated version chips (kernel, gnome, mesa, podman, etc.) instead of a stale `lts.20260210` with null packages.