### PR TITLE
docs: rename Bluefin LTS section to LTS and GDX

### DIFF
--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -13,6 +13,6 @@ Sometimes the raptor just gets you. This page tracks major driver versions acros
 
 <DriverVersionsCatalog streamId="bluefin-stable" />
 
-## Bluefin LTS
+## Bluefin LTS and GDX
 
 <DriverVersionsCatalog streamId="bluefin-lts" />

--- a/scripts/fetch-github-driver-versions.js
+++ b/scripts/fetch-github-driver-versions.js
@@ -485,7 +485,7 @@ async function main() {
   const ltsStream = hasSbomLts
     ? buildStreamFromSbom(
         "bluefin-lts",
-        "Bluefin LTS",
+        "Bluefin LTS and GDX",
         "Long-term support stream from ublue-os/bluefin-lts.",
         "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
         sbomCache,
@@ -494,7 +494,7 @@ async function main() {
       )
     : buildStreamFromApi(
         "bluefin-lts",
-        "Bluefin LTS",
+        "Bluefin LTS and GDX",
         "Long-term support stream from ublue-os/bluefin-lts.",
         "sudo bootc switch ghcr.io/ublue-os/bluefin:lts --enforce-container-sigpolicy",
         ltsReleases,

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -260,7 +260,7 @@ interface DriverVersionsCatalogProps {
 export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalogProps): React.JSX.Element {
   const allStreams = Array.isArray(catalog.streams) ? catalog.streams : [];
   const stream = allStreams.find((entry) => entry.id === streamId);
-  const fallbackLabel = streamId === "bluefin-lts" ? "LTS" : "Stable";
+  const fallbackLabel = streamId === "bluefin-lts" ? "LTS and GDX" : "Stable";
 
   if (!stream && allStreams.length > 0) {
     return (
@@ -306,7 +306,7 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
           <section key={stream.id} className={styles.streamSection}>
             <header className={styles.streamHeader}>
               <span className={styles.streamMeta}>
-                {stream.source} · {stream.rowCount} releases in {streamId === "bluefin-lts" ? "LTS" : "Stable"} ·
+                {stream.source} · {stream.rowCount} releases in {streamId === "bluefin-lts" ? "LTS and GDX" : "Stable"} ·
                 updated {formatDate(catalog.generatedAt)}
               </span>
             </header>


### PR DESCRIPTION
- Update ## Bluefin LTS heading to ## Bluefin LTS and GDX in driver-versions.mdx
- Update DriverVersionsCatalog.tsx fallbackLabel and stream meta label from 'LTS' to 'LTS and GDX'
- Update fetch script to produce 'Bluefin LTS and GDX' as the stream name so the label persists across data refreshes

HWE Kernel investigation: LTS release notes (ublue-os/bluefin-lts) do not include Kernel or HWE Kernel fields — only package changelogs. hweKernel remains null for LTS intentionally. The component already conditionally renders the HWE Kernel card only when hweKernel !== null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bluefin LTS documentation and labels to reflect "Bluefin LTS and GDX" across release notes and driver version displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->