### PR TITLE
ci: rebuild site daily instead of weekly

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ on:
   merge_group:
   workflow_dispatch:
   schedule:
-    - cron: "50 6 * * 0" # 6:50 UTC sundays
+    - cron: "0 7 * * *" # 07:00 UTC daily (after nightly SBOM update at 04:00 UTC)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The changelogs page was showing stale release versions because pages.yml only ran on push to main or weekly on Sundays. The nightly SBOM update (update-sbom-cache.yml at 04:00 UTC) runs correctly but the built site never picked up fresh data between Sunday deploys.

Change the schedule to daily at 07:00 UTC, 3 hours after the SBOM update completes. This ensures the changelogs page shows the latest releases (e.g. stable-20260421) within 24 hours of publication rather than up to 7 days later.