### PR TITLE
fix(css): restore cardPlayIcon properties — unclosed block broke build

### DIFF
--- a/src/components/MusicPlaylist.module.css
+++ b/src/components/MusicPlaylist.module.css
@@ -63,6 +63,11 @@
 }
 
 .cardPlayIcon {
+  width: 60px;
+  height: 60px;
+  color: white;
+  opacity: 0.8;
+}
 
 .playOverlay {
   position: absolute;


### PR DESCRIPTION
Restores the missing properties and closing brace on `.cardPlayIcon` in `MusicPlaylist.module.css`. The rename in #818 accidentally dropped the block body, causing a CSS parse error that broke the production build.

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced play icon styling for improved visual presentation in the music playlist interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/819)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->