### PR TITLE
fix(test): use relative URLs in artwork HTTP tests for baseURL portability

### DIFF
--- a/tests/e2e/artwork-gallery.spec.ts
+++ b/tests/e2e/artwork-gallery.spec.ts
@@ -213,7 +213,8 @@ test("brew install commands appear under each collection", async ({ page }) => {
 const THUMB_DIR = path.join(__dirname, "../../static/img/artwork/thumbnails");
 const FULLRES_DIR = path.join(__dirname, "../../static/img/artwork/fullres");
 const ARTWORK_JSON = path.join(__dirname, "../../static/data/artwork.json");
-const BASE_URL = "http://localhost:3000";
+// page.request.get() uses the baseURL from playwright.config.ts automatically
+// when given relative paths — no hardcoded BASE_URL needed.
 
 /** Run ffprobe to get pixel dimensions of a local image file. */
 function getImageDimensions(filepath: string): { width: number; height: number } {
@@ -408,7 +409,7 @@ test.describe("image HTTP responses", () => {
     await page.goto("/artwork");
     const failed: string[] = [];
     for (const url of thumbUrls) {
-      const res = await page.request.get(`${BASE_URL}${url}`);
+      const res = await page.request.get(url);
       if (res.status() !== 200) {
         failed.push(`${url}: HTTP ${res.status()}`);
       }
@@ -450,7 +451,7 @@ test.describe("image HTTP responses", () => {
     await page.goto("/artwork");
     const failed: string[] = [];
     for (const url of fullresUrls) {
-      const res = await page.request.get(`${BASE_URL}${url}`);
+      const res = await page.request.get(url);
       if (res.status() !== 200) {
         failed.push(`${url}: HTTP ${res.status()}`);
       }


### PR DESCRIPTION
## What

The artwork HTTP response tests (`artwork-gallery.spec.ts`) hardcoded `http://localhost:3000` for image URL probing. This breaks when running against production via a separate config.

## Fix

Remove the hardcoded `BASE_URL` constant. `page.request.get()` resolves relative paths against Playwright's configured `baseURL` automatically.

## Test

Tests now work with both local dev server and production `baseURL` configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced artwork gallery validation with comprehensive checks for image assets, including disk size limits, aspect ratio correctness, HTTP availability, and browser rendering integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->