### PR TITLE
ci: fix SBOM cache miss condition to use cache-matched-key

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -85,7 +85,7 @@ jobs:
             github-data-sbom-
 
       - name: Fetch SBOM on cache miss
-        if: steps.sbom-cache.outputs.cache-hit != 'true'
+        if: steps.sbom-cache.outputs.cache-matched-key == ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/fetch-github-sbom.js


### PR DESCRIPTION
actions/cache/restore sets cache-hit=true only for exact primary key matches, not restore-key partial matches. Since the primary key includes the run_id and never matches, cache-hit is always false and the fallback fetch-github-sbom.js always runs — overwriting the restored cache with cosign-less data (packageVersions: null for dakota).

Use cache-matched-key instead, which is non-empty whenever any cache was restored (primary or restore-key). This stops the fallback from running when a nightly SBOM cache entry is already available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build pipeline's Software Bill of Materials (SBOM) caching mechanism to improve cache miss detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->