### PR TITLE
fix: install oras in pages.yml so Dakotaraptor driver versions populate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -84,6 +84,9 @@ jobs:
           restore-keys: |
             github-data-sbom-
 
+      - name: Install oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
       - name: Fetch SBOM on cache miss
         if: steps.sbom-cache.outputs.cache-matched-key == ''
         env:


### PR DESCRIPTION
## Problem

Dakotaraptor section on the driver versions page is empty.

## Root Cause

`pages.yml` does not install `oras`. Without it, `fetch-github-sbom.js` cannot read the image creation date annotation on `ghcr.io/projectbluefin/dakota:latest`, so it falls back to cache key `latest-unknown`. `buildStreamFromSbom()` then filters it out because the date parse returns NaN.

## Fix

Add `oras-project/setup-oras` step before the SBOM fetch step, matching the identical step already present in `update-sbom-cache.yml` (same SHA pin).

```yaml
- name: Install oras
  uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to install `oras` tool during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->