### PR TITLE
fix(driver-versions): detect kernel and mesa patch-level version bumps

### DIFF
--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -105,16 +105,14 @@ function ReleaseNode({
     kernelMajor !== null &&
     previousKernelMajor !== null &&
     previousKernelMajor !== kernelMajor;
-  const kernelParts = majorMinor(row.versions.kernel);
-  const previousKernelParts = majorMinor(previousRow?.versions.kernel);
   const kernelMinorBump =
     !kernelMajorBump &&
-    kernelParts.major !== null &&
-    previousKernelParts.major !== null &&
-    kernelParts.minor !== null &&
-    previousKernelParts.minor !== null &&
-    kernelParts.major === previousKernelParts.major &&
-    kernelParts.minor !== previousKernelParts.minor;
+    kernelMajor !== null &&
+    previousKernelMajor !== null &&
+    kernelMajor === previousKernelMajor &&
+    !!row.versions.kernel &&
+    !!previousRow?.versions.kernel &&
+    row.versions.kernel !== previousRow.versions.kernel;
 
   const nvidiaMajor = majorNumber(row.versions.nvidia);
   const previousNvidiaMajor = majorNumber(previousRow?.versions.nvidia);
@@ -139,16 +137,14 @@ function ReleaseNode({
     mesaMajor !== null &&
     previousMesaMajor !== null &&
     previousMesaMajor !== mesaMajor;
-  const mesaParts = majorMinor(row.versions.mesa);
-  const previousMesaParts = majorMinor(previousRow?.versions.mesa);
   const mesaMinorBump =
     !mesaMajorBump &&
-    mesaParts.major !== null &&
-    previousMesaParts.major !== null &&
-    mesaParts.minor !== null &&
-    previousMesaParts.minor !== null &&
-    mesaParts.major === previousMesaParts.major &&
-    mesaParts.minor !== previousMesaParts.minor;
+    mesaMajor !== null &&
+    previousMesaMajor !== null &&
+    mesaMajor === previousMesaMajor &&
+    !!row.versions.mesa &&
+    !!previousRow?.versions.mesa &&
+    row.versions.mesa !== previousRow.versions.mesa;
 
   const gnomeMajor = majorNumber(row.versions.gnome);
   const previousGnomeMajor = majorNumber(previousRow?.versions.gnome);
@@ -296,7 +292,15 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
 
       {(() => {
         const latest = stream.latest;
-        const older = stream.history.slice(1);
+        const older = stream.history
+          .slice(1)
+          .filter(
+            (row) =>
+              row.versions.kernel ||
+              row.versions.nvidia ||
+              row.versions.mesa ||
+              row.versions.gnome,
+          );
 
         return (
           <section key={stream.id} className={styles.streamSection}>


### PR DESCRIPTION
kernelMinorBump and mesaMinorBump previously used majorMinor() which extracted only X.Y from version strings. This caused patch-level changes like kernel 6.19.7→6.19.10 and 6.12.0-218→6.12.0-224 to produce no bump badge, even though the kernel version changed.

Replace both conditions with a full string comparison: when major number is the same but the full version string differs, show the minor bump badge. This correctly handles both X.Y minor bumps and X.Y.Z patch bumps.

Also filter all-null LTS history rows from the archive timeline. Entries with no version data (kernel/nvidia/mesa/gnome all null) are excluded from rendering so they no longer show confusing N/A placeholders. Bump comparisons use the filtered list so previousRow always points to a row with actual version data.

Fixes:
- stable-20260501: kernel 6.19.10→6.19.12 (no badge)
- stable-20260421: kernel 6.19.7→6.19.10 (no badge)
- stable-20260324: kernel 6.18.10→6.18.13 (no badge)
- lts-20260428: kernel 6.12.0-218→6.12.0-224 (no badge)


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Driver Versions Catalog timeline now displays only entries containing version information, removing empty or irrelevant history rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->