### PR TITLE
ci: disable E2E tests until build time is stable

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,12 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -143,7 +143,7 @@ jobs:
         run: npm run build:ci
 
       - name: Run E2E tests
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: false
         run: npx playwright install --with-deps chromium && npx playwright test
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:3000


### PR DESCRIPTION
Turns off E2E tests without deleting anything. Re-enable by restoring the push/pull_request triggers in e2e-tests.yml and the if condition in pages.yml.