### PR TITLE
arch: add SBOM adapter layer and release-list emitter

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -643,7 +643,7 @@ async function main() {
         stream: streamId,
         tag,
         date: entry.checkedAt,
-        digest: entry.digest?.slice(0, 19),
+        digest: entry.digest ? entry.digest.slice(0, 19) : null,
         kernel: pv.kernel || null,
         gnome: pv.gnome || null,
         mesa: pv.mesa || null,

--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -631,6 +631,28 @@ async function main() {
   const frontendOutput = { ...output, streams: frontendStreams };
   atomicWriteJson(FRONTEND_OUTPUT_FILE, frontendOutput);
   console.log(`SBOM frontend slim cache written to ${FRONTEND_OUTPUT_FILE}`);
+
+  // Write release-list.json — a lightweight index of all releases across streams,
+  // suitable for changelogs/feed pages without importing the full SBOM payload.
+  const RELEASE_LIST_FILE = path.join(path.dirname(OUTPUT_FILE), "release-list.json");
+  const releaseList = [];
+  for (const [streamId, stream] of Object.entries(streams)) {
+    for (const [tag, entry] of Object.entries(stream.releases || {})) {
+      const pv = entry.packageVersions || {};
+      releaseList.push({
+        stream: streamId,
+        tag,
+        date: entry.checkedAt,
+        digest: entry.digest?.slice(0, 19),
+        kernel: pv.kernel || null,
+        gnome: pv.gnome || null,
+        mesa: pv.mesa || null,
+      });
+    }
+  }
+  releaseList.sort((a, b) => new Date(b.date) - new Date(a.date));
+  atomicWriteJson(RELEASE_LIST_FILE, { generatedAt: output.generatedAt, releases: releaseList });
+  console.log(`Release list written to ${RELEASE_LIST_FILE} (${releaseList.length} entries)`);
 }
 
 if (require.main === module) {

--- a/src/lib/sbom-adapter.ts
+++ b/src/lib/sbom-adapter.ts
@@ -15,20 +15,29 @@
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface PackageVersions {
-  kernel?: string;
-  gnome?: string;
-  mesa?: string;
-  podman?: string;
-  systemd?: string;
-  [key: string]: string | undefined;
+  kernel?: string | null;
+  gnome?: string | null;
+  mesa?: string | null;
+  podman?: string | null;
+  systemd?: string | null;
+  [key: string]: string | null | undefined;
+}
+
+export interface Attestation {
+  present: boolean | null;
+  verified: boolean;
+  predicateType: string | null;
+  slsaType?: string;
+  errorKind?: string;
+  error: string | null;
 }
 
 export interface Release {
   tag: string;
   imageRef: string;
-  digest: string;
-  attestation: string;
-  packageVersions: PackageVersions;
+  digest: string | null;
+  attestation: Attestation;
+  packageVersions: PackageVersions | null;
   checkedAt: string;
 }
 
@@ -117,7 +126,7 @@ export function getLatestRelease(streamId: string): LatestRelease | null {
     kernel: pv.kernel ?? "unknown",
     gnome: pv.gnome ?? "unknown",
     mesa: pv.mesa ?? "unknown",
-    digest: release.digest,
+    digest: release.digest ?? "unknown",
     imageRef: release.imageRef,
     allVersions: pv,
   };
@@ -170,7 +179,7 @@ export function findStreamsByPackageVersion(
   const matches: string[] = [];
   for (const [streamId, stream] of Object.entries(data.streams)) {
     for (const release of Object.values(stream.releases)) {
-      if (release.packageVersions[packageName] === version) {
+      if (release.packageVersions?.[packageName] === version) {
         matches.push(streamId);
         break;
       }

--- a/src/lib/sbom-adapter.ts
+++ b/src/lib/sbom-adapter.ts
@@ -1,0 +1,180 @@
+/**
+ * SBOM-first data adapter.
+ *
+ * Single entry point for components that need release, version, or package
+ * data. Reads from sbom-attestations-frontend.json and exposes a clean API
+ * so that components never import raw JSON directly.
+ *
+ * Design goals:
+ *   1. One canonical import for release data across the site
+ *   2. Lazy loading — the 104 KB SBOM payload is parsed on first access
+ *   3. Typed interfaces that match what components actually render
+ *   4. Adapter layer isolates components from upstream SBOM schema changes
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface PackageVersions {
+  kernel?: string;
+  gnome?: string;
+  mesa?: string;
+  podman?: string;
+  systemd?: string;
+  [key: string]: string | undefined;
+}
+
+export interface Release {
+  tag: string;
+  imageRef: string;
+  digest: string;
+  attestation: string;
+  packageVersions: PackageVersions;
+  checkedAt: string;
+}
+
+export interface Stream {
+  id: string;
+  label: string;
+  org: string;
+  package: string;
+  streamPrefix: string;
+  keyRepo: string;
+  keyless: boolean;
+  releases: Record<string, Release>;
+}
+
+export interface SbomData {
+  generatedAt: string;
+  lookbackDays: number;
+  maxReleasesPerStream: number;
+  streams: Record<string, Stream>;
+}
+
+export interface LatestRelease {
+  stream: string;
+  tag: string;
+  date: string;
+  kernel: string;
+  gnome: string;
+  mesa: string;
+  digest: string;
+  imageRef: string;
+  allVersions: PackageVersions;
+}
+
+export interface StreamSummary {
+  id: string;
+  label: string;
+  releaseCount: number;
+  latestTag: string | null;
+  latestDate: string | null;
+}
+
+// ── Lazy loader ──────────────────────────────────────────────────────────────
+
+let _cache: SbomData | null = null;
+
+function load(): SbomData {
+  if (_cache) return _cache;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  _cache = require("@site/static/data/sbom-attestations-frontend.json") as SbomData;
+  return _cache;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/** Get the raw SBOM data (lazy-loaded). */
+export function getSbomData(): SbomData {
+  return load();
+}
+
+/** List all stream IDs. */
+export function getStreamIds(): string[] {
+  return Object.keys(load().streams);
+}
+
+/** Get a single stream by ID. */
+export function getStream(streamId: string): Stream | undefined {
+  return load().streams[streamId];
+}
+
+/** Get the latest release for a stream. Returns null if stream has no releases. */
+export function getLatestRelease(streamId: string): LatestRelease | null {
+  const stream = getStream(streamId);
+  if (!stream) return null;
+
+  const entries = Object.entries(stream.releases);
+  if (entries.length === 0) return null;
+
+  // Releases are ordered newest-first by convention
+  const [tag, release] = entries[0];
+  const pv = release.packageVersions || {};
+
+  return {
+    stream: streamId,
+    tag,
+    date: release.checkedAt,
+    kernel: pv.kernel ?? "unknown",
+    gnome: pv.gnome ?? "unknown",
+    mesa: pv.mesa ?? "unknown",
+    digest: release.digest,
+    imageRef: release.imageRef,
+    allVersions: pv,
+  };
+}
+
+/** Get latest releases for all streams. Streams with no releases are skipped. */
+export function getAllLatestReleases(): LatestRelease[] {
+  return getStreamIds()
+    .map(getLatestRelease)
+    .filter((r): r is LatestRelease => r !== null);
+}
+
+/** Get a summary of all streams (id, label, release count, latest tag). */
+export function getStreamSummaries(): StreamSummary[] {
+  const data = load();
+  return Object.values(data.streams).map((s) => {
+    const tags = Object.keys(s.releases);
+    return {
+      id: s.id,
+      label: s.label,
+      releaseCount: tags.length,
+      latestTag: tags[0] ?? null,
+      latestDate: tags[0] ? s.releases[tags[0]].checkedAt : null,
+    };
+  });
+}
+
+/** Get all releases for a stream, sorted newest-first. */
+export function getReleases(streamId: string): Release[] {
+  const stream = getStream(streamId);
+  if (!stream) return [];
+  return Object.values(stream.releases);
+}
+
+/** Check SBOM freshness. Returns hours since generation. */
+export function getSbomAgeHours(): number {
+  const gen = new Date(load().generatedAt);
+  return (Date.now() - gen.getTime()) / (1000 * 60 * 60);
+}
+
+/**
+ * Find which streams contain a specific package version.
+ * Useful for "which images ship kernel X.Y.Z?" queries.
+ */
+export function findStreamsByPackageVersion(
+  packageName: string,
+  version: string,
+): string[] {
+  const data = load();
+  const matches: string[] = [];
+  for (const [streamId, stream] of Object.entries(data.streams)) {
+    for (const release of Object.values(stream.releases)) {
+      if (release.packageVersions[packageName] === version) {
+        matches.push(streamId);
+        break;
+      }
+    }
+  }
+  return matches;
+}

--- a/src/lib/sbom-feed-adapter.ts
+++ b/src/lib/sbom-feed-adapter.ts
@@ -1,0 +1,112 @@
+/**
+ * SBOM → Feed compatibility adapter.
+ *
+ * Bridges the gap between the SBOM data model (streams/releases/packages)
+ * and the legacy feed card format that FeedItems.tsx and FirehoseFeed.tsx
+ * currently render. This allows a gradual migration: components can switch
+ * to sbom-feed-adapter imports without rewriting their rendering logic.
+ *
+ * Once components are fully migrated, this adapter can be removed and
+ * components can consume sbom-adapter.ts directly.
+ */
+
+import type { LatestRelease, Release, Stream } from "./sbom-adapter";
+import { getStream, getStreamIds, getSbomData } from "./sbom-adapter";
+
+// ── Feed-compatible types ────────────────────────────────────────────────────
+
+export interface VersionChip {
+  label: string;
+  value: string;
+}
+
+export interface FeedCard {
+  id: string;
+  title: string;
+  stream: string;
+  tag: string;
+  date: string;
+  imageRef: string;
+  digest: string;
+  chips: VersionChip[];
+  kind: "release";
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const CHIP_KEYS = ["kernel", "gnome", "mesa", "podman", "systemd"] as const;
+
+function releaseToCard(streamId: string, tag: string, release: Release): FeedCard {
+  const pv = release.packageVersions || {};
+  const chips: VersionChip[] = CHIP_KEYS
+    .filter((k) => pv[k])
+    .map((k) => ({ label: k.charAt(0).toUpperCase() + k.slice(1), value: pv[k]! }));
+
+  const streamLabel = streamId
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+  return {
+    id: `${streamId}/${tag}`,
+    title: `${streamLabel} — ${tag}`,
+    stream: streamId,
+    tag,
+    date: release.checkedAt,
+    imageRef: release.imageRef,
+    digest: release.digest,
+    chips,
+    kind: "release",
+  };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Get all SBOM releases as feed cards, newest-first across all streams.
+ * Optionally filter by stream prefix (e.g., "bluefin-stable").
+ */
+export function getSbomFeedCards(streamFilter?: string): FeedCard[] {
+  const ids = streamFilter
+    ? getStreamIds().filter((id) => id.startsWith(streamFilter))
+    : getStreamIds();
+
+  const cards: FeedCard[] = [];
+  for (const streamId of ids) {
+    const stream = getStream(streamId);
+    if (!stream) continue;
+    for (const [tag, release] of Object.entries(stream.releases)) {
+      cards.push(releaseToCard(streamId, tag, release));
+    }
+  }
+
+  // Sort newest-first by date
+  cards.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return cards;
+}
+
+/**
+ * Get the latest release card per stream (one card per stream).
+ * Useful for the "pinned" cards at the top of the changelogs page.
+ */
+export function getPinnedCards(streamIds?: string[]): FeedCard[] {
+  const ids = streamIds ?? getStreamIds();
+  const cards: FeedCard[] = [];
+
+  for (const streamId of ids) {
+    const stream = getStream(streamId);
+    if (!stream) continue;
+    const tags = Object.keys(stream.releases);
+    if (tags.length === 0) continue;
+    const tag = tags[0];
+    cards.push(releaseToCard(streamId, tag, stream.releases[tag]));
+  }
+
+  return cards;
+}
+
+/**
+ * Get the SBOM generation timestamp as an ISO string.
+ */
+export function getSbomTimestamp(): string {
+  return getSbomData().generatedAt;
+}

--- a/src/lib/sbom-feed-adapter.ts
+++ b/src/lib/sbom-feed-adapter.ts
@@ -53,7 +53,7 @@ function releaseToCard(streamId: string, tag: string, release: Release): FeedCar
     tag,
     date: release.checkedAt,
     imageRef: release.imageRef,
-    digest: release.digest,
+    digest: release.digest ?? "",
     chips,
     kind: "release",
   };


### PR DESCRIPTION
## Summary

Adds the typed SBOM data API and feed compatibility layer for incremental migration from RSS/Atom feeds to SBOM-first data architecture.

### Changes

- **`src/lib/sbom-adapter.ts`** — Typed SBOM data API with lazy loading. Exports: `getSbomData`, `getStreamIds`, `getStream`, `getLatestRelease`, `getAllLatestReleases`, `getStreamSummaries`, `getReleases`, `getSbomAgeHours`, `findStreamsByPackageVersion`
- **`src/lib/sbom-feed-adapter.ts`** — SBOM → feed card compatibility layer. Enables incremental migration without flag-day risk. Components consume the adapter; data source can be swapped behind it.
- **`scripts/fetch-github-sbom.js`** — Extended to emit `release-list.json` with dates/tags from SBOM attestation metadata

### Context

Part of the documentation audit epic. Audit directive: all software release data must come from SBOMs, not RSS/Atom feeds. This PR provides the adapter layer that enables incremental migration of FeedItems.tsx, FirehoseFeed.tsx, and other components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates a consolidated, timestamped release index summarizing releases with stream, tag, date, digest and key package versions.
  * Adds a centralized SBOM-backed data layer for browsing streams, releases, summaries, SBOM age, and finding streams by package version; lazy-loaded and cached.
  * Provides feed-ready release cards and pinned stream highlights for UI consumption, with package-version chips and newest-first sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->