### PR TITLE
fix(reports): correctly identify 11 new April contributors

### DIFF
--- a/reports/2026-04-30-report.mdx
+++ b/reports/2026-04-30-report.mdx
@@ -14,7 +14,7 @@ import GitHubProfileCard from '@site/src/components/GitHubProfileCard';
 |--------|-------|
 | **Total Items** | 186 (12 planned, 174 opportunistic) |
 | **Automation** | 62.3% (308 bot PRs out of 494 total PRs) |
-| **Contributors** | 22 total, 0 new |
+| **Contributors** | 22 total, 11 new |
 
 
 ## Desktop
@@ -682,6 +682,40 @@ Keep Bluefin healthy with green builds. Wranglers apply within!
 
 ## Contributors
 
+### New Lights
+
+We welcome our newest Guardians to the project.
+
+> "I do not know what the future holds. But I know this: with you at our side, there is nothing we cannot face."
+> 
+> —Commander Zavala
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1.5rem', marginBottom: '2rem' }}>
+
+<GitHubProfileCard username="dylanmtaylor" highlight={true} />
+
+<GitHubProfileCard username="AlexNPavel" highlight={true} />
+
+<GitHubProfileCard username="akeeton" highlight={true} />
+
+<GitHubProfileCard username="ledif" highlight={true} />
+
+<GitHubProfileCard username="delphicmelody" highlight={true} />
+
+<GitHubProfileCard username="NiHaiden" highlight={true} />
+
+<GitHubProfileCard username="hulet" highlight={true} />
+
+<GitHubProfileCard username="nklowns" highlight={true} />
+
+<GitHubProfileCard username="RichardMartija" highlight={true} />
+
+<GitHubProfileCard username="goozkan" highlight={true} />
+
+<GitHubProfileCard username="StorageB" highlight={true} />
+
+</div>
+
 ### Wayfinders
 
 > "Define yourself by your actions."
@@ -690,35 +724,17 @@ Keep Bluefin healthy with green builds. Wranglers apply within!
 
 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1.5rem', marginBottom: '2rem' }}>
 
-<GitHubProfileCard username="dylanmtaylor" />
-
 <GitHubProfileCard username="renner0e" />
 
 <GitHubProfileCard username="hanthor" sponsorUrl="https://github.com/sponsors/hanthor" />
 
-<GitHubProfileCard username="AlexNPavel" />
-
 <GitHubProfileCard username="repires" />
 
-<GitHubProfileCard username="akeeton" />
-
 <GitHubProfileCard username="inffy" sponsorUrl="https://github.com/sponsors/inffy" />
-
-<GitHubProfileCard username="ledif" />
 
 <GitHubProfileCard username="castrojo" sponsorUrl="https://github.com/sponsors/castrojo" />
 
 <GitHubProfileCard username="ahmedadan" sponsorUrl="https://github.com/sponsors/ahmedadan" />
-
-<GitHubProfileCard username="delphicmelody" />
-
-<GitHubProfileCard username="NiHaiden" />
-
-<GitHubProfileCard username="hulet" />
-
-<GitHubProfileCard username="nklowns" />
-
-<GitHubProfileCard username="RichardMartija" />
 
 <GitHubProfileCard username="jumpyvi" />
 
@@ -729,10 +745,6 @@ Keep Bluefin healthy with green builds. Wranglers apply within!
 <GitHubProfileCard username="coxde" />
 
 <GitHubProfileCard username="alatiera" />
-
-<GitHubProfileCard username="goozkan" />
-
-<GitHubProfileCard username="StorageB" />
 
 </div>
 


### PR DESCRIPTION
The known-contributors.json was populated on every local regeneration run, consuming new-contributor detection. Reset the cache to the seed baseline (40 entries) and regenerate so the script correctly identifies contributors not previously seen.

New contributors this period (vs seed baseline):
AlexNPavel, NiHaiden, RichardMartija, StorageB, akeeton, delphicmelody, dylanmtaylor, goozkan, hulet, ledif, nklowns

These 11 now appear in the 'New Lights' section with highlight={true}.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor report to reflect 11 new contributors
  * Reorganized contributors section with enhanced profile highlighting and refined groupings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->