### PR TITLE
blog(knuckle): wrap intent statement in tip admonition

### DIFF
--- a/blog/2026-05-28-knuckle.mdx
+++ b/blog/2026-05-28-knuckle.mdx
@@ -62,7 +62,11 @@ Flatcar is an awesome OS, here's a list. I like it because it offers different s
 - CNCF governance — vendor-neutral, community-maintained, built to outlast any single company's interest
 - Production-proven at scale: Adobe (18,000+ nodes), STACKIT (20,000+ nodes, their customers' most popular OS choice), and [many more](https://www.flatcar.org/docs/latest/community/adopters/)
 
-People sometimes ask why we don't make a Server Edition. It's because we don't care about distributions it's all Kubernetes. :) This project is intended to spread the use of Flatcar Linux and Fedora CoreOS to the home enthusiast audience. My hope is that this will live somewhere upstream and acts as the thing that brings these operating systems into enthusiast homelabs. And even if it fails at that we can prove people want it.
+People sometimes ask why we don't make a Server Edition. It's because we don't care about distributions it's all Kubernetes. :) And even if it fails at that we can prove people want it.
+
+:::tip[Intent]
+This project is intended to spread the use of Flatcar Linux and Fedora CoreOS to the home enthusiast audience. My hope is that this will live somewhere upstream and acts as the thing that brings these operating systems into enthusiast homelabs.
+:::
 
 Knuckle is feature complete, we won't be adding whizbang features, it's vanilla only and will only ever support vanilla. However ...
 


### PR DESCRIPTION
Moves the project intent sentence into a green :::tip[Intent] admonition box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted blog post content with improved visual presentation using callout styling to highlight project intent messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->