### PR TITLE
feat(changelogs,images): wire Dakota into changelogs stream and fix i…

### DIFF
--- a/scripts/fetch-github-images.js
+++ b/scripts/fetch-github-images.js
@@ -127,6 +127,10 @@ const PRODUCT_SPECS = [
     streamOrder: ["latest"],
     versionSource: null,
     sbomStreamId: "dakota-latest",
+    // Nvidia driver lives only in the -nvidia variant image, which has its own
+    // SBOM stream. Source nvidia version from there rather than the release feed
+    // (Dakota has no GitHub releases feed).
+    nvidiaStreamId: "dakota-nvidia-latest",
     keyRepo: "projectbluefin/dakota",
     nvidiaPackage: "dakota-nvidia",
     allowTestingStreams: false,
@@ -447,6 +451,14 @@ async function buildStreamVersionInfo(
     versions.flatpak = spec.versionOverrides.flatpak ?? versions.flatpak;
     versions.mesa = spec.versionOverrides.mesa ?? versions.mesa;
     versions.podman = spec.versionOverrides.podman ?? versions.podman;
+  }
+
+  // For products with a dedicated nvidia SBOM stream (e.g. dakota-nvidia-latest),
+  // source the nvidia driver version from SBOM when the release feed returns null.
+  // Dakota has no GitHub releases feed, so parseFeedVersion always returns null.
+  if (versions.nvidia === null && spec.nvidiaStreamId) {
+    const nvidiaVersions = lookupSbomVersions(sbomCache, spec.nvidiaStreamId);
+    versions.nvidia = nvidiaVersions?.nvidia || null;
   }
 
   return versions;

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -246,6 +246,35 @@ function enrichLtsDxGdxFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
 }
 
 /**
+ * Overlay Nvidia version onto Dakota events from the dakota-nvidia-latest SBOM
+ * stream. The nvidia RPM lives in the -nvidia variant image, not the base
+ * dakota image, so a separate lookup is needed.
+ */
+function enrichDakotaNvidiaFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
+  return events.map((event) => {
+    const dateMatch = event.release.tag.match(/(\d{8})/);
+    if (!dateMatch) return event;
+    const cacheKey = `latest-${dateMatch[1]}`;
+    // Prefer the typed nvidia field that extractBstPackageVersions populates;
+    // fall back to allPackages for forward-compat with any future SBOM format changes.
+    const nvidiaRelease =
+      getSbomCache()?.streams?.["dakota-nvidia-latest"]?.releases?.[cacheKey];
+    const nvidiaVersion =
+      nvidiaRelease?.packageVersions?.nvidia ??
+      nvidiaRelease?.packageVersions?.allPackages?.["NVIDIA-Linux-x86"] ??
+      nvidiaRelease?.packageVersions?.allPackages?.["nvidia-driver"];
+    if (!nvidiaVersion) return event;
+    return {
+      ...event,
+      release: {
+        ...event.release,
+        gdxPackages: [{ name: "Nvidia", version: nvidiaVersion, prevVersion: null }],
+      },
+    };
+  });
+}
+
+/**
  * Override the "HWE Kernel" carry-forward value in LTS events with the
  * authoritative version from the bluefin-lts-hwe SBOM stream.
  *
@@ -308,6 +337,28 @@ function getLtsOsEvents(): OsReleaseEvent[] {
   return _ltsOsEvents;
 }
 
+let _dakotaOsEvents: OsReleaseEvent[] | null = null;
+function getDakotaOsEvents(): OsReleaseEvent[] {
+  if (!_dakotaOsEvents) {
+    // Rewrite "latest-YYYYMMDD" → "dakota-YYYYMMDD" for display in the card tag chip.
+    // enrichDakotaNvidiaFromSbom still works because it matches /(\d{8})/ from the tag.
+    const base = sbomStreamToEvents(
+      getSbomCache(),
+      "dakota-latest",
+      "dakota",
+      "https://github.com/projectbluefin/dakota",
+    ).map((event) => ({
+      ...event,
+      release: {
+        ...event.release,
+        tag: event.release.tag.replace(/^latest-/, "dakota-"),
+      },
+    }));
+    _dakotaOsEvents = enrichDakotaNvidiaFromSbom(base);
+  }
+  return _dakotaOsEvents;
+}
+
 // Rolling 12-month window for the stream — pinned cards (PINNED_OS_EVENTS) are unaffected.
 let _allOsStreamEvents: OsReleaseEvent[] | null = null;
 function getAllOsStreamEvents(): OsReleaseEvent[] {
@@ -317,6 +368,7 @@ function getAllOsStreamEvents(): OsReleaseEvent[] {
       ...getBluefinOsEvents(),
       ...getStableDailyOsEvents(),
       ...getLtsOsEvents(),
+      ...getDakotaOsEvents(),
     ]
       .filter((e) => e.dateMs > cutoff)
       .sort((a, b) => b.dateMs - a.dateMs);
@@ -371,7 +423,12 @@ function computePinnedOsEvents(): OsReleaseEvent[] {
       bluefin.find((e) => e.stream === "stable") ?? bluefin[0];
     // Pinned LTS card: latest from LTS feed
     const pinnedLts: OsReleaseEvent | undefined = lts.length > 0 ? lts[0] : undefined;
-    _pinnedOsEvents = [pinnedStable, pinnedLts, DAKOTA_PLACEHOLDER_EVENT]
+    // Prefer the most recent SBOM-sourced Dakota event for the pinned card so
+    // package versions stay current. Falls back to the hardcoded placeholder
+    // when SBOM data isn't available (local dev with empty seed file).
+    const dakota = getDakotaOsEvents();
+    const pinnedDakota: OsReleaseEvent = dakota.length > 0 ? dakota[0] : DAKOTA_PLACEHOLDER_EVENT;
+    _pinnedOsEvents = [pinnedStable, pinnedLts, pinnedDakota]
       .filter((e): e is OsReleaseEvent => e !== undefined);
   }
   return _pinnedOsEvents;

--- a/src/types/sbom.ts
+++ b/src/types/sbom.ts
@@ -61,6 +61,12 @@ export interface PackageVersions {
   /** e.g. "1.17.3-1.fc43" from the `flatpak` RPM */
   flatpak: string | null;
   /**
+   * e.g. "595.71.05" from the `NVIDIA-Linux-x86` BST element (dakota-nvidia
+   * SBOM stream only). Null for all non-nvidia images and all Fedora-based
+   * streams (where nvidia is sourced from the release feed instead).
+   */
+  nvidia?: string | null;
+  /**
    * Flat name→version map of every RPM artifact in the image.
    * Used by fetch-firehose.js to compute per-release package diffs.
    * Absent (undefined) from cache entries written before this field was added.


### PR DESCRIPTION
…mages card SBOM

Changelogs page (/changelogs)
- Adds getDakotaOsEvents() via sbomStreamToEvents() on the dakota-latest SBOM stream. Each nightly SBOM run accumulates a new latest-YYYYMMDD entry; these now appear as dated release cards in the Updates Stream alongside stable and LTS entries.
- enrichDakotaNvidiaFromSbom() overlays the Nvidia driver version from the dakota-nvidia-latest SBOM stream into each event's gdxPackages, following the same pattern used for LTS GDX enrichment.
- Tags are rewritten from latest-YYYYMMDD to dakota-YYYYMMDD for display.
- The pinned Current Versions card uses live SBOM data instead of the static hardcoded placeholder, falling back to placeholder for local dev.

Images catalog (/images)
- Dakota Nvidia version was always null: parseFeedVersion reads GitHub release HTML, but Dakota has no GitHub releases.
- extractBstPackageVersions already populated nvidia via BST_PACKAGE_MAP (NVIDIA-Linux-x86 -> field: nvidia) in the dakota-nvidia-latest stream, but buildStreamVersionInfo never queried that stream.
- Adds nvidiaStreamId: 'dakota-nvidia-latest' to the Dakota product spec. buildStreamVersionInfo now overlays nvidia from that SBOM stream when parseFeedVersion returns null, completing the SBOM-only version policy for all Dakota packages.

Types
- Adds nvidia?: string | null to PackageVersions in src/types/sbom.ts to match what extractBstPackageVersions already produces at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced NVIDIA driver version information accuracy by implementing intelligent data source fallbacks. The system now retrieves version details from dedicated streams when standard feeds are unavailable, ensuring more reliable and current system version displays throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/812)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->