### PR TITLE
fix(images): polish card UI and fix Last Published date

### DIFF
--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -600,6 +600,7 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
     latestUpdatedAt(versions) || existing?.lastPublishedAt || null;
   const staleCutoff = Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000;
   const stale = updatedAt ? Date.parse(updatedAt) < staleCutoff : false;
+  const lastPublishedAt = updatedAt || feedItem?.pubDate || null;
 
   return {
     id: spec.id,
@@ -618,7 +619,7 @@ async function buildProduct(spec, feeds, cachedById, ageHours, sbomCache) {
     versions: versionsFromFeed,
     security: buildSecurityInfo(spec, inspectTag),
     inspectTag,
-    lastPublishedAt: updatedAt,
+    lastPublishedAt: lastPublishedAt,
     stale,
     keepEvenIfStale: Boolean(spec.keepEvenIfStale),
   };

--- a/src/components/ImagesCatalog.module.css
+++ b/src/components/ImagesCatalog.module.css
@@ -72,19 +72,6 @@
   color: var(--ifm-color-primary);
 }
 
-.registryBadge {
-  display: inline-block;
-  font-size: 0.74rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-800);
-}
-
 .summary {
   position: relative;
   z-index: 1;
@@ -154,7 +141,7 @@
 .focusSection {
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 12px;
-  padding: 0.7rem 0.8rem 0.8rem;
+  padding: 0.8rem;
 }
 
 .streamsSection {
@@ -295,6 +282,18 @@
   background: color-mix(in srgb, var(--ifm-color-primary) 6%, var(--ifm-background-color));
   padding: 0.35rem 0.45rem 0.45rem;
   overflow: hidden;
+}
+
+.securitySection :global(.tabs) {
+  margin-top: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.securitySection :global(.tabs-container > .margin-top--md) {
+  margin-top: 0.25rem !important;
+  background: transparent;
+  padding: 0;
 }
 
 /* Streams widget: title + driver toggle + tabs as one unit */

--- a/src/components/ImagesCatalog.tsx
+++ b/src/components/ImagesCatalog.tsx
@@ -224,7 +224,7 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
             <Heading as="h2" className={styles.cardTitle}>
               {product.name}
             </Heading>
-            <span className={styles.registryBadge}>{product.org}</span>
+
           </header>
 
           <section className={styles.linkRow}>
@@ -284,9 +284,11 @@ export default function ImagesCatalogComponent(): React.JSX.Element {
                 </span>
               </>
             )}
-            <span className={sourceClass(product.metadataSource)}>
-              {sourceText(product.metadataSource, "Metadata")}
-            </span>
+            {product.metadataSource !== "live" && (
+              <span className={sourceClass(product.metadataSource)}>
+                {sourceText(product.metadataSource, "Metadata")}
+              </span>
+            )}
           </div>
 
           <p className={styles.validationMeta}>


### PR DESCRIPTION
- Remove Metadata: live chip (only show cache/unavailable states)
- Remove ublue-os/projectbluefin org pills (registryBadge)
- Fix .focusSection padding asymmetry (0.7rem top → uniform 0.8rem)
- Normalize CodeBlock container: securitySection tabs now transparent like streamsSection so copy blocks have consistent visual weight
- Fix .testingDetails code selector scope (> direct child only)
- Fix Last published: Unknown — use feedItem?.pubDate as fallback in updatedAt calculation (packages:read PAT unavailable in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed registry badge from image card headers.
  * Metadata source status indicator now displays only when metadata source is not live.

* **Style**
  * Updated focus section padding styling.
  * Enhanced security section tab styling with transparent backgrounds.

* **Improvements**
  * Improved date handling for published information with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->