### PR TITLE
docs(contributing): removed GTS release channel from release channels section

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1060,12 +1060,6 @@ sudo bootc switch ghcr.io/ublue-os/bluefin:stable
 sudo bootc switch ghcr.io/ublue-os/bluefin:latest
 ```
 
-**gts** (LTS):
-```bash
-# Rebase to GTS (Long Term Support)
-sudo bootc switch ghcr.io/ublue-os/bluefin:gts
-```
-
 ## Pinning Package Versions
 
 :::caution Temporary Workarounds Only


### PR DESCRIPTION
## Summary
Removes the GTS release channel, wich was rolled to bluefin:stable.

## Changes
- Removed GTS release channel from release channels section.

## Type
- [x] Documentation