### PR TITLE
fix(ci): run Playwright E2E tests on push to main and PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,9 @@
 name: E2E Tests
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The Playwright E2E tests in `.github/workflows/e2e-tests.yml` were configured as `workflow_dispatch` only — meaning they never ran automatically on push or PR. This meant documentation site regressions could ship to main without being caught.

## Fix

Adds `push` (branches: [main]) and `pull_request` triggers alongside the existing `workflow_dispatch` trigger.

## Changes

- `.github/workflows/e2e-tests.yml`: add `push` and `pull_request` triggers

Closes #893