### PR TITLE
fix(cards): wire dakota SBOM enrichment and invalidate card cache on SBOM change

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -121,7 +121,7 @@ jobs:
           path: |
             static/img/cards
             static/data/card-hashes.json
-          key: card-images-${{ hashFiles('scripts/generate-card-images.mjs', 'scripts/lib/card-template.mjs') }}
+          key: card-images-${{ hashFiles('scripts/generate-card-images.mjs', 'scripts/lib/card-template.mjs', 'static/data/sbom-attestations-frontend.json') }}
           restore-keys: |
             card-images-
 

--- a/scripts/generate-card-images.mjs
+++ b/scripts/generate-card-images.mjs
@@ -194,10 +194,19 @@ function sbomKeyForRelease(tag, stream) {
 
 function enrichFromSbom(release, stream) {
   if (!SBOM_CACHE) return release;
-  const key = sbomKeyForRelease(release.tag, stream);
-  if (!key) return release;
 
-  const packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
+  let packages;
+  if (stream === "dakota") {
+    // Dakota tag ("dakota-alpha") has no date — look up the latest entry in
+    // the dakota-latest SBOM stream directly instead of using a dated key.
+    const dakotaReleases = SBOM_CACHE?.streams?.["dakota-latest"]?.releases ?? {};
+    const latestKey = Object.keys(dakotaReleases).sort().reverse()[0];
+    packages = latestKey ? dakotaReleases[latestKey]?.packageVersions : undefined;
+  } else {
+    const key = sbomKeyForRelease(release.tag, stream);
+    if (!key) return release;
+    packages = SBOM_CACHE?.streams?.[key.streamId]?.releases?.[key.cacheKey]?.packageVersions;
+  }
   if (!packages) return release;
 
   // SBOM-primary: SBOM version wins for tracked packages; prevVersion preserved from
@@ -322,11 +331,12 @@ async function main() {
 
   const stableRelease = stableRaw ? enrichFromSbom(stableRaw, "stable") : null;
   const ltsRelease    = ltsRaw    ? enrichFromSbom(ltsRaw,    "lts")    : null;
+  const dakotaRelease = enrichFromSbom(DAKOTA_RELEASE, "dakota");
 
   const cards = [
-    { release: stableRelease, stream: "stable", slug: "bluefin" },
-    { release: ltsRelease,    stream: "lts",    slug: "bluefin-lts" },
-    { release: DAKOTA_RELEASE, stream: "dakota", slug: "dakota" },
+    { release: stableRelease,  stream: "stable", slug: "bluefin" },
+    { release: ltsRelease,     stream: "lts",    slug: "bluefin-lts" },
+    { release: dakotaRelease,  stream: "dakota", slug: "dakota" },
   ];
 
   const outDir = join(ROOT, "static/img/cards");


### PR DESCRIPTION
## Problem

`/img/cards/dakota-light.png` and `dakota-dark.png` were showing stale package versions (Kernel 6.18.7, Mesa 25.3.5, Podman 5.8.0) despite the SBOM having current data (6.19.11, 26.0.5, 5.8.2).

## Root causes (3)

**1. `enrichFromSbom()` was never called for dakota**
Stable and LTS releases are enriched via `enrichFromSbom()` before being passed to `computeCardHash()`. Dakota used the raw `DAKOTA_RELEASE` constant directly — no enrichment, always stale.

**2. `enrichFromSbom()` couldn't look up dakota even if called**
`sbomKeyForRelease()` extracts a date from the release tag (e.g. `stable-20260501`), but `DAKOTA_RELEASE.tag = "dakota-alpha"` has no date → returns `null` → no SBOM lookup. Added a dakota-specific path that fetches the latest entry from the `dakota-latest` SBOM stream directly.

**3. GHA card cache key didn't include SBOM data**
`hashFiles('scripts/generate-card-images.mjs', 'scripts/lib/card-template.mjs')` — only script changes invalidated the cache. SBOM updates (new package versions) were invisible to the cache key, so old cards were served indefinitely. Added `static/data/sbom-attestations-frontend.json` to the hash.

## Verification

Ran `npm run generate-card-images` locally after fix:
- `dakota-light.png` / `dakota-dark.png` regenerated with current SBOM data
- Kernel **6.19.11** (was 6.18.7), Mesa **26.0.5** (was 25.3.5), Podman **5.8.2** (was 5.8.0), systemd **260.1** (was 259.2)
- Stable and LTS cards: cache hit (unchanged — correct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM-backed package versioning handling for accurate version information.

* **Chores**
  * Enhanced cache invalidation for generated card images to ensure fresh content when dependencies change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->