### PR TITLE
feat(pin-indicators): show 📌 Pinned badge for intentionally-held component versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !/static/data/firehose-apps.json
 !/static/data/artwork.json
 !/static/data/artwork-versions.json
+!/static/data/stream-pins.json
 
 # Generated temp files
 ARTWORK_CHANGES.md

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "fetch-sbom": "node scripts/fetch-github-sbom.js",
     "fetch-firehose": "node scripts/fetch-firehose.js",
     "generate-card-images": "node scripts/generate-card-images.mjs",
-    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-github-driver-versions && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-firehose",
+    "fetch-data": "npm run fetch-feeds && npm run fetch-playlists && npm run fetch-github-profiles && npm run fetch-github-repos && npm run fetch-pin-state && npm run fetch-github-driver-versions && npm run fetch-github-images && npm run fetch-contributors && npm run fetch-firehose",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "fetch-pin-state": "node scripts/fetch-pin-state.js"
   },
   "dependencies": {
     "@1password/docusaurus-plugin-stored-data": "^1.0.0",

--- a/scripts/fetch-pin-state.js
+++ b/scripts/fetch-pin-state.js
@@ -37,7 +37,7 @@ async function fetchWorkflowContent(repo, filePath) {
       : {}),
   };
 
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(15000) });
   if (!response.ok) {
     throw new Error(`GitHub API error for ${repo}/${filePath}: ${response.status} ${response.statusText}`);
   }

