### PR TITLE
fix(sbom): store cacheKey as tag so nvidia overlay matches correctly

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -414,7 +414,10 @@ async function processLatestTagStream(spec, existing) {
     }
 
     releases[cacheKey] = {
-      tag: imageRef,
+      // Store cacheKey as tag (e.g. "latest-20260514") so buildNvidiaMapFromSbomStream
+      // and the nvidiaByTag lookup in buildStreamFromSbom can match by cacheKey.
+      // Storing the full imageRef causes the lookup to fail (wrong image name).
+      tag: cacheKey,
       imageRef,
       digest: null,
       attestation,


### PR DESCRIPTION
`buildStreamFromSbom` looks up nvidia versions with `nvidiaByTag?.[entry.tag || cacheKey]`.\n\nWe were storing `tag: imageRef` (e.g. `ghcr.io/projectbluefin/dakota:latest`) — a truthy value that is never a key in the nvidia map. The fallback to `cacheKey` never ran, so nvidia was always `null`.\n\nFix: store `tag: cacheKey` (e.g. `latest-20260514`). The `buildNvidiaMapFromSbomStream` stores entries keyed by cacheKey, so `nvidiaByTag['latest-20260514']` correctly returns `595.71.05`."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache lookup logic to ensure consistent tag identification across system components, improving reliability of data retrieval processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/840)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->