### PR TITLE
fix(ci): align SBOM cache save/restore paths

### DIFF
--- a/.github/workflows/update-sbom-cache.yml
+++ b/.github/workflows/update-sbom-cache.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Restore existing SBOM data cache (for incremental updates)
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: static/data
+          path: |
+            static/data/sbom-attestations.json
+            static/data/sbom-attestations-frontend.json
           key: github-data-sbom-${{ github.run_id }}
           restore-keys: |
             github-data-sbom-
@@ -79,5 +81,7 @@ jobs:
       - name: Save SBOM data cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: static/data
+          path: |
+            static/data/sbom-attestations.json
+            static/data/sbom-attestations-frontend.json
           key: github-data-sbom-${{ github.run_id }}


### PR DESCRIPTION
## Problem

The `update-sbom-cache.yml` save step used `path: static/data` (full directory), while the **Restore SBOM attestation cache** step in `pages.yml` used:
```
path: |
  static/data/sbom-attestations.json
  static/data/sbom-attestations-frontend.json
```

GHA cache matches on both key prefix AND path spec — different paths cause a cache miss even when the key prefix matches. This meant the SBOM-specific override step in `pages.yml` **never found any cache entry**, so the pages build always used stale SBOM data from the general cache (which had the old broken-pagination results with null LTS packages).

## Fix

Narrow the save path in `update-sbom-cache.yml` to the same two files that `pages.yml` expects, so the prefix restore-key `github-data-sbom-` returns an exact path match and the SBOM override actually fires.

## Verification needed

After merge:
1. Trigger `update-sbom-cache.yml` → creates new cache with matching path
2. Trigger `pages.yml` → SBOM override step should now report a cache hit
3. Live `/data/sbom-attestations-frontend.json` should show `lts-20260414` with populated `packageVersions`