### PR TITLE
ci: add Playwright e2e test workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,86 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Restore GitHub data cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            static/data/artwork-versions.json
+            static/data/driver-versions.json
+            static/data/file-contributors.json
+            static/data/firehose-apps.json
+            static/data/github-repos.json
+            static/data/images.json
+            static/data/playlist-metadata.json
+            static/data/stream-pins.json
+          key: github-data-${{ hashFiles('scripts/fetch-*.js') }}
+          restore-keys: |
+            github-data-
+
+      - name: Restore GitHub profiles cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: static/data/github-profiles.json
+          key: github-profiles-v1-${{ github.run_id }}
+          restore-keys: |
+            github-profiles-v1-
+
+      - name: Fetch data
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          IMAGES_CACHE_HOURS: "0"
+          IMAGES_REFRESH_HOURS: "0"
+          DRIVER_VERSIONS_CACHE_HOURS: "0"
+          FIREHOSE_CACHE_HOURS: "0"
+        run: npm run fetch-data
+
+      - name: Build site
+        run: npm run build:ci
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() && failure() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14


### PR DESCRIPTION
Run existing Playwright specs on PRs and pushes to main. Fetches real data before testing to catch regressions like the changelogs app stream disappearance.

Closes castrojo/documentation#91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated end-to-end testing workflow to the continuous integration pipeline to validate application functionality on every pull request and merge to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->