### PR TITLE
feat(downloads-testing): add Dakota Alpha 2 ISOs to download page

### DIFF
--- a/src/components/DownloadSectionTesting.tsx
+++ b/src/components/DownloadSectionTesting.tsx
@@ -132,6 +132,25 @@ const DownloadSectionTesting: React.FC = () => (
           checksumUrl: `${BASE}/dakota-nvidia-live-latest.iso-CHECKSUM`,
         },
       ]}
+      sections={[
+        {
+          label: "Alpha 2",
+          entries: [
+            {
+              label: "AMD / Intel",
+              isoUrl: `${BASE}/dakota-live-alpha2.iso`,
+              isoFilename: "dakota-live-alpha2.iso",
+              checksumUrl: `${BASE}/dakota-live-alpha2.iso-CHECKSUM`,
+            },
+            {
+              label: "Nvidia",
+              isoUrl: `${BASE}/dakota-nvidia-live-alpha2.iso`,
+              isoFilename: "dakota-nvidia-live-alpha2.iso",
+              checksumUrl: `${BASE}/dakota-nvidia-live-alpha2.iso-CHECKSUM`,
+            },
+          ],
+        },
+      ]}
     />
   </>
 );


### PR DESCRIPTION
Add `dakota-live-alpha2.iso` and `dakota-nvidia-live-alpha2.iso` as an "Alpha 2" labeled section under the Bluefin Dakotaraptor download card on the ISO Testing page.

## What changed

- `src/components/DownloadSectionTesting.tsx` — added a `sections` entry labeled **Alpha 2** to the Dakotaraptor `DownloadCard` with two entries:
  - AMD / Intel → `https://projectbluefin.dev/dakota-live-alpha2.iso`
  - Nvidia → `https://projectbluefin.dev/dakota-nvidia-live-alpha2.iso`
  - Both include CHECKSUM links following the existing pattern

## Preview

The Alpha 2 entries appear as a sub-section below the "latest" entries on the [ISO Testing page](https://docs.projectbluefin.io/downloads-testing), consistent with how HWE Testing and GDX sections appear under the LTS card.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alpha 2 download section for Bluefin Dakotaraptor with platform-specific options for AMD/Intel and Nvidia architectures.
  * Checksum files now available for Alpha 2 releases for integrity verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/834)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->