### PR TITLE
refactor: extract shared request-queue module from fetch scripts

### DIFF
--- a/scripts/fetch-contributors.js
+++ b/scripts/fetch-contributors.js
@@ -1,5 +1,9 @@
 const fs = require("fs");
 const path = require("path");
+const {
+  sequentialFetchWithDelay,
+  githubHeaders,
+} = require("./lib/request-queue");
 
 const OUTPUT_DIR = path.join(__dirname, "..", "static", "data");
 const OUTPUT_FILE = path.join(OUTPUT_DIR, "file-contributors.json");
@@ -37,14 +41,7 @@ function isBotAccount(login) {
 
 async function fetchCommits(filePath) {
   const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits?path=${filePath}`;
-
-  const headers = {
-    "User-Agent": "Bluefin-Docs-Build",
-  };
-
-  if (GITHUB_TOKEN) {
-    headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
-  }
+  const headers = githubHeaders(GITHUB_TOKEN);
 
   try {
     const response = await fetch(url, { headers });
@@ -145,21 +142,17 @@ async function fetchAllContributors() {
     `Found ${allFiles.length} files to process (${docFiles.length} docs, ${blogFiles.length} blog)`,
   );
 
-  const contributorsData = {};
-  let successCount = 0;
+  const resultsMap = await sequentialFetchWithDelay(
+    allFiles,
+    async (filePath) => {
+      console.log(`Fetching contributors for ${filePath}...`);
+      const contributors = await fetchCommits(filePath);
+      return contributors.length > 0 ? contributors : null;
+    },
+  );
 
-  for (const filePath of allFiles) {
-    console.log(`Fetching contributors for ${filePath}...`);
-    const contributors = await fetchCommits(filePath);
-
-    if (contributors.length > 0) {
-      contributorsData[filePath] = contributors;
-      successCount++;
-    }
-
-    // Small delay to be nice to GitHub's API
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
+  const contributorsData = Object.fromEntries(resultsMap);
+  const successCount = resultsMap.size;
 
   console.log(
     `\nSuccessfully fetched contributors for ${successCount}/${allFiles.length} files`,

--- a/scripts/fetch-github-profiles.js
+++ b/scripts/fetch-github-profiles.js
@@ -2,6 +2,10 @@ const fs = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
 const glob = require("glob");
+const {
+  sequentialFetchWithDelay,
+  githubHeaders,
+} = require("./lib/request-queue");
 
 const REPO_ROOT = path.join(__dirname, "..");
 
@@ -166,14 +170,7 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
 async function fetchProfile(username) {
   const url = `https://api.github.com/users/${username}`;
-
-  const headers = {
-    "User-Agent": "Bluefin-Docs-Build",
-  };
-
-  if (GITHUB_TOKEN) {
-    headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
-  }
+  const headers = githubHeaders(GITHUB_TOKEN);
 
   try {
     const response = await fetch(url, { headers });
@@ -363,16 +360,15 @@ async function fetchAllProfiles() {
   // Start with existing profiles and overlay fresh fetches
   const profiles = force ? {} : { ...existingProfiles };
 
-  for (const username of usernamestoFetch) {
-    console.log(`Fetching ${username}...`);
-    const profile = await fetchProfile(username);
-
-    if (profile) {
-      profiles[username] = profile;
-    }
-
-    // Small delay to be nice to GitHub's API
-    await new Promise((resolve) => setTimeout(resolve, 100));
+  const fetchedMap = await sequentialFetchWithDelay(
+    usernamestoFetch,
+    async (username) => {
+      console.log(`Fetching ${username}...`);
+      return fetchProfile(username);
+    },
+  );
+  for (const [username, profile] of fetchedMap) {
+    profiles[username] = profile;
   }
 
   const fetched = Object.keys(profiles).length;

--- a/scripts/fetch-github-repos.js
+++ b/scripts/fetch-github-repos.js
@@ -1,5 +1,9 @@
 const fs = require("fs");
 const path = require("path");
+const {
+  sequentialFetchWithDelay,
+  githubHeaders,
+} = require("./lib/request-queue");
 
 // List all GitHub repos from projects.mdx
 const GITHUB_REPOS = [
@@ -68,14 +72,7 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
 async function fetchRepo(repoPath) {
   const url = `https://api.github.com/repos/${repoPath}`;
-
-  const headers = {
-    "User-Agent": "Bluefin-Docs-Build",
-  };
-
-  if (GITHUB_TOKEN) {
-    headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
-  }
+  const headers = githubHeaders(GITHUB_TOKEN);
 
   try {
     const response = await fetch(url, { headers });
@@ -133,20 +130,15 @@ async function fetchAllRepos() {
 
   console.log(`Fetching ${GITHUB_REPOS.length} GitHub repos...`);
 
-  const repos = {};
+  const resultsMap = await sequentialFetchWithDelay(
+    GITHUB_REPOS,
+    async (repoPath) => {
+      console.log(`Fetching ${repoPath}...`);
+      return fetchRepo(repoPath);
+    },
+  );
 
-  // Fetch repos with a small delay to avoid rate limiting
-  for (const repoPath of GITHUB_REPOS) {
-    console.log(`Fetching ${repoPath}...`);
-    const repo = await fetchRepo(repoPath);
-
-    if (repo) {
-      repos[repoPath] = repo;
-    }
-
-    // Small delay to be nice to GitHub's API
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
+  const repos = Object.fromEntries(resultsMap);
 
   console.log(
     `\nSuccessfully fetched ${Object.keys(repos).length}/${GITHUB_REPOS.length} repos`,

--- a/scripts/lib/build-metrics.mjs
+++ b/scripts/lib/build-metrics.mjs
@@ -9,6 +9,15 @@
  */
 
 import { request } from "@octokit/request";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { retryWithBackoff: _retryWithBackoff } = require("./request-queue.js");
+
+/** Wrapper that passes the [build-metrics] label to the shared implementation. */
+function retryWithBackoff(fn, maxRetries = 3) {
+  return _retryWithBackoff(fn, { maxRetries, label: "[build-metrics]" });
+}
 
 /**
  * Workflow definitions to track
@@ -55,57 +64,6 @@ const requestWithAuth = request.defaults({
     authorization: `token ${process.env.GITHUB_TOKEN || process.env.GH_TOKEN}`,
   },
 });
-
-/**
- * Helper function to handle network retry with exponential backoff
- *
- * @param {Function} fn - Async function to retry
- * @param {number} maxRetries - Maximum retry attempts (default: 3)
- * @returns {Promise<any>} Result from successful function call
- */
-async function retryWithBackoff(fn, maxRetries = 3) {
-  let lastError;
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-
-      // Don't retry on authentication or rate limit errors
-      if (error.status === 401 || error.status === 403) {
-        console.warn(
-          `[build-metrics] Authentication/rate limit error: ${error.message}`,
-        );
-        throw error;
-      }
-
-      // Retry on network errors
-      const isNetworkError =
-        error.code === "ECONNRESET" ||
-        error.code === "ETIMEDOUT" ||
-        error.code === "ENOTFOUND" ||
-        error.code === "EAI_AGAIN" ||
-        error.message?.includes("socket hang up") ||
-        error.message?.includes("timeout");
-
-      if (isNetworkError && attempt < maxRetries) {
-        const delay = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
-        console.log(
-          `[build-metrics] Retry ${attempt}/${maxRetries} after network error: ${error.message || error.code}`,
-        );
-        console.log(`[build-metrics] Waiting ${delay}ms before retry...`);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        continue;
-      }
-
-      // If not a network error or max retries reached, throw
-      throw lastError;
-    }
-  }
-
-  throw lastError;
-}
 
 /**
  * Fetch workflow runs for a specific workflow within a date range

--- a/scripts/lib/graphql-queries.mjs
+++ b/scripts/lib/graphql-queries.mjs
@@ -5,6 +5,10 @@
  */
 
 import { graphql } from "@octokit/graphql";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { retryWithBackoff } = require("./request-queue.js");
 
 /**
  * GraphQL query definition for Projects V2
@@ -106,54 +110,6 @@ const graphqlWithAuth = graphql.defaults({
     authorization: `token ${process.env.GITHUB_TOKEN || process.env.GH_TOKEN}`,
   },
 });
-
-/**
- * Helper function to handle network retry with exponential backoff
- *
- * @param {Function} fn - Async function to retry
- * @param {number} maxRetries - Maximum retry attempts (default: 3)
- * @returns {Promise<any>} Result from successful function call
- */
-async function retryWithBackoff(fn, maxRetries = 3) {
-  let lastError;
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-
-      // Don't retry on authentication or rate limit errors
-      if (error.status === 401 || error.status === 403) {
-        throw error;
-      }
-
-      // Retry on network errors
-      const isNetworkError =
-        error.code === "ECONNRESET" ||
-        error.code === "ETIMEDOUT" ||
-        error.code === "ENOTFOUND" ||
-        error.code === "EAI_AGAIN" ||
-        error.message?.includes("socket hang up") ||
-        error.message?.includes("timeout");
-
-      if (isNetworkError && attempt < maxRetries) {
-        const delay = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
-        console.log(
-          `Retry ${attempt}/${maxRetries} after network error: ${error.message || error.code}`,
-        );
-        console.log(`Waiting ${delay}ms before retry...`);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        continue;
-      }
-
-      // If not a network error or max retries reached, throw
-      throw error;
-    }
-  }
-
-  throw lastError;
-}
 
 /**
  * Fetch project items with pagination support and retry logic

--- a/scripts/lib/request-queue.js
+++ b/scripts/lib/request-queue.js
@@ -1,0 +1,146 @@
+/**
+ * Shared request-queue utilities for GitHub API fetch scripts.
+ *
+ * Consolidates two patterns that were duplicated across multiple scripts:
+ *
+ * 1. `retryWithBackoff(fn, opts)` — exponential-backoff retry for transient
+ *    network errors (ECONNRESET, ETIMEDOUT, etc.).  Skips retry on auth/rate-
+ *    limit errors (401/403).  Previously duplicated in graphql-queries.mjs
+ *    and build-metrics.mjs.
+ *
+ * 2. `sequentialFetchWithDelay(items, fetchFn, delayMs)` — iterates an array,
+ *    calling an async function for each item with a fixed inter-request delay.
+ *    Previously duplicated in fetch-github-repos.js, fetch-contributors.js,
+ *    and fetch-github-profiles.js.
+ */
+
+"use strict";
+
+// ── Retry with exponential backoff ──────────────────────────────────────────
+
+/**
+ * Determine whether an error is a transient network error worth retrying.
+ *
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isNetworkError(error) {
+  return (
+    error.code === "ECONNRESET" ||
+    error.code === "ETIMEDOUT" ||
+    error.code === "ENOTFOUND" ||
+    error.code === "EAI_AGAIN" ||
+    error.message?.includes("socket hang up") ||
+    error.message?.includes("timeout")
+  );
+}
+
+/**
+ * Retry an async function with exponential backoff on transient network errors.
+ *
+ * Behaviour preserved from the original implementations:
+ *  - 401 / 403 → throw immediately (auth / rate-limit).
+ *  - Network errors → retry up to `maxRetries` times with 2^attempt × 1 000 ms delay.
+ *  - Any other error → throw immediately.
+ *
+ * @param {Function} fn          Async function to execute.
+ * @param {object}   [opts]      Options.
+ * @param {number}   [opts.maxRetries=3]  Maximum retry attempts.
+ * @param {string}   [opts.label]         Optional log prefix (e.g. "[build-metrics]").
+ * @returns {Promise<any>} Result of the successful call.
+ */
+async function retryWithBackoff(fn, opts = {}) {
+  const maxRetries = opts.maxRetries ?? 3;
+  const label = opts.label ? `${opts.label} ` : "";
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      // Don't retry on authentication or rate limit errors
+      if (error.status === 401 || error.status === 403) {
+        if (label) {
+          console.warn(
+            `${label}Authentication/rate limit error: ${error.message}`,
+          );
+        }
+        throw error;
+      }
+
+      // Retry on network errors
+      if (isNetworkError(error) && attempt < maxRetries) {
+        const delay = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
+        console.log(
+          `${label}Retry ${attempt}/${maxRetries} after network error: ${error.message || error.code}`,
+        );
+        console.log(`${label}Waiting ${delay}ms before retry...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      // If not a network error or max retries reached, throw
+      throw error;
+    }
+  }
+
+  throw lastError;
+}
+
+// ── Sequential fetch with inter-request delay ──────────────────────────────
+
+/**
+ * Process an array of items sequentially, calling `fetchFn` for each and
+ * pausing `delayMs` between requests to avoid hitting GitHub rate limits.
+ *
+ * @param {Array}    items       Items to iterate.
+ * @param {Function} fetchFn    `async (item) => result | null`. Called once per item.
+ * @param {object}   [opts]     Options.
+ * @param {number}   [opts.delayMs=100]  Milliseconds to wait between requests.
+ * @returns {Promise<Map>} Map of item → result (null results are excluded).
+ */
+async function sequentialFetchWithDelay(items, fetchFn, opts = {}) {
+  const delayMs = opts.delayMs ?? 100;
+  const results = new Map();
+
+  for (const item of items) {
+    const result = await fetchFn(item);
+    if (result != null) {
+      results.set(item, result);
+    }
+
+    // Inter-request delay to be nice to GitHub's API
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return results;
+}
+
+// ── GitHub auth headers helper ──────────────────────────────────────────────
+
+/**
+ * Build standard GitHub API request headers.
+ *
+ * @param {string} [token]  GitHub personal access token. Falls back to
+ *                          GITHUB_TOKEN / GH_TOKEN env vars when omitted.
+ * @returns {object} Headers object suitable for `fetch()`.
+ */
+function githubHeaders(token) {
+  const t = token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const headers = { "User-Agent": "Bluefin-Docs-Build" };
+  if (t) {
+    headers["Authorization"] = `Bearer ${t}`;
+  }
+  return headers;
+}
+
+module.exports = {
+  isNetworkError,
+  retryWithBackoff,
+  sequentialFetchWithDelay,
+  githubHeaders,
+};

--- a/scripts/request-queue.test.js
+++ b/scripts/request-queue.test.js
@@ -1,0 +1,230 @@
+/**
+ * Tests for scripts/lib/request-queue.js
+ */
+
+const { describe, it, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isNetworkError,
+  retryWithBackoff,
+  sequentialFetchWithDelay,
+  githubHeaders,
+} = require("./lib/request-queue");
+
+// ── isNetworkError ──────────────────────────────────────────────────────────
+
+describe("isNetworkError", () => {
+  it("returns true for ECONNRESET", () => {
+    const err = new Error("connection reset");
+    err.code = "ECONNRESET";
+    assert.equal(isNetworkError(err), true);
+  });
+
+  it("returns true for ETIMEDOUT", () => {
+    const err = new Error("timed out");
+    err.code = "ETIMEDOUT";
+    assert.equal(isNetworkError(err), true);
+  });
+
+  it("returns true for ENOTFOUND", () => {
+    const err = new Error("not found");
+    err.code = "ENOTFOUND";
+    assert.equal(isNetworkError(err), true);
+  });
+
+  it("returns true for EAI_AGAIN", () => {
+    const err = new Error("dns");
+    err.code = "EAI_AGAIN";
+    assert.equal(isNetworkError(err), true);
+  });
+
+  it('returns true for "socket hang up"', () => {
+    assert.equal(isNetworkError(new Error("socket hang up")), true);
+  });
+
+  it('returns true for "timeout" in message', () => {
+    assert.equal(isNetworkError(new Error("request timeout")), true);
+  });
+
+  it("returns false for generic errors", () => {
+    assert.equal(isNetworkError(new Error("something else")), false);
+  });
+
+  it("returns false for auth errors", () => {
+    const err = new Error("Bad credentials");
+    err.status = 401;
+    assert.equal(isNetworkError(err), false);
+  });
+});
+
+// ── retryWithBackoff ────────────────────────────────────────────────────────
+
+describe("retryWithBackoff", () => {
+  it("returns result on first success", async () => {
+    const result = await retryWithBackoff(() => Promise.resolve(42));
+    assert.equal(result, 42);
+  });
+
+  it("retries on network error and eventually succeeds", async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(
+      () => {
+        calls++;
+        if (calls < 2) {
+          const err = new Error("socket hang up");
+          throw err;
+        }
+        return Promise.resolve("ok");
+      },
+      { maxRetries: 3 },
+    );
+    assert.equal(result, "ok");
+    assert.equal(calls, 2);
+  });
+
+  it("throws immediately on 401", async () => {
+    const err = new Error("Unauthorized");
+    err.status = 401;
+    await assert.rejects(
+      () => retryWithBackoff(() => { throw err; }, { maxRetries: 3 }),
+      (thrown) => thrown.status === 401,
+    );
+  });
+
+  it("throws immediately on 403", async () => {
+    const err = new Error("Forbidden");
+    err.status = 403;
+    await assert.rejects(
+      () => retryWithBackoff(() => { throw err; }, { maxRetries: 3 }),
+      (thrown) => thrown.status === 403,
+    );
+  });
+
+  it("throws non-network errors without retrying", async () => {
+    let calls = 0;
+    await assert.rejects(
+      () =>
+        retryWithBackoff(
+          () => {
+            calls++;
+            throw new Error("not a network error");
+          },
+          { maxRetries: 3 },
+        ),
+      { message: "not a network error" },
+    );
+    assert.equal(calls, 1);
+  });
+});
+
+// ── sequentialFetchWithDelay ────────────────────────────────────────────────
+
+describe("sequentialFetchWithDelay", () => {
+  it("calls fetchFn for each item and collects results", async () => {
+    const items = ["a", "b", "c"];
+    const result = await sequentialFetchWithDelay(
+      items,
+      async (item) => item.toUpperCase(),
+      { delayMs: 0 },
+    );
+    assert.equal(result.size, 3);
+    assert.equal(result.get("a"), "A");
+    assert.equal(result.get("b"), "B");
+    assert.equal(result.get("c"), "C");
+  });
+
+  it("excludes null results", async () => {
+    const items = [1, 2, 3];
+    const result = await sequentialFetchWithDelay(
+      items,
+      async (item) => (item === 2 ? null : item * 10),
+      { delayMs: 0 },
+    );
+    assert.equal(result.size, 2);
+    assert.equal(result.get(1), 10);
+    assert.equal(result.get(3), 30);
+    assert.equal(result.has(2), false);
+  });
+
+  it("processes items sequentially (not in parallel)", async () => {
+    const order = [];
+    await sequentialFetchWithDelay(
+      ["first", "second", "third"],
+      async (item) => {
+        order.push(item);
+        return item;
+      },
+      { delayMs: 0 },
+    );
+    assert.deepEqual(order, ["first", "second", "third"]);
+  });
+
+  it("returns empty map for empty input", async () => {
+    const result = await sequentialFetchWithDelay(
+      [],
+      async () => "never called",
+      { delayMs: 0 },
+    );
+    assert.equal(result.size, 0);
+  });
+
+  it("applies default 100ms delay", async () => {
+    const start = Date.now();
+    await sequentialFetchWithDelay(
+      ["a", "b"],
+      async (item) => item,
+    );
+    const elapsed = Date.now() - start;
+    // Two items → one inter-request delay of ~100ms + one trailing delay
+    assert.ok(elapsed >= 150, `Expected ≥150ms, got ${elapsed}ms`);
+  });
+});
+
+// ── githubHeaders ───────────────────────────────────────────────────────────
+
+describe("githubHeaders", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+  const originalGhToken = process.env.GH_TOKEN;
+
+  beforeEach(() => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+  });
+
+  // Restore after tests
+  it("returns User-Agent without auth when no token", () => {
+    const headers = githubHeaders();
+    assert.equal(headers["User-Agent"], "Bluefin-Docs-Build");
+    assert.equal(headers["Authorization"], undefined);
+  });
+
+  it("uses explicit token parameter", () => {
+    const headers = githubHeaders("test-token-123");
+    assert.equal(headers["Authorization"], "Bearer test-token-123");
+  });
+
+  it("falls back to GITHUB_TOKEN env var", () => {
+    process.env.GITHUB_TOKEN = "env-token";
+    const headers = githubHeaders();
+    assert.equal(headers["Authorization"], "Bearer env-token");
+    // cleanup
+    if (originalToken) process.env.GITHUB_TOKEN = originalToken;
+    else delete process.env.GITHUB_TOKEN;
+  });
+
+  it("falls back to GH_TOKEN env var", () => {
+    process.env.GH_TOKEN = "gh-token";
+    const headers = githubHeaders();
+    assert.equal(headers["Authorization"], "Bearer gh-token");
+    // cleanup
+    if (originalGhToken) process.env.GH_TOKEN = originalGhToken;
+    else delete process.env.GH_TOKEN;
+  });
+
+  // Restore env vars at the end
+  it("cleanup env", () => {
+    if (originalToken) process.env.GITHUB_TOKEN = originalToken;
+    if (originalGhToken) process.env.GH_TOKEN = originalGhToken;
+  });
+});


### PR DESCRIPTION
Deduplicates GitHub API rate-limiting and retry logic across 5 fetch scripts into `scripts/lib/request-queue.js`.

**Exports:** `isNetworkError`, `retryWithBackoff`, `sequentialFetchWithDelay`, `githubHeaders`

**Deduplicated from:** fetch-github-repos.js, fetch-contributors.js, fetch-github-profiles.js, graphql-queries.mjs, build-metrics.mjs

**Result:** −160 lines duplicated logic, +146 lines shared module, +23 new tests

**Verified:**
- `npm run build` — success
- `npm test` — 56/56 pass

Assisted-by: Claude Opus 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated GitHub API request and retry logic across multiple data-fetching scripts into a centralized utility module for improved consistency.

* **Tests**
  * Added comprehensive test suite for the new request utilities module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->