### PR TITLE
fix(sbom): fix tag field on cache hits and new entries

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -369,7 +369,9 @@ async function processLatestTagStream(spec, existing) {
     console.log(`  ${spec.id}: ${cacheKey}${isCacheHit ? " (cache hit)" : ""}`);
 
   if (isCacheHit) {
-    releases[cacheKey] = existingEntry;
+    // Update tag to cacheKey on every cache hit — idempotent migration from
+    // the old tag:imageRef format (which broke the nvidiaByTag lookup).
+    releases[cacheKey] = { ...existingEntry, tag: cacheKey };
   } else {
     console.log(`  ${spec.id}: verifying attestation for ${imageRef}`);
     const rawAttestation = await verifyAttestation(imageRef, spec);
@@ -414,7 +416,7 @@ async function processLatestTagStream(spec, existing) {
     }
 
     releases[cacheKey] = {
-      tag: imageRef,
+      tag: cacheKey,
       imageRef,
       digest: null,
       attestation,


### PR DESCRIPTION
Cache hits in `processLatestTagStream` were preserving the old `tag: imageRef` value. New entries were also storing `tag: imageRef`.\n\nBoth now store `tag: cacheKey` (e.g. `latest-20260514`). Cache hits apply the fix idempotently — no SBOM re-downloads needed.\n\nNext SBOM cache run migrates all existing entries and the nvidia overlay resolves correctly."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Fixed inconsistent storage of version cache identifiers** – Latest version cache entries now consistently store version tags in the same format, with proper handling for both newly created and previously cached entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/841)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->