### PR TITLE
fix(sbom): restore usesLatestTag:true for Dakota specs

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -303,21 +303,20 @@ const STREAM_SPECS = [
     label: "Dakota Latest",
     org: "projectbluefin",
     package: "dakota",
-    // Date-stamped tags: latest.YYYYMMDD (normalised to latest-YYYYMMDD by normaliseLtsTag).
-    // Switched from usesLatestTag:true to streamPrefix:"latest" so all dated builds
-    // accumulate in history instead of only keeping the current :latest.
-    streamPrefix: "latest",
+    // Uses usesLatestTag:true — routes through processLatestTagStream() which
+    // fetches :latest plus the 10 most recent commit-SHA image tags for history.
     keyRepo: "projectbluefin/dakota",
     keyless: true,
+    usesLatestTag: true,
   },
   {
     id: "dakota-nvidia-latest",
     label: "Dakota Nvidia Latest",
     org: "projectbluefin",
     package: "dakota-nvidia",
-    streamPrefix: "latest",
     keyRepo: "projectbluefin/dakota",
     keyless: true,
+    usesLatestTag: true,
   },
 ];
 


### PR DESCRIPTION
PR #837 changed the Dakota specs from `usesLatestTag:true` to `streamPrefix:\"latest\"`. This caused `processStream()` to call `findRecentTagsForStream()` which returns 0 tags because Dakota stopped using `latest.YYYYMMDD` date tags in February 2026.\n\nRestores `usesLatestTag:true` so `processLatestTagStream()` is called — which (after PR #838) now fetches `:latest` plus the 10 most recent commit-SHA image tags for history.\n\nWithout this: `dakota-latest: found 0 recent tagged releases` in every SBOM cache run."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal script optimization for stream processing logic (no user-visible changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/839)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->