### PR TITLE
fix(images): remove ARM from Bluefin supported architectures

### DIFF
--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -47,7 +47,7 @@ const PRODUCT_SPECS = [
     nvidiaPackage: "bluefin-nvidia-open",
     allowTestingStreams: false,
     isoSectionLink: "/downloads#bluefin",
-    supportedArches: ["amd", "intel", "arm"],
+    supportedArches: ["amd", "intel"],
   },
   {
     id: "ublue-bluefin-dx",
@@ -63,7 +63,7 @@ const PRODUCT_SPECS = [
     nvidiaPackage: "bluefin-dx-nvidia-open",
     allowTestingStreams: false,
     isoSectionLink: "/downloads#bluefin",
-    supportedArches: ["amd", "intel", "arm"],
+    supportedArches: ["amd", "intel"],
   },
   {
     id: "ublue-bluefin-lts",
@@ -81,7 +81,7 @@ const PRODUCT_SPECS = [
     allowTestingStreams: true,
     keepEvenIfStale: true,
     isoSectionLink: "/downloads#bluefin-lts",
-    supportedArches: ["amd", "intel", "arm"],
+    supportedArches: ["amd", "intel"],
   },
   {
     id: "ublue-bluefin-dx-lts",
@@ -99,7 +99,7 @@ const PRODUCT_SPECS = [
     allowTestingStreams: true,
     keepEvenIfStale: true,
     isoSectionLink: "/downloads#bluefin-lts",
-    supportedArches: ["amd", "intel", "arm"],
+    supportedArches: ["amd", "intel"],
   },
   {
     id: "ublue-bluefin-gdx",
@@ -115,7 +115,7 @@ const PRODUCT_SPECS = [
     keepEvenIfStale: true,
     allowTestingStreams: true,
     isoSectionLink: "/downloads#bluefin-gdx",
-    supportedArches: ["nvidia", "arm"],
+    supportedArches: ["nvidia"],
   },
   {
     id: "projectbluefin-dakota",

--- a/static/data/images.json
+++ b/static/data/images.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-03T23:24:17.918Z",
+  "generatedAt": "2026-05-04T00:01:41.394Z",
   "cacheHours": 168,
   "refreshHours": 336,
   "staleDays": 30,
@@ -16,8 +16,7 @@
       "isoSectionLink": "/downloads#bluefin",
       "supportedArches": [
         "amd",
-        "intel",
-        "arm"
+        "intel"
       ],
       "streams": [
         {
@@ -130,8 +129,7 @@
       "isoSectionLink": "/downloads#bluefin",
       "supportedArches": [
         "amd",
-        "intel",
-        "arm"
+        "intel"
       ],
       "streams": [
         {
@@ -229,8 +227,7 @@
       "isoSectionLink": "/downloads#bluefin-lts",
       "supportedArches": [
         "amd",
-        "intel",
-        "arm"
+        "intel"
       ],
       "streams": [
         {
@@ -354,8 +351,7 @@
       "packagePageUrl": "https://github.com/orgs/ublue-os/packages/container/package/bluefin-gdx",
       "isoSectionLink": "/downloads#bluefin-gdx",
       "supportedArches": [
-        "nvidia",
-        "arm"
+        "nvidia"
       ],
       "streams": [
         {
@@ -433,8 +429,7 @@
       "isoSectionLink": "/downloads#bluefin-lts",
       "supportedArches": [
         "amd",
-        "intel",
-        "arm"
+        "intel"
       ],
       "streams": [
         {


### PR DESCRIPTION
Bluefin does not publish ARM (aarch64) releases. Remove arm from supportedArches for all Bluefin product specs and regenerate images.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * ARM architecture support has been removed from Bluefin stable, LTS, DX, and DX-LTS variants. Only AMD and Intel architectures are now supported for these products.
  * Bluefin GDX now supports NVIDIA architecture only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->