### PR TITLE
fix(sbom): remove dakota cosign-sign workaround — SLSA attestation live

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -299,12 +299,6 @@ const STREAM_SPECS = [
     keyRepo: "projectbluefin/dakota",
     keyless: true,
     usesLatestTag: true,
-    // Dakota's publish.yml uses `cosign sign` (keyless OIDC) without push-to-registry: true
-    // on the SLSA attestation step, so the attestation is only in GitHub's internal store
-    // and not discoverable as an OCI referrer via cosign verify-attestation.
-    // TODO: Remove signingType once projectbluefin/dakota#391 (push-to-registry: true) merges;
-    //       then switch to standard keyless: true SLSA path (remove this signingType entirely).
-    signingType: "cosign-sign",
   },
 ];
 


### PR DESCRIPTION
Dakota image now has proper keyless SLSA provenance attestation (verified with cosign verify-attestation). Remove the cosign-sign signing type override from the dakota stream spec.

Closes castrojo/documentation#92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored image stream processing configuration to use a dedicated flow for latest image tags.
  * Enhanced caching mechanism to derive cache keys from image creation date annotations.
  * Improved attestation verification and SBOM processing for latest image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->