### PR TITLE
fix(changelogs): remove OS release cards from Updates Stream; fix Dak…

### DIFF
--- a/src/components/FirehoseFeed.module.css
+++ b/src/components/FirehoseFeed.module.css
@@ -326,16 +326,6 @@
   border-radius: 8px;
 }
 
-.osHiddenNotice {
-  padding: 0.6rem 1rem;
-  margin-bottom: 1rem;
-  background: var(--ifm-color-warning-contrast-background, #fff3cd);
-  border-left: 3px solid var(--ifm-color-warning, #e0a800);
-  border-radius: 4px;
-  font-size: 0.875rem;
-  color: var(--ifm-color-warning-dark, #856404);
-}
-
 .clearFiltersBtn {
   margin-top: 0.75rem;
   padding: 0.4rem 1rem;

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from "react";
 import Heading from "@theme/Heading";
 import firehoseData from "@site/static/data/firehose-apps.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
-import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent, ParsedMajorPackage, OsStream, OsFeedItem } from "../types/os-feed";
+import type { OsReleaseEvent, AppTimelineEvent, ParsedMajorPackage, OsStream, OsFeedItem } from "../types/os-feed";
 import type { SbomAttestationsData, PackageVersions } from "../types/sbom";
 import { parseOsRelease } from "../utils/parseOsRelease";
 import {
@@ -268,7 +268,18 @@ function enrichDakotaNvidiaFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] 
       ...event,
       release: {
         ...event.release,
-        gdxPackages: [{ name: "Nvidia", version: nvidiaVersion, prevVersion: null }],
+        // Nvidia is a regular package chip on Dakota (no GDX variant).
+        // Merge into majorPackages: remove any stale Nvidia entry, then append.
+        majorPackages: [
+          ...event.release.majorPackages.filter(
+            (p) => p.name.toLowerCase() !== "nvidia",
+          ),
+          { name: "Nvidia", version: nvidiaVersion, prevVersion: null },
+        ],
+        // Also scrub any stale Nvidia from gdxPackages — Dakota has no GDX row.
+        gdxPackages: event.release.gdxPackages.filter(
+          (p) => p.name.toLowerCase() !== "nvidia",
+        ),
       },
     };
   });
@@ -312,19 +323,6 @@ function getBluefinOsEvents(): OsReleaseEvent[] {
   return _bluefinOsEvents;
 }
 
