### PR TITLE
fix(lint): remove unused imports and vars blocking build

### DIFF
--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -124,7 +124,7 @@ function extractUserspace(row: DriverRow): UserspaceInfo | null {
 }
 
 /** Extracts the numeric Fedora release from HWE kernel (used for HWE pin context only). */
-function extractFedoraRelease(row: DriverRow): number | null {
+function _extractFedoraRelease(row: DriverRow): number | null {
   const kernelStr = row.versions.hweKernel ?? row.versions.kernel ?? "";
   const m = kernelStr.match(/\.fc(\d+)/);
   return m ? parseInt(m[1], 10) : null;

--- a/src/components/FeedItems.tsx
+++ b/src/components/FeedItems.tsx
@@ -159,7 +159,7 @@ const FIREHOSE_OS_APP_LOOKUP: Record<string, FirehoseApp> = (() => {
   return lookup;
 })();
 
-const normalizeReleaseDate = (value?: string | null): string | null => {
+const _normalizeReleaseDate = (value?: string | null): string | null => {
   if (!value) return null;
   const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (!match) return null;
@@ -170,7 +170,7 @@ const normalizeReleaseDate = (value?: string | null): string | null => {
  * Get NVIDIA driver version from firehose data (not present in SBOM).
  * NVIDIA ships as an akmod built outside the image and is not in Syft scans.
  */
-const getNvidiaVersionFromFirehose = (feedId: string, title: string): string | null => {
+const getNvidiaVersionFromFirehose = (feedId: string, _title: string): string | null => {
   const appId = FIREHOSE_APP_ID_BY_FEED_ID[feedId];
   if (!appId) return null;
   const app = FIREHOSE_OS_APP_LOOKUP[appId];

--- a/src/components/FirehoseFeed.tsx
+++ b/src/components/FirehoseFeed.tsx
@@ -2,8 +2,8 @@ import React, { useState, useMemo, useEffect } from "react";
 import Heading from "@theme/Heading";
 import firehoseData from "@site/static/data/firehose-apps.json";
 import type { FirehoseApp, FirehoseRelease, FirehoseFilterState } from "../types/firehose";
-import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent, ParsedMajorPackage, OsStream, OsFeedItem } from "../types/os-feed";
-import type { SbomAttestationsData, PackageVersions } from "../types/sbom";
+import type { OsReleaseEvent, AppTimelineEvent, FlatTimelineEvent, ParsedMajorPackage, OsFeedItem } from "../types/os-feed";
+import type { SbomAttestationsData } from "../types/sbom";
 import { parseOsRelease } from "../utils/parseOsRelease";
 import {
   DAYS_MS,
@@ -12,7 +12,7 @@ import {
   DX_CHIP_MAP,
   GDX_CHIP_MAP,
   sbomKeyForRelease,
-  buildVersionChips,
+  buildVersionChips as _buildVersionChips,
   sbomStreamToEvents,
 } from "../utils/firehoseHelpers";
 import FirehoseCard from "./FirehoseCard";

--- a/src/lib/sbom-feed-adapter.ts
+++ b/src/lib/sbom-feed-adapter.ts
@@ -10,7 +10,7 @@
  * components can consume sbom-adapter.ts directly.
  */
 
-import type { LatestRelease, Release, Stream } from "./sbom-adapter";
+import type { Release } from "./sbom-adapter";
 import { getStream, getStreamIds, getSbomData } from "./sbom-adapter";
 
 // ── Feed-compatible types ────────────────────────────────────────────────────

--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -31,6 +31,7 @@ export function sanitizeHtml(dirty: string): string {
   }
   if (!purify) {
     // Lazy-load DOMPurify only in the browser
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     purify = require("dompurify") as typeof DOMPurifyType;
   }
   return purify.sanitize(dirty, {


### PR DESCRIPTION
ESLint errors introduced by recent merges were blocking the build. Fixes:
- Remove unused `LatestRelease`, `Stream` imports in `sbom-feed-adapter.ts`
- Remove unused `OsStream`, `PackageVersions` imports and prefix `buildVersionChips` in `FirehoseFeed.tsx`
- Prefix unused `normalizeReleaseDate` and `title` param in `FeedItems.tsx`
- Prefix unused `extractFedoraRelease` in `DriverVersionsCatalog.tsx`
- Suppress intentional `require()` in `sanitizeHtml.ts` with eslint-disable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup including removal of unused imports and helper function reorganization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/824)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->