### PR TITLE
fix(changelogs): fall back to most-recent nvidia SBOM entry for Dakota

### DIFF
--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -251,14 +251,26 @@ function enrichLtsDxGdxFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
  * dakota image, so a separate lookup is needed.
  */
 function enrichDakotaNvidiaFromSbom(events: OsReleaseEvent[]): OsReleaseEvent[] {
+  // Resolve the most-recent dakota-nvidia-latest release once, used as a
+  // fallback when the exact date key is absent (the nvidia build may lag
+  // the base image build by one nightly SBOM cycle).
+  const nvidiaStream = getSbomCache()?.streams?.["dakota-nvidia-latest"];
+  const latestNvidiaRelease = (() => {
+    if (!nvidiaStream?.releases) return null;
+    const keys = Object.keys(nvidiaStream.releases).sort().reverse();
+    return keys.length > 0 ? nvidiaStream.releases[keys[0]] : null;
+  })();
+
   return events.map((event) => {
     const dateMatch = event.release.tag.match(/(\d{8})/);
     if (!dateMatch) return event;
     const cacheKey = `latest-${dateMatch[1]}`;
     // Prefer the typed nvidia field that extractBstPackageVersions populates;
     // fall back to allPackages for forward-compat with any future SBOM format changes.
+    // If the exact date key is absent (nvidia build lags base by one cycle),
+    // fall back to the most-recent available nvidia entry.
     const nvidiaRelease =
-      getSbomCache()?.streams?.["dakota-nvidia-latest"]?.releases?.[cacheKey];
+      nvidiaStream?.releases?.[cacheKey] ?? latestNvidiaRelease;
     const nvidiaVersion =
       nvidiaRelease?.packageVersions?.nvidia ??
       nvidiaRelease?.packageVersions?.allPackages?.["NVIDIA-Linux-x86"] ??


### PR DESCRIPTION
The nvidia variant SBOM (dakota-nvidia-latest) may lag the base image SBOM (dakota-latest) by one nightly cycle. When enrichDakotaNvidiaFromSbom looked up the exact date key (e.g. latest-20260509) and found no entry in dakota-nvidia-latest, nvidiaVersion resolved to null and the Nvidia chip was silently dropped.

Resolve the most-recent dakota-nvidia-latest entry once outside the map loop and use it as a fallback when the exact date key is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event processing performance by precomputing release information upfront and reducing redundant data lookups during event handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/815)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->