--- a/scripts/fetch-pin-state.js
+++ b/scripts/fetch-pin-state.js
@@ -69,7 +69,12 @@ async function main() {
       }
 
       if (kernelPin) {
-        // Both HWE workflows should have the same pin; last-write wins (consistent).
+        const existing = streamPins[stream].hweKernel;
+        if (existing && existing !== kernelPin) {
+          throw new Error(
+            `Conflicting hweKernel pins for ${stream}: ${existing} vs ${kernelPin} (from ${filePath})`,
+          );
+        }
         streamPins[stream].hweKernel = kernelPin;
         console.log(`  ${stream} hweKernel pin: ${kernelPin}`);
       } else {

--- a/scripts/fetch-pin-state.js
+++ b/scripts/fetch-pin-state.js
@@ -1,0 +1,103 @@
+/**
+ * fetch-pin-state.js
+ *
+ * Reads bluefin-lts HWE workflow YAML files from the GitHub Contents API
+ * and extracts any `kernel-pin` (or future `*-pin`) workflow inputs.
+ * Writes static/data/stream-pins.json consumed by the docs UI to render
+ * 📌 "Pinned" badges next to intentionally-held component versions.
+ *
+ * Usage: node scripts/fetch-pin-state.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const OUTPUT_FILE = path.join(__dirname, "..", "static", "data", "stream-pins.json");
+
+const WORKFLOWS_TO_CHECK = [
+  {
+    repo: "ublue-os/bluefin-lts",
+    path: ".github/workflows/build-regular-hwe.yml",
+    stream: "bluefin-lts",
+  },
+  {
+    repo: "ublue-os/bluefin-lts",
+    path: ".github/workflows/build-dx-hwe.yml",
+    stream: "bluefin-lts",
+  },
+];
+
+async function fetchWorkflowContent(repo, filePath) {
+  const url = `https://api.github.com/repos/${repo}/contents/${filePath}`;
+  const headers = {
+    "User-Agent": "bluefin-docs/fetch-pin-state",
+    Accept: "application/vnd.github.v3+json",
+    ...(process.env.GITHUB_TOKEN
+      ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+      : {}),
+  };
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`GitHub API error for ${repo}/${filePath}: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return Buffer.from(data.content, "base64").toString("utf8");
+}
+
+/**
+ * Extract `kernel-pin` value from a workflow YAML string.
+ * Matches the pattern:   kernel-pin: <version>
+ */
+function extractKernelPin(yamlContent) {
+  const match = yamlContent.match(/kernel-pin:\s*([^\s\n#]+)/);
+  return match ? match[1].trim() : null;
+}
+
+async function main() {
+  const streamPins = {};
+
+  for (const { repo, path: filePath, stream } of WORKFLOWS_TO_CHECK) {
+    try {
+      console.log(`Fetching ${repo}/${filePath}...`);
+      const content = await fetchWorkflowContent(repo, filePath);
+      const kernelPin = extractKernelPin(content);
+
+      if (!streamPins[stream]) {
+        streamPins[stream] = {};
+      }
+
+      if (kernelPin) {
+        // Both HWE workflows should have the same pin; last-write wins (consistent).
+        streamPins[stream].hweKernel = kernelPin;
+        console.log(`  ${stream} hweKernel pin: ${kernelPin}`);
+      } else {
+        console.log(`  ${stream}: no kernel-pin found (floating)`);
+      }
+    } catch (err) {
+      console.warn(`  Warning: could not fetch ${repo}/${filePath}: ${err.message}`);
+      // Non-fatal: keep any previously discovered pin for this stream.
+    }
+  }
+
+  // Ensure all known streams appear in the output, even if empty (= all floating).
+  for (const stream of ["bluefin-stable"]) {
+    if (!streamPins[stream]) {
+      streamPins[stream] = {};
+    }
+  }
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    streams: streamPins,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2) + "\n");
+  console.log(`Wrote ${OUTPUT_FILE}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -332,6 +332,28 @@
   font-style: italic;
 }
 
+.pinnedTag {
+  display: inline-block;
+  margin-top: 0.35rem;
+  border: 1px solid #b45309;
+  border-radius: 999px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: #fef3c7;
+  color: #78350f;
+  position: relative;
+  z-index: 2;
+}
+
+[data-theme="dark"] .pinnedTag {
+  background: #451a03;
+  color: #fed7aa;
+  border-color: #c2410c;
+}
+
 .bumpTag {
   display: inline-block;
   margin-top: 0.35rem;

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -3,7 +3,23 @@ import Link from "@docusaurus/Link";
 import Heading from "@theme/Heading";
 import CodeBlock from "@theme/CodeBlock";
 import driverVersionsData from "@site/static/data/driver-versions.json";
+import streamPinsData from "@site/static/data/stream-pins.json";
 import styles from "./DriverVersionsCatalog.module.css";
+
+interface StreamPins {
+  hweKernel?: string | null;
+  kernel?: string | null;
+  mesa?: string | null;
+  nvidia?: string | null;
+  gnome?: string | null;
+}
+
+interface PinsData {
+  generatedAt?: string;
+  streams?: Record<string, StreamPins>;
+}
+
+const pinsCatalog = streamPinsData as unknown as PinsData;
 
 interface VersionSet {
   kernel: string | null;
@@ -88,16 +104,20 @@ function ReleaseNode({
   row,
   previousRow,
   emphasize,
+  pins,
 }: {
   row: DriverRow;
   previousRow?: DriverRow;
   emphasize: boolean;
+  pins?: StreamPins | null;
 }) {
   const kernel = valueOrFallback(row.versions.kernel);
   const nvidia = valueOrFallback(row.versions.nvidia);
   const mesa = valueOrFallback(row.versions.mesa);
   const hwe = row.versions.hweKernel;
   const gnome = valueOrFallback(row.versions.gnome);
+
+  const hweIsPinned = Boolean(pins?.hweKernel && hwe && hwe === pins.hweKernel);
 
   const kernelMajor = majorNumber(row.versions.kernel);
   const previousKernelMajor = majorNumber(previousRow?.versions.kernel);
@@ -196,6 +216,14 @@ function ReleaseNode({
             <div className={styles.majorVersionCard}>
               <span className={styles.majorVersionLabel}>HWE Kernel</span>
               <VersionValue value={hwe} />
+              {hweIsPinned && (
+                <span
+                  className={styles.pinnedTag}
+                  title={`Pinned to ${pins!.hweKernel} by maintainer — not following upstream`}
+                >
+                  📌 Pinned
+                </span>
+              )}
             </div>
           )}
           <div
@@ -302,6 +330,8 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
               row.versions.gnome,
           );
 
+        const streamPins = pinsCatalog.streams?.[streamId] ?? null;
+
         return (
           <section key={stream.id} className={styles.streamSection}>
             <header className={styles.streamHeader}>
@@ -314,7 +344,7 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
             {latest ? (
               <>
                 <div className={styles.timeline}>
-                  <ReleaseNode row={latest} previousRow={older[0]} emphasize />
+                  <ReleaseNode row={latest} previousRow={older[0]} emphasize pins={streamPins} />
                 </div>
 
                 {older.length > 0 && (
@@ -325,6 +355,7 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
                         row={row}
                         previousRow={older[index + 1]}
                         emphasize={false}
+                        pins={streamPins}
                       />
                     ))}
                   </div>

--- a/src/components/OsReleaseCard.module.css
+++ b/src/components/OsReleaseCard.module.css
@@ -200,6 +200,22 @@
   border-color: rgba(234, 179, 8, 0.4);
 }
 
+.chipPinned {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(180, 83, 9, 0.35);
+}
+
+[data-theme="dark"] .chipPinned {
+  background: rgba(120, 53, 15, 0.25);
+  border-color: rgba(194, 65, 12, 0.5);
+}
+
+.chipPinnedIcon {
+  font-size: 0.72rem;
+  line-height: 1;
+  margin-left: 2px;
+}
+
 .chipLabel {
   font-weight: 600;
   color: var(--ifm-color-emphasis-700);

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -179,7 +179,7 @@ function CommitsSection({ commits }: { commits: ParsedCommit[] }) {
 
 function VersionChip({ pkg, pinnedVersion }: { pkg: ParsedMajorPackage; pinnedVersion?: string | null }) {
   const changed = Boolean(pkg.prevVersion);
-  const isPinned = Boolean(pinnedVersion);
+  const isPinned = pinnedVersion != null && pkg.version === pinnedVersion;
   return (
     <span
       className={`${styles.versionChip} ${changed ? styles.chipChanged : ""} ${isPinned ? styles.chipPinned : ""}`}

--- a/src/components/OsReleaseCard.tsx
+++ b/src/components/OsReleaseCard.tsx
@@ -7,7 +7,38 @@ import type {
   ParsedCommit,
   ParsedDiffEntry,
 } from "../types/os-feed";
+import streamPinsData from "@site/static/data/stream-pins.json";
 import styles from "./OsReleaseCard.module.css";
+
+interface StreamPins {
+  hweKernel?: string | null;
+  kernel?: string | null;
+  mesa?: string | null;
+  nvidia?: string | null;
+  gnome?: string | null;
+}
+
+interface PinsData {
+  streams?: Record<string, StreamPins>;
+}
+
+/** Map OsReleaseEvent stream IDs to stream-pins.json stream keys. */
+const STREAM_TO_PIN_KEY: Record<string, string> = {
+  lts: "bluefin-lts",
+  stable: "bluefin-stable",
+  "stable-daily": "bluefin-stable",
+};
+
+/** Map chip display name (lowercase) to StreamPins field. */
+const CHIP_NAME_TO_PIN_KEY: Record<string, keyof StreamPins> = {
+  "hwe kernel": "hweKernel",
+  kernel: "kernel",
+  mesa: "mesa",
+  nvidia: "nvidia",
+  gnome: "gnome",
+};
+
+const pinsCatalog = streamPinsData as unknown as PinsData;
 
 // ── Date formatting ───────────────────────────────────────────────────────────
 
@@ -146,16 +177,26 @@ function CommitsSection({ commits }: { commits: ParsedCommit[] }) {
 
 // ── Version chip ──────────────────────────────────────────────────────────────
 
-function VersionChip({ pkg }: { pkg: ParsedMajorPackage }) {
+function VersionChip({ pkg, pinnedVersion }: { pkg: ParsedMajorPackage; pinnedVersion?: string | null }) {
   const changed = Boolean(pkg.prevVersion);
+  const isPinned = Boolean(pinnedVersion);
   return (
     <span
-      className={`${styles.versionChip} ${changed ? styles.chipChanged : ""}`}
-      title={changed ? `Previously: ${pkg.prevVersion}` : undefined}
+      className={`${styles.versionChip} ${changed ? styles.chipChanged : ""} ${isPinned ? styles.chipPinned : ""}`}
+      title={
+        isPinned
+          ? `Pinned to ${pinnedVersion} by maintainer — not following upstream`
+          : changed
+            ? `Previously: ${pkg.prevVersion}`
+            : undefined
+      }
     >
       <span className={styles.chipLabel}>{pkg.name}</span>
       <span className={styles.chipValue}>{pkg.version}</span>
-      {changed && (
+      {isPinned && (
+        <span className={styles.chipPinnedIcon} aria-label="pinned">📌</span>
+      )}
+      {!isPinned && changed && (
         <span className={styles.chipUpdated} aria-label="updated">
           ↑
         </span>
@@ -205,6 +246,10 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
   const streamLabel = isLts ? "LTS" : isDaily ? "Daily" : isDakota ? "Dakota" : "Stable";
   const cardVariantClass = isLts ? styles.cardLts : isDakota ? styles.cardDakota : styles.cardStable;
   const cardClass = `${styles.card} ${cardVariantClass}`;
+
+  // Pin lookup for this stream
+  const pinKey = STREAM_TO_PIN_KEY[stream] ?? null;
+  const streamPins: StreamPins | null = pinKey ? ((pinsCatalog.streams?.[pinKey] ?? null) as StreamPins | null) : null;
 
   // Key package chips (header row): subset of well-known packages.
   // Falls back to fullDiff when a name isn't in the curated majorPackages table.
@@ -275,9 +320,11 @@ const OsReleaseCard: React.FC<OsReleaseCardProps> = ({ event }) => {
       {/* ── Key package version chips ── */}
       {headerChips.length > 0 && (
         <div className={styles.chipsRow}>
-          {headerChips.map((pkg) => (
-            <VersionChip key={pkg.name} pkg={pkg} />
-          ))}
+          {headerChips.map((pkg) => {
+            const pinField = CHIP_NAME_TO_PIN_KEY[pkg.name.toLowerCase()];
+            const pinnedVersion = pinField ? streamPins?.[pinField] : null;
+            return <VersionChip key={pkg.name} pkg={pkg} pinnedVersion={pinnedVersion} />;
+          })}
         </div>
       )}
 

--- a/static/data/stream-pins.json
+++ b/static/data/stream-pins.json
@@ -1,0 +1,9 @@
+{
+  "generatedAt": "2026-05-02T00:00:00Z",
+  "streams": {
+    "bluefin-lts": {
+      "hweKernel": "6.19.12-100.fc42"
+    },
+    "bluefin-stable": {}
+  }
+}


### PR DESCRIPTION
## Summary

Adds visual **📌 Pinned** badges when a Bluefin component is intentionally held at a specific version by maintainers, rather than floating with upstream.

**Currently active pin:** `bluefin-lts` HWE Kernel = `6.19.12-100.fc42`

## Changes

### Data pipeline
- **`scripts/fetch-pin-state.js`** (new) — reads `kernel-pin` workflow inputs from `ublue-os/bluefin-lts` via GitHub Contents API; writes `static/data/stream-pins.json`
- **`stream-pins.json`** — committed initial state with current pin values; regenerated by CI via `npm run fetch-pin-state` (added to the `fetch-data` pipeline before `fetch-github-driver-versions`)

### UI — Driver Versions page (`/driver-versions`)
HWE Kernel card shows a **📌 Pinned** badge with tooltip _"Pinned to X by maintainer — not following upstream"_ when the displayed version matches the active pin.

### UI — Changelogs page (`/changelogs`)
HWE Kernel version chip shows a **📌** icon inline with the same tooltip.

### Styling
Amber/orange palette consistent with existing `bumpTag` and `chipChanged` styles. Dark mode supported via `[data-theme="dark"]` overrides.

## When no pins are active
No badges shown — existing behavior is unchanged. The design is extensible: adding `kernel`, `mesa`, `nvidia`, or `gnome` fields to `stream-pins.json` will automatically surface badges on those chips without additional code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pinned kernel version indicators for release streams—recommended HWE kernel versions now display 📌 badges with special styling.
  * Stream-specific pinned versions help users identify the preferred kernel configuration for each distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->