### PR TITLE
fix(sbom): patch tag:cacheKey on cache hits

### DIFF
--- a/scripts/fetch-github-sbom.js
+++ b/scripts/fetch-github-sbom.js
@@ -369,7 +369,9 @@ async function processLatestTagStream(spec, existing) {
     console.log(`  ${spec.id}: ${cacheKey}${isCacheHit ? " (cache hit)" : ""}`);
 
   if (isCacheHit) {
-    releases[cacheKey] = existingEntry;
+    // Patch tag to cacheKey on cache hits — migrates old tag:imageRef entries
+    // so the nvidiaByTag lookup in buildStreamFromSbom works correctly.
+    releases[cacheKey] = { ...existingEntry, tag: cacheKey };
   } else {
     console.log(`  ${spec.id}: verifying attestation for ${imageRef}`);
     const rawAttestation = await verifyAttestation(imageRef, spec);


### PR DESCRIPTION
Cache hits in `processLatestTagStream` preserved entries unchanged, keeping the old `tag: imageRef` value from before PR #840. Patch `tag` to `cacheKey` on every cache hit — idempotent, no SBOM re-downloads. Fixes nvidia=null on all historical Dakota entries after the next SBOM cache run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache synchronization issue where tag values were not updated with current date information, which could cause downstream lookup failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/842)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->