### PR TITLE
fix(series): update hummingbird slug and title, mark parts 2+3 published

### DIFF
--- a/src/config/series.ts
+++ b/src/config/series.ts
@@ -30,14 +30,14 @@ export const blogSeries: Record<string, BlogSeriesConfig> = {
         title: "Bluefin Spring 2026: Part of a Growing Ecosystem",
         slug: "bluefin-spring-2026-2",
         date: "May 12, 2026",
-        published: false,
+        published: true,
       },
       {
         part: 3,
-        title: "The Dinosaur and the [ Redacted ]",
-        slug: "the-dinosaur-and-the-redacted",
+        title: "The Dinosaur and the Hummingbird",
+        slug: "the-dinosaur-and-the-hummingbird",
         date: "May 12, 2026",
-        published: false,
+        published: true,
       },
       {
         part: 4,


### PR DESCRIPTION
Updates `src/config/series.ts` to match the renamed slug on the live hummingbird post:
- `slug`: `the-dinosaur-and-the-redacted` → `the-dinosaur-and-the-hummingbird`
- `title`: `The Dinosaur and the [ Redacted ]` → `The Dinosaur and the Hummingbird`
- `published`: `false` → `true` for parts 2 and 3 (both are live)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two blog series entries are now published and available for readers. Part 2 and Part 3, titled "The Dinosaur and the Hummingbird," from the blog series collection are now live and accessible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/830)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->