### PR TITLE
docs(contributing): update Fedora version references from 43 and 42 to 44

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1043,7 +1043,7 @@ podman run --rm -it \
 
 Bluefin uses continuous delivery:
 - **Daily builds**: Automatic, no manual release
-- **Version format**: `42.20251012.1` (Fedora.YYYYMMDD.build)
+- **Version format**: `F44.20260512` (F{FedoraVersion}.{YYYYMMDD})
 - **Multiple builds per day**: Various channels updated independently
 
 ### Release Channels

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -453,7 +453,7 @@ podman build -t bluefin-test:latest .
 
 # Build with specific arguments
 podman build \
-  --build-arg FEDORA_MAJOR_VERSION=42 \
+  --build-arg FEDORA_MAJOR_VERSION=44 \
   --build-arg IMAGE_NAME=bluefin \
   -t bluefin-test:latest \
   .
@@ -465,7 +465,7 @@ podman build \
 # Test a specific build script
 podman run --rm -it \
   -v "$(pwd)/build_files:/build_files:ro" \
-  ghcr.io/ublue-os/silverblue-main:42 \
+  ghcr.io/ublue-os/silverblue-main:44 \
   bash /build_files/base/04-packages.sh
 ```
 
@@ -950,7 +950,7 @@ Discord: "Hey, package X is failing to install"
   ↓ (quick back-and-forth debugging)
   ↓ (copy findings to text editor)
   ↓
-GitHub Issue: "Package X fails on Fedora 42 due to Y dependency"
+GitHub Issue: "Package X fails on Fedora 44 due to Y dependency"
   - Symptoms
   - Root cause
   - Solution
@@ -1032,8 +1032,8 @@ bash -x build_files/base/04-packages.sh
 # Container execution (more realistic)
 podman run --rm -it \
   -v "$(pwd):/workspace:ro" \
-  -e FEDORA_MAJOR_VERSION=42 \
-  ghcr.io/ublue-os/silverblue-main:42 \
+  -e FEDORA_MAJOR_VERSION=44 \
+  ghcr.io/ublue-os/silverblue-main:44 \
   bash /workspace/build_files/base/04-packages.sh
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -153,8 +153,8 @@ We're making containers here with bash and a little bit of Python, it's not the 
 
 | Channel | Purpose | Update Frequency | Fedora Version |
 |---------|---------|------------------|----------------|
-| **latest** | Daily builds | Multiple times per day | 43 (current) |
-| **stable** | Weekly builds | Weekly | 43 |
+| **latest** | Daily builds | Multiple times per day | 44 (current) |
+| **stable** | Weekly builds | Weekly | 44 |
 
 ### Prerequisites
 
@@ -998,7 +998,7 @@ git push origin your-branch
 strategy:
   matrix:
     variant: [bluefin, bluefin-dx]
-    fedora: [42, 43]
+    fedora: [43, 44]
 ```
 
 ### Build Script Development


### PR DESCRIPTION
## docs: update Fedora version references from 43 to 44

### Summary
Updates outdated Fedora version references in the contributing documentation to reflect the current supported version.

### Changes
- Updated release channels section: Fedora 43 → 44
- Updated matrix builds example: `[42, 43]` → `[43, 44]`

### Type
- [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release channel documentation with current Fedora version information to ensure users have accurate guidance for latest and stable channels
  * Refreshed workflow configuration examples with updated version references for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/843)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->