### PR TITLE
fix(blog): fix alateira typo → alatiera, add discussion link #4607

### DIFF
--- a/blog/2026-05-12-bluefin-spring-2026.mdx
+++ b/blog/2026-05-12-bluefin-spring-2026.mdx
@@ -238,7 +238,7 @@ Thanks to our awesome [ISO factory](https://github.com/projectbluefin/iso) we ca
   contributors={[
     { login: "ahmedadan", roles: ["maintainer", "ublue-contributor", "brew-contributor"] },
     { login: "akeeton", roles: ["ublue-contributor"] },
-    { login: "alateira", roles: ["maintainer", "ublue-contributor", "gnome-os"] },
+    { login: "alatiera", roles: ["maintainer", "ublue-contributor", "gnome-os"] },
     { login: "AlexanderVanhee", roles: ["contributor"] },
     { login: "AlexNPavel", roles: ["ublue-contributor"] },
     { login: "anacierdem" },
@@ -370,3 +370,5 @@ Thanks to our awesome [ISO factory](https://github.com/projectbluefin/iso) we ca
     { login: "zeroby0" },
   ]}
 />
+
+### [Discussion Thread](https://github.com/ublue-os/bluefin/discussions/4607)


### PR DESCRIPTION
Two fixes for the Bluefin Spring 2026 blog post:

- **Typo fix**: `alateira` → `alatiera` (Jordan Petridis) — the misspelled handle returns 404 from GitHub, causing an "Unable to load profile" card
- **Discussion link**: adds `### [Discussion Thread](https://github.com/ublue-os/bluefin/discussions/4607)` at the bottom, matching the pattern used in past release posts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a GitHub contributor login spelling in the release notes.

* **Documentation**
  * Added a Discussion Thread section linking to the community discussion for the Bluefin Spring 2026 release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/821)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->