### PR TITLE
fix(blog): add discussion thread link to hummingbird post

### DIFF
--- a/blog/2026-05-15-hummingbird.mdx
+++ b/blog/2026-05-15-hummingbird.mdx
@@ -29,3 +29,5 @@ Well, I got what I wanted, a CoreOS style base image to have a true "CoreOS Desk
 I hope some of you step up and accept's Scott's challenge, we have an opportunity to do something brand new, chances like this don't come along often! A place for a cloud native in Fedora, I can't wait to see what Legends rise to the challenge.  
 
 
+
+### [Discussion Thread](https://github.com/ublue-os/bluefin/discussions/4607)


### PR DESCRIPTION
Discussion thread link was missing from the hummingbird (spring 2026 part 3) post. Adds [#4607](https://github.com/ublue-os/bluefin/discussions/4607) footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Discussion Thread link to enable readers to engage in discussions related to the blog post.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/831)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->