-let _stableDailyOsEvents: OsReleaseEvent[] | null = null;
-function getStableDailyOsEvents(): OsReleaseEvent[] {
-  if (!_stableDailyOsEvents) {
-    _stableDailyOsEvents = sbomStreamToEvents(
-      getSbomCache(),
-      "bluefin-stable-daily",
-      "stable-daily",
-      "https://github.com/orgs/ublue-os/packages/container/package/bluefin",
-    );
-  }
-  return _stableDailyOsEvents;
-}
-
 let _ltsOsEvents: OsReleaseEvent[] | null = null;
 function getLtsOsEvents(): OsReleaseEvent[] {
   if (!_ltsOsEvents) {
@@ -359,23 +357,6 @@ function getDakotaOsEvents(): OsReleaseEvent[] {
   return _dakotaOsEvents;
 }
 
-// Rolling 12-month window for the stream — pinned cards (PINNED_OS_EVENTS) are unaffected.
-let _allOsStreamEvents: OsReleaseEvent[] | null = null;
-function getAllOsStreamEvents(): OsReleaseEvent[] {
-  if (!_allOsStreamEvents) {
-    const cutoff = Date.now() - ROLLING_WINDOW_MS;
-    _allOsStreamEvents = [
-      ...getBluefinOsEvents(),
-      ...getStableDailyOsEvents(),
-      ...getLtsOsEvents(),
-      ...getDakotaOsEvents(),
-    ]
-      .filter((e) => e.dateMs > cutoff)
-      .sort((a, b) => b.dateMs - a.dateMs);
-  }
-  return _allOsStreamEvents;
-}
-
 // Dakota placeholder — versions sourced from SBOM attestation on dakota-latest stream
 // and BST element pins. Update when junction refs change.
 // Last updated: freedesktop-sdk-25.08.10 + gnome-build-meta 50.1
@@ -399,11 +380,10 @@ const DAKOTA_PLACEHOLDER_EVENT: OsReleaseEvent = {
       { name: "pipewire", version: "1.6.1", prevVersion: null },
       { name: "sudo-rs", version: "0.2.13", prevVersion: null },
       { name: "uutils-coreutils", version: "0.8.0", prevVersion: null },
-    ],
-    dxPackages: [],
-    gdxPackages: [
       { name: "Nvidia", version: "595.71.05", prevVersion: null },
     ],
+    dxPackages: [],
+    gdxPackages: [],
     commits: [],
     fullDiff: [],
   },
@@ -550,13 +530,7 @@ function getFeaturedApp(uniqueApps: UniqueApp[]): FirehoseApp | null {
 
 // ── Statistics panel ──────────────────────────────────────────────────────────
 
-function Statistics({
-  uniqueApps,
-  osEventCount,
-}: {
-  uniqueApps: UniqueApp[];
-  osEventCount: number;
-}) {
+function Statistics({ uniqueApps }: { uniqueApps: UniqueApp[] }) {
   const counts = useMemo(() => {
     const byType: Record<string, number> = {};
     for (const { app } of uniqueApps) {
@@ -577,12 +551,6 @@ function Statistics({
             <dd>{count}</dd>
           </React.Fragment>
         ))}
-        {osEventCount > 0 && (
-          <>
-            <dt>OS Releases in stream</dt>
-            <dd>{osEventCount}</dd>
-          </>
-        )}
       </dl>
     </section>
   );
@@ -701,31 +669,9 @@ const FirehoseFeed: React.FC = () => {
     setFeaturedApp(getFeaturedApp(uniqueApps));
   }, [uniqueApps]);
 
-  // ── OS stream events (filtered by date, always shown) ─────────────────────
-
-  const filteredOsStreamEvents = useMemo((): OsReleaseEvent[] => {
-    // When filtering to a specific app type, OS events are hidden
-    if (filters.packageType === "flatpak" || filters.packageType === "homebrew") return [];
-    if (filters.updatedWithin === "all") return getAllOsStreamEvents();
-    const maxAge = DAYS_MS[filters.updatedWithin];
-    const now = Date.now();
-    return getAllOsStreamEvents().filter((e) => e.dateMs > 0 && now - e.dateMs <= maxAge);
-  }, [filters.packageType, filters.updatedWithin]);
-
-  // How many stream OS events are hidden by the date filter
-  const hiddenOsCount = useMemo(
-    () =>
-      filters.updatedWithin !== "all" &&
-      filters.packageType !== "flatpak" &&
-      filters.packageType !== "homebrew"
-        ? getAllOsStreamEvents().filter((e) => e.dateMs > 0).length - filteredOsStreamEvents.length
-        : 0,
-    [filteredOsStreamEvents, filters.packageType, filters.updatedWithin],
-  );
-
-  // ── Unified "Updates Stream" ───────────────────────────────────────────────
-  //
-  // OS releases and app entries (flatpak/homebrew) are always shown together.
+  // ── Updates Stream — app events only (Flatpak + Homebrew) ──────────────────
+  // OS release history was removed from this stream — the pinned "Current
+  // Versions" cards above already surface the latest stable/LTS/Dakota state.
 
   const appSection = useMemo(
     () =>
@@ -735,14 +681,8 @@ const FirehoseFeed: React.FC = () => {
     [filteredUniqueApps],
   );
 
-  const unifiedStream = useMemo((): FlatTimelineEvent[] => {
-    const items: FlatTimelineEvent[] = [...appSection, ...filteredOsStreamEvents];
-    items.sort((a, b) => b.dateMs - a.dateMs);
-    return items;
-  }, [filteredOsStreamEvents, appSection]);
-
-  const isEmpty = allEvents.length === 0 && getAllOsStreamEvents().length === 0;
-  const feedEmpty = unifiedStream.length === 0;
+  const isEmpty = allEvents.length === 0;
+  const feedEmpty = appSection.length === 0;
 
   return (
     <div className={styles.layout}>
@@ -765,25 +705,19 @@ const FirehoseFeed: React.FC = () => {
           matchCount={filteredUniqueApps.length}
         />
         {!isEmpty && (
-          <Statistics uniqueApps={uniqueApps} osEventCount={getAllOsStreamEvents().length} />
+          <Statistics uniqueApps={uniqueApps} />
         )}
       </aside>
 
       {/* ── Main feed ── */}
       <main className={styles.feedColumn}>
-        {/* Inline notice when OS events are hidden by the date filter */}
-        {hiddenOsCount > 0 && (
-          <p className={styles.osHiddenNotice}>
-            {hiddenOsCount} OS release{hiddenOsCount !== 1 ? "s" : ""} hidden by the
-            date filter.{" "}
-            <button
-              className={styles.clearFiltersBtn}
-              onClick={() => setFilters({ ...filters, updatedWithin: "all" })}
-            >
-              Show all
-            </button>
-          </p>
-        )}
+        {/* Current Versions is SBOM-driven — always render regardless of firehose state */}
+        <section className={styles.feedSection}>
+          <Heading as="h2" className={styles.feedSectionHeading}>Current Versions</Heading>
+          {PINNED_OS_EVENTS.map((event) => (
+            <OsReleaseCard key={`pinned-${event.release.tag}`} event={event} />
+          ))}
+        </section>
 
         {isEmpty ? (
           <div className={styles.emptyState}>
@@ -801,15 +735,7 @@ const FirehoseFeed: React.FC = () => {
           </div>
         ) : (
           <>
-            {/* ── Current Versions — pinned cards, always visible ── */}
-            <section className={styles.feedSection}>
-              <Heading as="h2" className={styles.feedSectionHeading}>Current Versions</Heading>
-              {PINNED_OS_EVENTS.map((event) => (
-                <OsReleaseCard key={`pinned-${event.release.tag}`} event={event} />
-              ))}
-            </section>
-
-            {/* ── Updates Stream — unified chronological feed ── */}
+            {/* ── Updates Stream — Flatpak & Homebrew app events ── */}
             {feedEmpty ? (
               <div className={styles.emptyState}>
                 <p>No items match the current filters.</p>
@@ -825,18 +751,14 @@ const FirehoseFeed: React.FC = () => {
                 <div className={styles.appSectionDivider}>
                   <Heading as="h2" className={styles.feedSectionHeading}>Updates Stream</Heading>
                   <span className={styles.appSectionHint}>
-                    OS releases, Flatpak &amp; Homebrew packages included in Bluefin
+                    Flatpak &amp; Homebrew packages included in Bluefin
                   </span>
                 </div>
-                {unifiedStream.map((event) =>
-                  event.kind === "os" ? (
-                    <OsReleaseCard key={`stream-${event.release.tag}-${event.dateMs}`} event={event} />
-                  ) : (
-                    <div key={event.app.id} className={styles.appEntry}>
-                      <FirehoseCard app={event.app} defaultCollapsed={true} />
-                    </div>
-                  ),
-                )}
+                {appSection.map((event) => (
+                  <div key={event.app.id} className={styles.appEntry}>
+                    <FirehoseCard app={event.app} defaultCollapsed={true} />
+                  </div>
+                ))}
               </section>
             )}
           </>


### PR DESCRIPTION
…ota Nvidia chip

Remove OS release cards from Updates Stream:
The pinned Current Versions section already surfaces the latest stable/LTS/Dakota state as visual cards. The OS release history cards in the Updates Stream were duplicates and are removed.

Updates Stream now shows only Flatpak and Homebrew app events. Removes filteredOsStreamEvents, hiddenOsCount, unifiedStream, getAllOsStreamEvents, getStableDailyOsEvents, and the FlatTimelineEvent import. Drops the osEventCount stat row and the osHiddenNotice CSS class.

Current Versions is now rendered unconditionally above the firehose empty state so SBOM-driven cards are always visible even when firehose data is absent.

Fix Dakota Nvidia chip placement:
Dakota has no GDX variant. Move Nvidia out of gdxPackages and into majorPackages in both enrichDakotaNvidiaFromSbom and the static DAKOTA_PLACEHOLDER_EVENT so it renders as a standard version chip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updates Stream now shows only application updates (Flatpak/Homebrew); OS release notifications and combined OS+app timeline removed
  * Sidebar statistics now reflect application-focused metrics using unique app counts
  * "Current Versions" (SBOM-derived) is rendered unconditionally in the main feed

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/813)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->