### PR TITLE
fix(sbom): fetch last 10 releases for Dakota history

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -338,26 +338,36 @@ const STREAM_SPECS = [
  * @param {object|null} existing  Existing SBOM cache for incremental updates
  */
 async function processLatestTagStream(spec, existing) {
-  const imageRef = `ghcr.io/${spec.org}/${spec.package}:latest`;
-  console.log(`  ${spec.id}: processing :latest tag (${imageRef})`);
-
-  const dateStr = await getImageCreatedDate(imageRef);
-  const cacheKey = dateStr ? `latest-${dateStr}` : "latest-unknown";
-  console.log(`  ${spec.id}: cache key = ${cacheKey}`);
-
-  const existingEntry = existing?.streams?.[spec.id]?.releases?.[cacheKey];
-  const hasVersions = existingEntry?.packageVersions != null;
-  const hasAllPackages =
-    existingEntry?.packageVersions?.allPackages != null &&
-    Object.keys(existingEntry.packageVersions.allPackages).length > 0;
-  const isVerified = existingEntry?.attestation?.verified === true;
-  const isCacheHit =
-    !FORCE_REFRESH && hasVersions && hasAllPackages && isVerified;
-
-  // Seed releases from existing cache so history accumulates across nightly runs.
-  // Without this, every run discards all prior entries — leaving only today's key.
+  // Seed from existing cache — accumulates history across nightly runs.
   const existingReleases = existing?.streams?.[spec.id]?.releases || {};
   const releases = { ...existingReleases };
+
+  // Build the list of image refs to process: :latest plus the 10 most recent
+  // commit-SHA tags (each is a distinct tagged build pushed to GHCR).
+  const allTags = await fetchGhcrTags(spec.org, spec.package);
+  const commitTags = allTags
+    .filter((t) => /^[0-9a-f]{40}$/.test(t))
+    .slice(-10); // last 10 = most recently pushed
+  const imageRefs = [
+    `ghcr.io/${spec.org}/${spec.package}:latest`,
+    ...commitTags.map((t) => `ghcr.io/${spec.org}/${spec.package}:${t}`),
+  ];
+
+  for (const imageRef of imageRefs) {
+    const dateStr = await getImageCreatedDate(imageRef);
+    const cacheKey = dateStr ? `latest-${dateStr}` : null;
+    if (!cacheKey) continue;
+
+    const existingEntry = releases[cacheKey];
+    const hasVersions = existingEntry?.packageVersions != null;
+    const hasAllPackages =
+      existingEntry?.packageVersions?.allPackages != null &&
+      Object.keys(existingEntry.packageVersions.allPackages).length > 0;
+    const isVerified = existingEntry?.attestation?.verified === true;
+    const isCacheHit =
+      !FORCE_REFRESH && hasVersions && hasAllPackages && isVerified;
+
+    console.log(`  ${spec.id}: ${cacheKey}${isCacheHit ? " (cache hit)" : ""}`);
 
   if (isCacheHit) {
     releases[cacheKey] = existingEntry;
@@ -405,7 +415,7 @@ async function processLatestTagStream(spec, existing) {
     }
 
     releases[cacheKey] = {
-      tag: "latest",
+      tag: imageRef,
       imageRef,
       digest: null,
       attestation,
@@ -413,6 +423,7 @@ async function processLatestTagStream(spec, existing) {
       checkedAt: new Date().toISOString(),
     };
   }
+  } // end for imageRefs
 
   return {
     id: spec.id,


### PR DESCRIPTION
## Problem

`processLatestTagStream()` only fetched the current `:latest` image, so the driver-versions page always showed a single Dakota entry.

Dakota stopped using `latest.YYYYMMDD` date tags in February 2026 and switched to 40-char commit-SHA image tags — one per build. The existing code had no way to discover these.

## Fix

`processLatestTagStream()` now:
1. Fetches all GHCR tags for the image
2. Filters to the 10 most recently pushed commit-SHA tags (40-char hex)
3. Processes `:latest` plus those 10 tags — each via `getImageCreatedDate()` → `latest-YYYYMMDD` cache key → SBOM fetch
4. Seeds from existing cache so history accumulates across nightly runs

Result: up to 10 historical Dakota releases in the driver-versions page, refreshed nightly.

## Verification

```
npm run build:ci  →  [SUCCESS] Generated static files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image reference processing and caching logic to handle multiple recent versions with date-based cache optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/838)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->