### PR TITLE
fix(changelogs): populate LTS HWE Kernel from lts-hwe SBOM stream

### DIFF
--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -267,6 +267,33 @@ function enrichLtsDxGdxFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
 }
 
 /**
+ * Override the "HWE Kernel" carry-forward value in LTS events with the
+ * authoritative version from the bluefin-lts-hwe SBOM stream.
+ *
+ * enrichLtsFromHistory carries "hwe kernel" forward from release notes, but
+ * LTS release notes have not included HWE Kernel since lts.20251223, causing
+ * the changelogs page to display a stale value. The SBOM stream always has the
+ * correct installed version.
+ */
+function enrichLtsHweKernelFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
+  return events.map((event) => {
+    if (event.stream !== "lts") return event;
+
+    const dateMatch = event.release.tag.match(/(\d{8})/);
+    if (!dateMatch) return event;
+    const hweKernel =
+      SBOM_CACHE?.streams?.["bluefin-lts-hwe"]?.releases?.[`lts-hwe-${dateMatch[1]}`]
+        ?.packageVersions?.kernel;
+    if (!hweKernel) return event;
+
+    const updatedPackages = event.release.majorPackages.map((pkg) =>
+      pkg.name.toLowerCase() === "hwe kernel" ? { ...pkg, version: hweKernel } : pkg,
+    );
+    return { ...event, release: { ...event.release, majorPackages: updatedPackages } };
+  });
+}
+
+/**
  * Synthesise OsReleaseEvent entries for stable-daily builds that exist only in
  * GHCR (no GitHub Release). These are GHCR nightly builds tagged
  * "stable-daily-YYYYMMDD" — they never appear in bluefin-releases.json so they
@@ -325,8 +352,10 @@ function loadStableDailyEventsFromSbom(): OsReleaseEvent[] {
 // All parsed events from both feeds, enriched with SBOM package versions
 const BLUEFIN_OS_EVENTS: OsReleaseEvent[] = enrichFromSbom(loadOsEvents(bluefinReleasesData));
 const STABLE_DAILY_OS_EVENTS: OsReleaseEvent[] = loadStableDailyEventsFromSbom();
-const LTS_OS_EVENTS: OsReleaseEvent[] = enrichLtsDxGdxFromSbom(
-  enrichLtsFromHistory(enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts"))),
+const LTS_OS_EVENTS: OsReleaseEvent[] = enrichLtsHweKernelFromSbom(
+  enrichLtsDxGdxFromSbom(
+    enrichLtsFromHistory(enrichFromSbom(loadOsEvents(bluefinLtsReleasesData, "lts"))),
+  ),
 );
 
 // Rolling 12-month window for the stream — pinned cards (PINNED_OS_EVENTS) are unaffected.


### PR DESCRIPTION
The changelogs page was showing 6.17.8-200.fc42 for LTS HWE Kernel because enrichLtsFromHistory carry-forward was stuck at the last release that mentioned HWE Kernel in its notes (lts.20251223).

Add enrichLtsHweKernelFromSbom() which overrides the carried-forward HWE Kernel version with the authoritative value from the bluefin-lts-hwe SBOM stream (e.g. lts-hwe-20260501 → 6.17.12-200.fc42).

This runs after enrichLtsFromHistory in the pipeline so the carry-forward still populates older releases that predate the lts-hwe SBOM stream, but any release that has a matching lts-hwe-YYYYMMDD entry gets the correct installed version instead.


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of kernel version information in LTS OS events through enhanced event enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->