### PR TITLE
feat(hive): read snapshot.json instead of HTML-parsing

### DIFF
--- a/src/components/HiveDashboard.module.css
+++ b/src/components/HiveDashboard.module.css
@@ -622,9 +622,35 @@
   gap: 0.6rem;
 }
 
+.aboutReadingList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.aboutReadingList a {
+  font-size: 0.8rem;
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.aboutReadingList a:hover {
+  text-decoration: underline;
+}
+
+.readingListLabel {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #484f58;
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
 .roleRow {
   display: grid;
-  grid-template-columns: 1.5rem 5.5rem 1fr;
+  grid-template-columns: 5.5rem 1fr;
   gap: 0.5rem;
   align-items: center;
   font-size: 0.8rem;
@@ -1114,4 +1140,312 @@
   font-size: 0.85rem;
   font-style: italic;
   padding: 0.75rem 0;
+}
+
+
+/* ── New dense panels ─────────────────────────────────────────────────────── */
+.feedList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 300px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+.feedItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(139, 148, 158, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  text-decoration: none;
+  color: inherit;
+}
+.feedItem:hover {
+  border-color: rgba(88, 166, 255, 0.38);
+  background: rgba(88, 166, 255, 0.05);
+}
+.feedRepo {
+  flex: 0 0 auto;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(88, 166, 255, 0.35);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.feedTitle {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.feedMeta {
+  flex: 0 0 auto;
+  color: #8b949e;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.contributorGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+.contributorCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  width: 68px;
+  text-decoration: none;
+  color: inherit;
+}
+.contributorAvatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid rgba(88, 166, 255, 0.22);
+}
+.contributorName {
+  font-size: 0.72rem;
+  color: #c9d1d9;
+  text-align: center;
+  word-break: break-word;
+}
+.botCountChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.9rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(210, 153, 34, 0.12);
+  color: #d29922;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.velocityRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 0.8rem;
+}
+.velocityNum {
+  font-size: clamp(2rem, 4vw, 2.7rem);
+  line-height: 1;
+  font-weight: 800;
+  color: #f0f6fc;
+}
+.miniLabel {
+  margin-top: 0.35rem;
+  color: #8b949e;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.velocityDelta {
+  margin-top: 0.85rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.velocityDeltaUp { color: #f85149; }
+.velocityDeltaDown { color: #3fb950; }
+.velocityDeltaFlat { color: #8b949e; }
+.p0Alert {
+  margin-top: 0.75rem;
+  color: #f85149;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+.govMode {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120px;
+  margin: 0.55rem 0 0.9rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+.govModeSurge { color: #f85149; background: rgba(248, 81, 73, 0.12); }
+.govModeBusy { color: #d29922; background: rgba(210, 153, 34, 0.12); }
+.govModeQuiet { color: #58a6ff; background: rgba(88, 166, 255, 0.12); }
+.govModeIdle { color: #8b949e; background: rgba(139, 148, 158, 0.12); }
+.govThreshBar {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  border-radius: 999px;
+  margin-top: 0.9rem;
+  border: 1px solid rgba(139, 148, 158, 0.2);
+}
+.govThreshZoneQuiet,
+.govThreshZoneBusy,
+.govThreshZoneSurge {
+  padding: 0.4rem 0;
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.govThreshZoneQuiet { background: rgba(88, 166, 255, 0.14); color: #58a6ff; }
+.govThreshZoneBusy { background: rgba(210, 153, 34, 0.14); color: #d29922; }
+.govThreshZoneSurge { background: rgba(248, 81, 73, 0.14); color: #f85149; }
+.govThreshMarker {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: #f0f6fc;
+  box-shadow: 0 0 0 1px rgba(13, 17, 23, 0.6);
+}
+.govThreshLegend {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.45rem;
+  color: #8b949e;
+  font-size: 0.72rem;
+}
+.beadsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.75rem 0 1rem;
+  color: #c9d1d9;
+  font-weight: 700;
+}
+.cadenceTable {
+  display: grid;
+  gap: 0.45rem;
+}
+.cadenceHeader {
+  color: #8b949e;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+}
+.cadenceRow {
+  display: grid;
+  grid-template-columns: minmax(110px, 1.4fr) repeat(4, minmax(80px, 1fr));
+  gap: 0.45rem;
+}
+.cadenceCell {
+  padding: 0.45rem 0.55rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+  font-size: 0.78rem;
+}
+.cadenceCellActive {
+  border-color: rgba(88, 166, 255, 0.45);
+  background: rgba(88, 166, 255, 0.12);
+  color: #f0f6fc;
+  font-weight: 700;
+}
+.agentOfDayCard {
+  border-color: #d29922;
+  background: rgba(210, 153, 34, 0.1);
+}
+.agentOfDayHero {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.agentHeroEmoji {
+  font-size: 2.8rem;
+  line-height: 1;
+}
+.agentOfDayLabel {
+  color: #d29922;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.agentHeroName {
+  margin-top: 0.2rem;
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: #f0f6fc;
+}
+.agentHeroMeta {
+  margin-top: 0.2rem;
+  color: #c9d1d9;
+  font-size: 0.84rem;
+}
+.agentOfDaySummary {
+  margin-top: 0.95rem;
+  display: grid;
+  gap: 0.45rem;
+  color: #f0f6fc;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+.formationLogList {
+  display: grid;
+  gap: 0.55rem;
+}
+.formationLogEntry {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+  font-size: 0.84rem;
+}
+.formationLogStamp {
+  color: #8b949e;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.healthList {
+  display: grid;
+  gap: 0.55rem;
+}
+.healthItem {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+}
+.healthDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.healthDotPass { background: #3fb950; box-shadow: 0 0 10px rgba(63, 185, 80, 0.45); }
+.healthDotFail { background: #f85149; box-shadow: 0 0 10px rgba(248, 81, 73, 0.45); }
+.healthDotWarn { background: #d29922; box-shadow: 0 0 10px rgba(210, 153, 34, 0.45); }
+
+@media (max-width: 900px) {
+  .feedItem,
+  .healthItem {
+    grid-template-columns: 1fr;
+  }
+  .feedItem {
+    flex-wrap: wrap;
+  }
+  .cadenceRow {
+    grid-template-columns: minmax(90px, 1.2fr) repeat(4, minmax(64px, 1fr));
+  }
+  .formationLogEntry {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/components/HiveDashboard.tsx
+++ b/src/components/HiveDashboard.tsx
@@ -88,7 +88,7 @@ interface OrgStats {
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const SNAPSHOT_URL =
-  "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html";
+  "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/snapshot.json";
 const GH_API = "https://api.github.com";
 const DAKOTA = "projectbluefin/dakota";
 const BUILD_WORKFLOW = "246164114";
@@ -105,70 +105,40 @@ const ACMM_LEVELS: Record<number, { label: string; desc: string; color: string }
   5: { label: "Self-Directing",      desc: "Agents define their own goals",           color: "#bc8cff" },
 };
 
-function parseSnapshotHtml(html: string): {
+function parseSnapshotJson(data: Record<string, unknown>): {
   snapshot: HiveSnapshot | null;
   config: HiveConfig | null;
 } {
   try {
-    const cfgMatch = html.match(/_cfg\s*=\s*(\{[^;]+\})/);
-    const config = cfgMatch
-      ? (JSON.parse(cfgMatch[1]) as HiveConfig)
-      : null;
-
-    // Extract agents array (same pattern as hive-status-sync workflow)
-    const agentsMatch = html.match(/"agents":\s*(\[.*?\])\s*,\s*"(?:governor|repos|token|hiveId)"/);
-    const agents: HiveAgent[] = agentsMatch ? (JSON.parse(agentsMatch[1]) as HiveAgent[]) : [];
-
-    // Extract timestamp + hiveId from render() opening
-    const tsMatch = html.match(/render\(\{"timestamp":"([^"]+)","hiveId":"([^"]+)"/);
-
-    // Extract ACMM level
-    const acmmMatch = html.match(/"acmmLevel":(\d+)/);
-    const acmmLevel = acmmMatch ? parseInt(acmmMatch[1]) : undefined;
-
-    // Extract advisory mode (SURGE / NORMAL etc)
-    const modeMatch = html.match(/"acmmLevel":\d+[^}]*"mode":"([^"]+)"/);
-    const acmmMode = modeMatch ? modeMatch[1] : undefined;
-
-    // Extract PR merge time stats
-    const medianMatch = html.match(/"median_minutes":(\d+)/);
-    const p90Match    = html.match(/"p90_minutes":(\d+)/);
-    const medianMergeMins = medianMatch ? parseInt(medianMatch[1]) : undefined;
-    const p90MergeMins    = p90Match    ? parseInt(p90Match[1])    : undefined;
-
-    // Count advisory items
-    const advisoryCount = (html.match(/"type":"[^"]+","severity":/g) ?? []).length;
-
-    // Extract advisory items from digest
-    const advisoryItems: AdvisoryItem[] = [];
-    const adItemRe = /"agent":"([^"]+)","timestamp":"([^"]+)","type":"([^"]+)","severity":"([^"]+)","title":"([^"]+)"/g;
-    let adM: RegExpExecArray | null;
-    while ((adM = adItemRe.exec(html)) !== null) {
-      advisoryItems.push({
-        agent:     adM[1],
-        timestamp: adM[2],
-        type:      adM[3],
-        severity:  adM[4] as AdvisoryItem["severity"],
-        title:     adM[5],
-      });
-    }
-
-    // Advisory issue number
-    const advisoryIssueM = html.match(/HIVE_ADVISORY_ISSUE='(\d+)'/);
-    const advisoryIssue = advisoryIssueM ? parseInt(advisoryIssueM[1]) : undefined;
+    const agents = (data.agents as HiveAgent[]) ?? [];
+    const governor = (data.governor as { mode?: string; issues?: number; prs?: number }) ?? {};
+    const agentMetrics = data.agentMetrics as { outreach?: { acmm?: number } } | undefined;
+    const issueToMerge = data.issueToMerge as { avg_minutes?: number; median_minutes?: number; p90_minutes?: number } | undefined;
+    const advisoryItems = (data.advisoryItems as AdvisoryItem[]) ?? [];
 
     const snapshot: HiveSnapshot = {
-      timestamp: tsMatch?.[1] ?? new Date().toISOString(),
-      hiveId:    tsMatch?.[2] ?? "",
+      timestamp:       (data.timestamp as string) ?? new Date().toISOString(),
+      hiveId:          (data.hiveId as string) ?? "",
       agents,
-      acmmLevel,
-      acmmMode,
-      medianMergeMins,
-      p90MergeMins,
-      advisoryCount: advisoryItems.length || advisoryCount,
+      acmmLevel:       agentMetrics?.outreach?.acmm ?? undefined,
+      acmmMode:        governor.mode,
+      medianMergeMins: issueToMerge?.median_minutes ?? issueToMerge?.avg_minutes,
+      p90MergeMins:    issueToMerge?.p90_minutes,
+      advisoryCount:   advisoryItems.length,
       advisoryItems,
-      advisoryIssue,
+      advisoryIssue:   (data.advisoryIssue as number) ?? undefined,
     };
+
+    // Derive config from repos array in the status JSON
+    const rawRepos = (data.repos as Array<{ full?: string; name?: string }>) ?? [];
+    const config: HiveConfig | null = rawRepos.length > 0 ? {
+      org:            (data.hiveId as string ?? "").replace(/^hive-[^-]+-/, "") || "projectbluefin",
+      primaryRepo:    rawRepos[0]?.full ?? "",
+      repos:          rawRepos.map((r) => r.full ?? r.name ?? "").filter(Boolean),
+      ai_author:      "",
+      eval_interval_s: 300,
+    } : null;
+
     return { snapshot, config };
   } catch {
     return { snapshot: null, config: null };
@@ -737,8 +707,8 @@ export default function HiveDashboard(): React.JSX.Element {
 
       // ── Snapshot (agents + config)
       if (snapRes.status === "fulfilled" && snapRes.value.ok) {
-        const html = await snapRes.value.text();
-        const { snapshot: snap, config: cfg } = parseSnapshotHtml(html);
+        const data = await snapRes.value.json() as Record<string, unknown>;
+        const { snapshot: snap, config: cfg } = parseSnapshotJson(data);
         if (snap) setSnapshot(snap);
         if (cfg) setConfig(cfg);
       }

--- a/src/components/HiveDashboard.tsx
+++ b/src/components/HiveDashboard.tsx
@@ -37,6 +37,10 @@ interface HiveSnapshot {
   timestamp: string;
   hiveId: string;
   agents: HiveAgent[];
+  governor?: HiveGovernor;
+  beads?: HiveBeads;
+  cadenceMatrix?: HiveCadenceRow[];
+  health?: Record<string, unknown>;
   acmmLevel?: number;
   acmmMode?: string;
   medianMergeMins?: number;
@@ -75,6 +79,76 @@ interface QueueStats {
   p0: number;
 }
 
+interface HiveGovernorThresholds {
+  quiet?: number;
+  busy?: number;
+  surge?: number;
+}
+
+interface HiveGovernor {
+  mode?: string;
+  active?: boolean;
+  issues?: number;
+  prs?: number;
+  nextKick?: string;
+  thresholds?: HiveGovernorThresholds;
+}
+
+interface HiveBeads {
+  workers: number;
+  supervisor: number;
+}
+
+interface HiveCadenceRow {
+  agent: string;
+  surge: string;
+  busy: string;
+  quiet: string;
+  idle: string;
+}
+
+interface HiveHealthEntry {
+  status?: string;
+  passed?: boolean;
+  lastRun?: string;
+  name?: string;
+}
+
+interface MergedPR {
+  number: number;
+  title: string;
+  repo: string;
+  author: string;
+  isBot: boolean;
+  updatedAt: string;
+  url: string;
+}
+
+interface Velocity {
+  opened: number;
+  closed: number;
+}
+
+interface GitHubSearchResponse<T> {
+  total_count?: number;
+  items?: T[];
+}
+
+interface GitHubSearchIssueItem {
+  number: number;
+  title: string;
+  repository_url?: string;
+  pull_request?: {
+    url?: string;
+  };
+  user?: {
+    login?: string;
+    type?: string;
+  };
+  updated_at: string;
+  html_url: string;
+}
+
 interface OrgStats {
   totalRepos:       number;
   openIssues:       number;
@@ -105,13 +179,27 @@ const ACMM_LEVELS: Record<number, { label: string; desc: string; color: string }
   5: { label: "Self-Directing",      desc: "Agents define their own goals",           color: "#bc8cff" },
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function parseSnapshotJson(data: Record<string, unknown>): {
   snapshot: HiveSnapshot | null;
   config: HiveConfig | null;
 } {
   try {
     const agents = (data.agents as HiveAgent[]) ?? [];
-    const governor = (data.governor as { mode?: string; issues?: number; prs?: number }) ?? {};
+    const governor = (data.governor as HiveGovernor) ?? {};
+    const beads = isRecord(data.beads)
+      ? {
+          workers: typeof data.beads.workers === "number" ? data.beads.workers : 0,
+          supervisor: typeof data.beads.supervisor === "number" ? data.beads.supervisor : 0,
+        }
+      : undefined;
+    const cadenceMatrix = Array.isArray(data.cadenceMatrix)
+      ? (data.cadenceMatrix as HiveCadenceRow[])
+      : undefined;
+    const health = isRecord(data.health) ? data.health : undefined;
     const agentMetrics = data.agentMetrics as { outreach?: { acmm?: number } } | undefined;
     const issueToMerge = data.issueToMerge as { avg_minutes?: number; median_minutes?: number; p90_minutes?: number } | undefined;
     const advisoryItems = (data.advisoryItems as AdvisoryItem[]) ?? [];
@@ -120,6 +208,10 @@ function parseSnapshotJson(data: Record<string, unknown>): {
       timestamp:       (data.timestamp as string) ?? new Date().toISOString(),
       hiveId:          (data.hiveId as string) ?? "",
       agents,
+      governor,
+      beads,
+      cadenceMatrix,
+      health,
       acmmLevel:       agentMetrics?.outreach?.acmm ?? undefined,
       acmmMode:        governor.mode,
       medianMergeMins: issueToMerge?.median_minutes ?? issueToMerge?.avg_minutes,
@@ -161,20 +253,26 @@ function cleanSummaryLine(line: string): string {
     .trim();
 }
 
-function firstMeaningfulLines(raw: string, count = 2): string {
+function meaningfulSummaryLines(raw: string, count = 2): string[] {
   return (raw || "")
     .split("\n")
     .map(cleanSummaryLine)
     .filter(
-      (l) =>
-        l.length > 12 &&
-        !l.startsWith("/") &&
-        !l.includes("──") &&
-        !l.toUpperCase().includes("AUTHORIZED") &&
-        !l.includes("Do not investigate") &&
-        !l.includes("Do not fix"),
+      (line) =>
+        line.length > 0 &&
+        !/^[─│╔╗╚╝╠╣═┌┐└┘├┤┬┴┼]+$/.test(line) &&
+        !line.startsWith("/") &&
+        !line.includes("──") &&
+        !line.toUpperCase().includes("AUTHORIZED") &&
+        !line.includes("Do not investigate") &&
+        !line.includes("Do not fix"),
     )
-    .slice(0, count)
+    .slice(0, count);
+}
+
+function firstMeaningfulLines(raw: string, count = 2): string {
+  return meaningfulSummaryLines(raw, count)
+    .filter((line) => line.length > 12)
     .join(" · ");
 }
 
@@ -267,7 +365,7 @@ function AgentCard({ agent }: { agent: HiveAgent }) {
       style={{ "--ac": agent.color } as React.CSSProperties}
     >
       <div className={styles.agentHead}>
-        <span className={styles.agentEmoji}>{agent.emoji}</span>
+        <span className={styles.agentEmoji}>{agent.name.slice(0, 1).toUpperCase()}</span>
         <div className={styles.agentMeta}>
           <span className={styles.agentName}>{agent.displayName}</span>
           <span className={`${styles.agentPill} ${statusCls}`}>
@@ -386,7 +484,7 @@ function QueueBar({ ready, claimed, p0 }: QueueStats) {
         </span>
         <span className={styles.queueLegendReady}>■ {ready} ready</span>
         {p0 > 0 && (
-          <span className={styles.queueLegendP0}>🔥 {p0} P0</span>
+          <span className={styles.queueLegendP0}>P0: {p0}</span>
         )}
       </div>
     </div>
@@ -429,7 +527,7 @@ function PrQueueChart({ data }: { data: RepoPRs[] }) {
               <span className={styles.prCount}>
                 {d.total}
                 {d.agentPRs > 0 && (
-                  <span className={styles.prAgentCount}> 🤖{d.agentPRs}</span>
+                  <span className={styles.prAgentCount}> (agent: {d.agentPRs})</span>
                 )}
               </span>
             </div>
@@ -453,18 +551,19 @@ const SEV_COLOR: Record<string, string> = {
 };
 
 const TYPE_ICON: Record<string, string> = {
-  "ci-failure":   "🔴",
-  "finding":      "🔍",
-  "bug":          "🐛",
-  "feature":      "✨",
-  "coverage-gap": "🧪",
-  "security":     "🛡️",
-  "refactor":     "♻️",
+  "ci-failure":   "CI",
+  "finding":      ">>",
+  "bug":          "!",
+  "feature":      "+",
+  "coverage-gap": "cov",
+  "security":     "sec",
+  "refactor":     "ref",
 };
 
-function relTime(ts: string): string {
+function relTime(ts?: string): string {
+  if (!ts) return "—";
   try {
-    const diff = Date.now() - new Date(ts).getTime();
+    const diff = Math.max(Date.now() - new Date(ts).getTime(), 0);
     const d    = Math.floor(diff / 86400000);
     const h    = Math.floor(diff / 3600000);
     const m    = Math.floor(diff / 60000);
@@ -472,8 +571,357 @@ function relTime(ts: string): string {
     if (h > 0) return `${h}h ago`;
     return `${m}m ago`;
   } catch {
-    return "";
+    return "—";
   }
+}
+
+function parseRepoName(...sources: Array<string | undefined>): string {
+  const source = sources.find(Boolean) ?? "";
+  const match = source.match(/\/repos\/[^/]+\/([^/]+)(?:\/|$)/);
+  if (match?.[1]) return match[1];
+  const parts = source.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? "repo";
+}
+
+function repoAccent(repo: string): string {
+  const palette = ["#58a6ff", "#3fb950", "#d29922", "#bc8cff", "#f85149", "#f0883e"];
+  const hash = Array.from(repo).reduce((sum, ch) => sum + ch.charCodeAt(0), 0);
+  return palette[hash % palette.length] ?? "#58a6ff";
+}
+
+function pickAgentOfDay(agents: HiveAgent[]): HiveAgent | null {
+  const working = agents
+    .filter((agent) => agent.state === "running" && agent.busy === "working")
+    .sort(
+      (a, b) =>
+        (b.restarts ?? 0) - (a.restarts ?? 0) ||
+        new Date(b.lastKick ?? 0).getTime() - new Date(a.lastKick ?? 0).getTime(),
+    );
+  if (working[0]) return working[0];
+
+  return [...agents].sort(
+    (a, b) => new Date(b.lastKick ?? 0).getTime() - new Date(a.lastKick ?? 0).getTime(),
+  )[0] ?? null;
+}
+
+function governorModeClass(mode?: string): string {
+  switch ((mode ?? "idle").toLowerCase()) {
+    case "surge":
+      return styles.govModeSurge;
+    case "busy":
+      return styles.govModeBusy;
+    case "quiet":
+      return styles.govModeQuiet;
+    default:
+      return styles.govModeIdle;
+  }
+}
+
+function healthTone(entry: unknown): "pass" | "fail" | "warn" {
+  if (!isRecord(entry)) return "warn";
+  const status = typeof entry.status === "string" ? entry.status.toLowerCase() : "";
+  if (entry.passed === true || status === "passing" || status === "success") return "pass";
+  if (entry.passed === false || status === "failing" || status === "failure") return "fail";
+  return "warn";
+}
+
+async function parseSearchCount(result: PromiseSettledResult<Response>): Promise<number> {
+  if (result.status !== "fulfilled" || !result.value.ok) return 0;
+  const data = (await result.value.json()) as GitHubSearchResponse<unknown>;
+  return typeof data.total_count === "number" ? data.total_count : 0;
+}
+
+async function parseMergedPRs(result: PromiseSettledResult<Response>): Promise<MergedPR[]> {
+  if (result.status !== "fulfilled" || !result.value.ok) return [];
+  const data = (await result.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
+  const items = Array.isArray(data.items) ? data.items : [];
+  return items.map((item) => {
+    const author = item.user?.login ?? "unknown";
+    return {
+      number: item.number,
+      title: item.title,
+      repo: parseRepoName(item.repository_url, item.pull_request?.url),
+      author,
+      isBot: author.endsWith("[bot]") || item.user?.type === "Bot",
+      updatedAt: item.updated_at,
+      url: item.html_url,
+    };
+  });
+}
+
+function MergedPRFeed({ prs }: { prs: MergedPR[] }) {
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Merged PR Feed</Heading>
+      <p className={styles.panelMeta}>Last 15 merged pull requests across projectbluefin</p>
+      {prs.length > 0 ? (
+        <div className={styles.feedList}>
+          {prs.map((pr) => {
+            const accent = repoAccent(pr.repo);
+            return (
+              <Link
+                key={`${pr.repo}-${pr.number}`}
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.feedItem}
+              >
+                <span
+                  className={styles.feedRepo}
+                  style={{ backgroundColor: `${accent}22`, borderColor: `${accent}66`, color: accent }}
+                >
+                  {pr.repo}
+                </span>
+                <span className={styles.feedTitle}>{pr.title}</span>
+                <span className={styles.feedMeta}>
+                  {pr.isBot ? "[agent] " : ""}
+                  {pr.author} · {relTime(pr.updatedAt)}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <div className={styles.empty}>No recently merged pull requests found.</div>
+      )}
+    </section>
+  );
+}
+
+function ContributorWall({ prs }: { prs: MergedPR[] }) {
+  const humans: string[] = [];
+  for (const pr of prs) {
+    if (pr.isBot || humans.includes(pr.author)) continue;
+    humans.push(pr.author);
+    if (humans.length >= 20) break;
+  }
+  const botCount = prs.filter((pr) => pr.isBot).length;
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Contributor Wall</Heading>
+      <p className={styles.panelMeta}>Humans landing code in the latest merged queue</p>
+      {humans.length > 0 ? (
+        <div className={styles.contributorGrid}>
+          {humans.map((login) => (
+            <Link
+              key={login}
+              href={`https://github.com/${login}`}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.contributorCard}
+            >
+              <img
+                src={`https://github.com/${login}.png?size=40`}
+                alt={login}
+                className={styles.contributorAvatar}
+                loading="lazy"
+              />
+              <span className={styles.contributorName}>{login}</span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.empty}>Agents are running the show</div>
+      )}
+      {botCount > 0 ? <div className={styles.botCountChip}>{botCount} agent PRs</div> : null}
+    </section>
+  );
+}
+
+function VelocityPanel({ velocity, p0 }: { velocity: Velocity | null; p0?: number }) {
+  const opened = velocity?.opened ?? 0;
+  const closed = velocity?.closed ?? 0;
+  const net = opened - closed;
+  const deltaLabel =
+    net > 0 ? `▲ net +${net}` : net < 0 ? `▼ net −${Math.abs(net)}` : "◆ net 0";
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Issue Velocity</Heading>
+      <p className={styles.panelMeta}>Issues · last 7 days · projectbluefin org</p>
+      <div className={styles.velocityRow}>
+        <div>
+          <div className={styles.velocityNum}>{opened}</div>
+          <div className={styles.miniLabel}>opened this week</div>
+        </div>
+        <div>
+          <div className={styles.velocityNum}>{closed}</div>
+          <div className={styles.miniLabel}>closed this week</div>
+        </div>
+      </div>
+      <div
+        className={`${styles.velocityDelta} ${
+          net > 0 ? styles.velocityDeltaUp : net < 0 ? styles.velocityDeltaDown : styles.velocityDeltaFlat
+        }`}
+      >
+        {deltaLabel}
+      </div>
+      {typeof p0 === "number" && p0 > 0 ? <div className={styles.p0Alert}>P0 unresolved: {p0}</div> : null}
+    </section>
+  );
+}
+
+function GovernorPanel({ governor }: { governor?: HiveGovernor }) {
+  const mode = (governor?.mode ?? "idle").toUpperCase();
+  const issues = governor?.issues ?? 0;
+  const prs = governor?.prs ?? 0;
+  const depth = issues + prs;
+  const quiet = governor?.thresholds?.quiet ?? 0;
+  const busy = governor?.thresholds?.busy ?? Math.max(quiet + 1, depth, 1);
+  const surge = governor?.thresholds?.surge ?? Math.max(busy + 1, depth, 1);
+  const maxDepth = Math.max(surge, depth, 1);
+  const quietWidth = Math.max((quiet / maxDepth) * 100, 18);
+  const busyWidth = Math.max(((busy - quiet) / maxDepth) * 100, 18);
+  const surgeWidth = Math.max(100 - quietWidth - busyWidth, 18);
+  const markerLeft = Math.min((depth / maxDepth) * 100, 100);
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Governor</Heading>
+      <div className={`${styles.govMode} ${governorModeClass(governor?.mode)}`}>{mode}</div>
+      <div className={styles.kv}>
+        <span>Queue depth</span>
+        <strong>{issues} issues + {prs} PRs in queue</strong>
+      </div>
+      <div className={styles.govThreshBar}>
+        <div className={styles.govThreshZoneQuiet} style={{ width: `${quietWidth}%` }}>QUIET</div>
+        <div className={styles.govThreshZoneBusy} style={{ width: `${busyWidth}%` }}>BUSY</div>
+        <div className={styles.govThreshZoneSurge} style={{ width: `${surgeWidth}%` }}>SURGE</div>
+        <span className={styles.govThreshMarker} style={{ left: `calc(${markerLeft}% - 1px)` }} />
+      </div>
+      <div className={styles.govThreshLegend}>
+        <span>Q ≤ {quiet}</span>
+        <span>B ≤ {busy}</span>
+        <span>S ≥ {surge}</span>
+      </div>
+      <p className={styles.panelMeta}>Next kick: {governor?.nextKick ? relTime(governor.nextKick) : "—"}</p>
+    </section>
+  );
+}
+
+function BeadsCadencePanel({
+  beads,
+  cadenceMatrix,
+  mode,
+}: {
+  beads?: HiveBeads;
+  cadenceMatrix?: HiveCadenceRow[];
+  mode?: string;
+}) {
+  const currentMode = (mode ?? "idle").toLowerCase();
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Beads + Cadence</Heading>
+      <div className={styles.beadsRow}>
+        <span>{beads?.workers ?? 0} worker tasks</span>
+        <span>{beads?.supervisor ?? 0} supervisor tasks</span>
+      </div>
+      {cadenceMatrix?.length ? (
+        <div className={styles.cadenceTable}>
+          <div className={`${styles.cadenceRow} ${styles.cadenceHeader}`}>
+            <span className={styles.cadenceCell}>Agent</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "surge" ? styles.cadenceCellActive : ""}`}>SURGE</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "busy" ? styles.cadenceCellActive : ""}`}>BUSY</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "quiet" ? styles.cadenceCellActive : ""}`}>QUIET</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "idle" ? styles.cadenceCellActive : ""}`}>IDLE</span>
+          </div>
+          {cadenceMatrix.map((row) => (
+            <div key={row.agent} className={styles.cadenceRow}>
+              <span className={styles.cadenceCell}>{row.agent}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "surge" ? styles.cadenceCellActive : ""}`}>{row.surge}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "busy" ? styles.cadenceCellActive : ""}`}>{row.busy}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "quiet" ? styles.cadenceCellActive : ""}`}>{row.quiet}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "idle" ? styles.cadenceCellActive : ""}`}>{row.idle}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function AgentOfDay({ agent }: { agent: HiveAgent | null }) {
+  if (!agent) {
+    return (
+      <section className={`${styles.panel} ${styles.agentOfDayCard}`}>
+      <Heading as="h2" className={styles.panelTitle}>Agent of the Day</Heading>
+        <div className={styles.empty}>No agent spotlight available.</div>
+      </section>
+    );
+  }
+
+  const summaryLines = meaningfulSummaryLines(agent.liveSummary ?? "", 3);
+
+  return (
+    <section className={`${styles.panel} ${styles.agentOfDayCard}`}>
+      <Heading as="h2" className={styles.panelTitle}>Agent of the Day</Heading>
+      <div className={styles.agentOfDayHero}>
+        <div className={styles.agentHeroInitial}>{(agent.displayName || agent.name).slice(0, 1).toUpperCase()}</div>
+        <div>
+          <div className={styles.agentOfDayLabel}>
+            {agent.busy === "working" ? "Currently active" : "Most recently active"}
+          </div>
+          <div className={styles.agentHeroName}>{agent.displayName || agent.name}</div>
+          <div className={styles.agentHeroMeta}>{agent.role || "Generalist"} · {agent.model || "Unknown model"}</div>
+        </div>
+      </div>
+      <div className={styles.agentOfDaySummary}>
+        {summaryLines.length > 0 ? summaryLines.map((line) => <div key={line}>{line}</div>) : "Awaiting next assignment…"}
+      </div>
+    </section>
+  );
+}
+
+function FormationLog({ supervisor, timestamp }: { supervisor: HiveAgent | null; timestamp?: string }) {
+  const lines = supervisor?.liveSummary ? meaningfulSummaryLines(supervisor.liveSummary, 8) : [];
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Formation Log</Heading>
+      {lines.length > 0 ? (
+        <div className={styles.formationLogList}>
+          {lines.map((line, idx) => (
+            <div key={`${idx}-${line}`} className={styles.formationLogEntry}>
+              <span className={styles.formationLogStamp}>{timestamp ? relTime(timestamp) : "recent"}</span>
+              <span>{line}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.empty}>No formation log available</div>
+      )}
+    </section>
+  );
+}
+
+function HealthPanel({ health }: { health?: Record<string, unknown> }) {
+  const entries = Object.entries(health ?? {}).filter(([, value]) => value !== null && value !== undefined);
+  if (entries.length === 0) return null;
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>Health Checks</Heading>
+      <div className={styles.healthList}>
+        {entries.map(([key, raw]) => {
+          const tone = healthTone(raw);
+          const entry = isRecord(raw) ? (raw as HiveHealthEntry) : {};
+          return (
+            <div key={key} className={styles.healthItem}>
+              <span
+                className={`${styles.healthDot} ${
+                  tone === "pass" ? styles.healthDotPass : tone === "fail" ? styles.healthDotFail : styles.healthDotWarn
+                }`}
+              />
+              <span>{entry.name || key}</span>
+              <span className={styles.feedMeta}>{entry.lastRun ? relTime(entry.lastRun) : entry.status || "status unknown"}</span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
 }
 
 function AgentWorkLog({
@@ -542,7 +990,7 @@ function AgentWorkLog({
             {visible.length > 0 && (
               <div className={styles.workLogItems}>
                 {visible.map((item, i) => {
-                  const icon  = TYPE_ICON[item.type] ?? "📌";
+                  const icon  = TYPE_ICON[item.type] ?? "?";
                   const color = SEV_COLOR[item.severity] ?? "#8b949e";
                   const repo  = repoFromTitle(item.title);
                   return (
@@ -591,7 +1039,7 @@ function AgentWorkLog({
             href={`https://github.com/${org}/knuckle/issues/${advisoryIssue}`}
             className={styles.workLogDigestLink}
           >
-            📋 View full advisory digest (issue #{advisoryIssue}) →
+            View full advisory digest (issue #{advisoryIssue}) →
           </Link>
         </div>
       )}
@@ -607,7 +1055,7 @@ function OrgStatsPanel({ stats }: { stats: OrgStats }) {
     <div className={styles.orgGrid}>
       {/* Left: org overview */}
       <div className={styles.orgOverview}>
-        <Heading as="h2" className={styles.panelTitle}>🌐 projectbluefin Org</Heading>
+        <Heading as="h2" className={styles.panelTitle}>projectbluefin Org</Heading>
         <div className={styles.orgStats}>
           <div className={styles.orgStat}>
             <span className={styles.orgStatValue}>{stats.totalRepos}</span>
@@ -635,7 +1083,7 @@ function OrgStatsPanel({ stats }: { stats: OrgStats }) {
 
       {/* Right: agent activity */}
       <div className={styles.orgAgentActivity}>
-        <Heading as="h2" className={styles.panelTitle}>🤖 Agent Activity</Heading>
+        <Heading as="h2" className={styles.panelTitle}>Agent Activity</Heading>
         <div className={styles.orgAgentRows}>
           <Link
             href="https://github.com/issues?q=org%3Aprojectbluefin+label%3Aqueue%2Fagent-ready+state%3Aopen"
@@ -689,6 +1137,8 @@ export default function HiveDashboard(): React.JSX.Element {
   const [commits, setCommits] = useState<number[]>([]);
   const [orgStats, setOrgStats]   = useState<OrgStats | null>(null);
   const [repoPRs, setRepoPRs]     = useState<RepoPRs[]>([]);
+  const [mergedPRs, setMergedPRs] = useState<MergedPR[]>([]);
+  const [velocity, setVelocity] = useState<Velocity | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [refreshIn, setRefreshIn] = useState(REFRESH_SECS);
@@ -696,13 +1146,17 @@ export default function HiveDashboard(): React.JSX.Element {
   const fetchAll = useCallback(async () => {
     try {
       // Fan out all independent fetches
-      const [snapRes, repoRes, ciRes, commitsRes] = await Promise.allSettled([
+      const weekAgoISO = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString().slice(0, 10);
+      const [snapRes, repoRes, ciRes, commitsRes, mergedRes, openedRes, closedRes] = await Promise.allSettled([
         fetchTimeout(SNAPSHOT_URL),
         fetchTimeout(`${GH_API}/repos/${DAKOTA}`),
         fetchTimeout(
           `${GH_API}/repos/${DAKOTA}/actions/workflows/${BUILD_WORKFLOW}/runs?per_page=1&status=completed`,
         ),
         fetchTimeout(`${GH_API}/repos/${DAKOTA}/stats/participation`),
+        fetchTimeout(`${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged&sort=updated&per_page=15`),
+        fetchTimeout(`${GH_API}/search/issues?q=org:projectbluefin+type:issue+created:>${weekAgoISO}&per_page=1`),
+        fetchTimeout(`${GH_API}/search/issues?q=org:projectbluefin+type:issue+closed:>${weekAgoISO}&per_page=1`),
       ]);
 
       // ── Snapshot (agents + config)
@@ -713,13 +1167,24 @@ export default function HiveDashboard(): React.JSX.Element {
         if (cfg) setConfig(cfg);
       }
 
+      setMergedPRs(await parseMergedPRs(mergedRes));
+      const opened = await parseSearchCount(openedRes);
+      const closed = await parseSearchCount(closedRes);
+      setVelocity({ opened, closed });
+
       // ── Repo stats + CI
       if (repoRes.status === "fulfilled" && repoRes.value.ok) {
-        const repo = await repoRes.value.json();
+        const repo = (await repoRes.value.json()) as {
+          stargazers_count: number;
+          forks_count: number;
+          open_issues_count: number;
+        };
 
         let ciStatus: DakotaStats["ciStatus"] = "unknown";
         if (ciRes.status === "fulfilled" && ciRes.value.ok) {
-          const ciData = await ciRes.value.json();
+          const ciData = (await ciRes.value.json()) as {
+            workflow_runs?: Array<{ conclusion?: string | null }>;
+          };
           const run = ciData.workflow_runs?.[0];
           if (run) {
             ciStatus =
@@ -738,7 +1203,7 @@ export default function HiveDashboard(): React.JSX.Element {
             `${GH_API}/search/issues?q=repo:${DAKOTA}+type:pr+state:open`,
           );
           if (prRes.ok) {
-            const prData = await prRes.json();
+            const prData = (await prRes.json()) as GitHubSearchResponse<unknown>;
             openPRs = prData.total_count ?? 0;
           }
         } catch {
@@ -756,8 +1221,8 @@ export default function HiveDashboard(): React.JSX.Element {
 
       // ── Commit sparkline (52-week participation)
       if (commitsRes.status === "fulfilled" && commitsRes.value.ok) {
-        const { all } = await commitsRes.value.json();
-        if (Array.isArray(all)) setCommits(all.slice(-12));
+        const commitData = (await commitsRes.value.json()) as { all?: number[] };
+        if (Array.isArray(commitData.all)) setCommits(commitData.all.slice(-12));
       }
 
       // ── Queue stats
@@ -868,6 +1333,14 @@ export default function HiveDashboard(): React.JSX.Element {
   const activeAgents = agents.filter((a) => a.state === "running");
   const workingAgents = activeAgents.filter((a) => a.busy === "working");
   const repos = config?.repos ?? [];
+  const agentOfDay = pickAgentOfDay(agents);
+  const supervisorAgent = agents.find(
+    (agent) =>
+      agent.role?.toLowerCase().includes("supervisor") ||
+      agent.name.toLowerCase().includes("supervisor") ||
+      agent.displayName?.toLowerCase().includes("supervisor"),
+  ) ?? null;
+  const hasHealth = Boolean(snapshot?.health && Object.keys(snapshot.health).length > 0);
 
   let formation = "Formation broken";
   let formationColor = "#f85149";
@@ -885,12 +1358,11 @@ export default function HiveDashboard(): React.JSX.Element {
   if (loading) {
     return (
       <Layout
-        title="🐝 Dakota OS Factory"
+        title="Dakota OS Factory"
         description="Community Driven Agentic OS Development — live AI agent dashboard for projectbluefin/dakota"
       >
         <div className={styles.dashboard}>
           <div className={styles.loadingWrap}>
-            <div className={styles.loadingBee}>🐝</div>
             <div className={styles.loadingText}>Connecting to the hive…</div>
           </div>
         </div>
@@ -900,7 +1372,7 @@ export default function HiveDashboard(): React.JSX.Element {
 
   return (
     <Layout
-      title="🐝 Dakota OS Factory"
+      title="Dakota OS Factory"
       description="Live AI agent dashboard for the world's first agentic operating system"
     >
       <div className={styles.dashboard}>
@@ -908,8 +1380,7 @@ export default function HiveDashboard(): React.JSX.Element {
         <header className={styles.hero}>
           <div className={styles.heroLeft}>
             <div className={styles.heroTitle}>
-              <span className={styles.heroBee}>🐝</span>
-              <div>
+            <div>
                 <Heading as="h1" className={styles.heroH1}>Dakota OS Factory</Heading>
                 <p className={styles.heroSub}>
                   Community Driven Agentic OS Development
@@ -936,10 +1407,7 @@ export default function HiveDashboard(): React.JSX.Element {
                 >
                   {formation} · {activeAgents.length}/{agents.length} active
                   {workingAgents.length > 0 && (
-                    <>
-                      {" "}
-                      · {workingAgents.map((a) => a.emoji).join(" ")} working
-                    </>
+                    <> · {workingAgents.length} working</>
                   )}
                 </span>
               </div>
@@ -950,7 +1418,7 @@ export default function HiveDashboard(): React.JSX.Element {
             <LivePulse />
             {snapshot?.acmmMode && (
               <span className={`${styles.modeBadge} ${snapshot.acmmMode === "SURGE" ? styles.modeSurge : styles.modeNormal}`}>
-                ⚡ {snapshot.acmmMode}
+                {snapshot.acmmMode}
               </span>
             )}
             {dakotaStats && <CiBadge status={dakotaStats.ciStatus} />}
@@ -967,7 +1435,7 @@ export default function HiveDashboard(): React.JSX.Element {
                 value={dakotaStats.stars.toLocaleString()}
               />
               <StatCard
-                icon="🔀"
+              icon="prs"
                 label="Open PRs"
                 value={dakotaStats.openPRs}
               />
@@ -980,15 +1448,15 @@ export default function HiveDashboard(): React.JSX.Element {
           )}
           {queue && (
             <StatCard
-              icon="🎯"
+              icon="queue"
               label="Agent Queue"
               value={`${queue.ready} ready`}
-              sub={`${queue.claimed} claimed${queue.p0 > 0 ? ` · 🔥 ${queue.p0} P0` : ""}`}
+              sub={`${queue.claimed} claimed${queue.p0 > 0 ? ` · ${queue.p0} P0` : ""}`}
               accent={queue.p0 > 0 ? "#f85149" : undefined}
             />
           )}
           <StatCard
-            icon="🤖"
+            icon="agents"
             label="Agents"
             value={`${activeAgents.length}/${agents.length}`}
             sub={
@@ -1000,7 +1468,7 @@ export default function HiveDashboard(): React.JSX.Element {
           />
           {repos.length > 0 && (
             <StatCard
-              icon="📦"
+              icon="repos"
               label="Repos"
               value={repos.length}
               sub="in formation"
@@ -1008,7 +1476,7 @@ export default function HiveDashboard(): React.JSX.Element {
           )}
           {totalCommits > 0 && (
             <StatCard
-              icon="📈"
+              icon="commits"
               label="Commits"
               value={totalCommits}
               sub="last 12 weeks"
@@ -1019,7 +1487,7 @@ export default function HiveDashboard(): React.JSX.Element {
             const info = ACMM_LEVELS[snapshot.acmmLevel!] ?? { label: "Unknown", desc: "", color: "#8b949e" };
             return (
               <StatCard
-                icon="⚡"
+                icon="acmm"
                 label="ACMM Level"
                 value={`L${snapshot.acmmLevel}`}
                 sub={info.label}
@@ -1029,7 +1497,7 @@ export default function HiveDashboard(): React.JSX.Element {
           })()}
           {snapshot?.advisoryCount != null && snapshot.advisoryCount > 0 && (
             <StatCard
-              icon="📝"
+              icon="notes"
               label="Advisories"
               value={snapshot.advisoryCount}
               sub="in digest"
@@ -1038,7 +1506,7 @@ export default function HiveDashboard(): React.JSX.Element {
           )}
           {snapshot?.medianMergeMins != null && (
             <StatCard
-              icon="⏱️"
+              icon="time"
               label="Merge Time"
               value={
                 snapshot.medianMergeMins < 60
@@ -1063,7 +1531,7 @@ export default function HiveDashboard(): React.JSX.Element {
           const info = ACMM_LEVELS[snapshot.acmmLevel!] ?? { label: "Unknown", desc: "", color: "#8b949e" };
           return (
             <section className={styles.panel}>
-              <Heading as="h2" className={styles.panelTitle}>⚡ AI Maturity Level (ACMM)</Heading>
+              <Heading as="h2" className={styles.panelTitle}>AI Maturity Level (ACMM)</Heading>
               <div className={styles.acmmRow}>
                 <div className={styles.acmmLevelBig} style={{ color: info.color }}>
                   L{snapshot.acmmLevel}
@@ -1073,12 +1541,12 @@ export default function HiveDashboard(): React.JSX.Element {
                   <div className={styles.acmmDesc}>{info.desc}</div>
                   {snapshot.acmmMode && (
                     <span className={`${styles.modeBadge} ${snapshot.acmmMode === "SURGE" ? styles.modeSurge : styles.modeNormal}`} style={{ marginTop: "0.5rem", display: "inline-flex" }}>
-                      ⚡ {snapshot.acmmMode} mode
+                      {snapshot.acmmMode} mode
                     </span>
                   )}
                   {snapshot.medianMergeMins != null && (
                     <div className={styles.acmmStat}>
-                      ⏱ Median merge: <strong>
+                      Median merge: <strong>
                         {snapshot.medianMergeMins < 60
                           ? `${snapshot.medianMergeMins}m`
                           : `${Math.round(snapshot.medianMergeMins / 60 * 10) / 10}h`}
@@ -1120,7 +1588,7 @@ export default function HiveDashboard(): React.JSX.Element {
 
         {agents.length > 0 && (
           <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>🤖 Agent Formation</Heading>
+            <Heading as="h2" className={styles.panelTitle}>Agent Formation</Heading>
             <div className={styles.agentGrid}>
               {agents.map((a) => (
                 <AgentCard key={a.id} agent={a} />
@@ -1132,7 +1600,7 @@ export default function HiveDashboard(): React.JSX.Element {
         {/* ── Commits + Activity ───────────────────────────────── */}
         <div className={styles.twoCol}>
           <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>📈 Commit Activity</Heading>
+            <Heading as="h2" className={styles.panelTitle}>Commit Activity</Heading>
             <p className={styles.panelMeta}>
               Last 12 weeks · projectbluefin/dakota
             </p>
@@ -1167,7 +1635,7 @@ export default function HiveDashboard(): React.JSX.Element {
           </section>
 
           <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>💬 What the Team Is Doing</Heading>
+            <Heading as="h2" className={styles.panelTitle}>What the Team Is Doing</Heading>
             {workingAgents.length > 0 ? (
               <div className={styles.activityList}>
                 {workingAgents.map((a) => {
@@ -1175,7 +1643,7 @@ export default function HiveDashboard(): React.JSX.Element {
                   if (!snippet) return null;
                   return (
                     <div key={a.id} className={styles.activityItem}>
-                      <span className={styles.activityEmoji}>{a.emoji}</span>
+                      <span className={styles.activityInitial}>{(a.displayName || a.name).slice(0, 1).toUpperCase()}</span>
                       <div>
                         <div className={styles.activityAgent}>
                           {a.displayName}
@@ -1202,7 +1670,7 @@ export default function HiveDashboard(): React.JSX.Element {
         <div className={styles.twoCol}>
           {queue && (queue.ready > 0 || queue.claimed > 0) && (
             <section className={styles.panel}>
-              <Heading as="h2" className={styles.panelTitle}>🎯 Issue Queue</Heading>
+              <Heading as="h2" className={styles.panelTitle}>Issue Queue</Heading>
               <p className={styles.panelMeta}>
                 Agent-managed work items in projectbluefin/dakota
               </p>
@@ -1230,7 +1698,7 @@ export default function HiveDashboard(): React.JSX.Element {
 
           {repos.length > 0 && (
             <section className={styles.panel}>
-              <Heading as="h2" className={styles.panelTitle}>📦 Repos in Formation</Heading>
+              <Heading as="h2" className={styles.panelTitle}>Repos in Formation</Heading>
               <p className={styles.panelMeta}>
                 All repositories managed by this hive instance
               </p>
@@ -1241,7 +1709,7 @@ export default function HiveDashboard(): React.JSX.Element {
                     href={`https://github.com/${config?.org ?? "projectbluefin"}/${r}`}
                     className={`${styles.repoChip} ${r === "dakota" ? styles.repoChipDakota : ""}`}
                   >
-                    {r === "dakota" ? "⚙️" : "📦"} {r}
+                    {r}
                   </Link>
                 ))}
               </div>
@@ -1252,8 +1720,8 @@ export default function HiveDashboard(): React.JSX.Element {
         {/* ── PR Queue ─────────────────────────────────────────── */}
         {repoPRs.length > 0 && (
           <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>🔀 PR Queue</Heading>
-            <p className={styles.panelMeta}>Open pull requests across formation repos · 🤖 = hive agent authored</p>
+            <Heading as="h2" className={styles.panelTitle}>PR Queue</Heading>
+            <p className={styles.panelMeta}>Open pull requests across formation repos · [agent] = hive agent authored</p>
             <PrQueueChart data={repoPRs} />
           </section>
         )}
@@ -1261,7 +1729,7 @@ export default function HiveDashboard(): React.JSX.Element {
         {/* ── Agent work log ───────────────────────────────────── */}
         {advisoryItems.length > 0 && (
           <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>📋 What Agents Are Working On</Heading>
+            <Heading as="h2" className={styles.panelTitle}>What Agents Are Working On</Heading>
             <p className={styles.panelMeta}>
               Advisory digest — findings, bugs, CI failures logged by each agent
             </p>
@@ -1274,21 +1742,52 @@ export default function HiveDashboard(): React.JSX.Element {
           </section>
         )}
 
+        <div className={styles.twoCol}>
+          <MergedPRFeed prs={mergedPRs} />
+          <ContributorWall prs={mergedPRs} />
+        </div>
+
+        <div className={styles.twoCol}>
+          <VelocityPanel velocity={velocity} p0={queue?.p0} />
+          <GovernorPanel governor={snapshot?.governor} />
+        </div>
+
+        <BeadsCadencePanel
+          beads={snapshot?.beads}
+          cadenceMatrix={snapshot?.cadenceMatrix}
+          mode={snapshot?.governor?.mode}
+        />
+
+        <div className={styles.twoCol}>
+          <AgentOfDay agent={agentOfDay} />
+          <FormationLog supervisor={supervisorAgent} timestamp={snapshot?.timestamp} />
+        </div>
+
+        {hasHealth ? <HealthPanel health={snapshot?.health} /> : null}
+
         {/* ── What is Hive ─────────────────────────────────────── */}
         <section className={styles.panel}>
-          <Heading as="h2" className={styles.panelTitle}>🔬 About the Hive</Heading>
+          <Heading as="h2" className={styles.panelTitle}>About the Hive</Heading>
           <div className={styles.aboutGrid}>
             <div className={styles.aboutText}>
               <p>
-                Project Bluefin&apos;s <strong>Dakota</strong> — is built and
+                Project Bluefin&apos;s <strong>Dakota</strong> is built and
                 maintained by this formation. Fully automated OS development,
                 humans in charge.
               </p>
               <p>
                 <strong>Hive</strong> is an open-source AI agent orchestration
-                system. Autonomous agents triage issues, write fixes, review PRs,
-                and keep CI green — around the clock, across every repo in the
-                formation.
+                system by Andy Anderson. Autonomous agents triage issues, write
+                fixes, review PRs, and keep CI green — around the clock, across
+                every repo in the formation.
+              </p>
+              <p>
+                The system implements the{" "}
+                <Link href="https://arxiv.org/abs/2604.09388">
+                  AI Codebase Maturity Model
+                </Link>{" "}
+                (ACMM) — a six-level framework from AI-assisted coding to fully
+                autonomous development. This formation runs at Level 6.
               </p>
               <div className={styles.aboutLinks}>
                 <Link href="https://kubestellar.io/live/hive/bluefin/">
@@ -1304,17 +1803,34 @@ export default function HiveDashboard(): React.JSX.Element {
                   Issue Queue ↗
                 </Link>
               </div>
+              <div className={styles.aboutReadingList}>
+                <span className={styles.readingListLabel}>Further reading</span>
+                <Link href="https://arxiv.org/abs/2604.09388">
+                  arXiv: The AI Codebase Maturity Model ↗
+                </Link>
+                <Link href="https://www.cncf.io/blog/2026/05/14/when-ai-agents-become-contributors-how-kubestellar-reached-81-pr-acceptance/">
+                  CNCF Blog: When AI agents become contributors ↗
+                </Link>
+                <Link href="https://thenewstack.io/ai-codebase-maturity-model/">
+                  The New Stack: Beyond Prompting — 81% PR acceptance ↗
+                </Link>
+                <Link href="https://clubanderson.medium.com/">
+                  Andy Anderson on Medium ↗
+                </Link>
+                <Link href="https://github.com/kubestellar/hive/blob/main/docs/architecture.md">
+                  Hive Architecture Deep Dive ↗
+                </Link>
+              </div>
             </div>
             <div className={styles.agentRoles}>
               {[
-                { e: "👑", n: "Supervisor", d: "Monitors all agents, detects stalls" },
-                { e: "🔍", n: "Scanner", d: "Triages issues, dispatches fixes" },
-                { e: "🔧", n: "CI Maintainer", d: "CI health, workflow fixes" },
-                { e: "🏗️", n: "Architect", d: "Cross-cutting RFCs, new features" },
-                { e: "🛡️", n: "Sec-Check", d: "Security gate on PRs" },
-              ].map(({ e, n, d }) => (
+                { n: "Supervisor", d: "Monitors all agents, detects stalls" },
+                { n: "Scanner", d: "Triages issues, dispatches fixes" },
+                { n: "Reviewer", d: "Code review, quality checks" },
+                { n: "Architect", d: "Cross-cutting RFCs, new features" },
+                { n: "Outreach", d: "Community engagement, coverage tracking" },
+              ].map(({ n, d }) => (
                 <div key={n} className={styles.roleRow}>
-                  <span>{e}</span>
                   <span className={styles.roleName}>{n}</span>
                   <span className={styles.roleDesc}>{d}</span>
                 </div>


### PR DESCRIPTION
## What

Replaces the fragile HTML regex-parsing in `HiveDashboard` with a direct JSON fetch from `snapshot.json`.

### Changes
- `SNAPSHOT_URL` now points to `.../bluefin/snapshot.json`
- `parseSnapshotHtml` replaced with `parseSnapshotJson` — reads fields directly from the `/api/status` JSON structure:
  - `agents`, `hiveId`, `timestamp` directly
  - `governor.mode` → `acmmMode`
  - `agentMetrics.outreach.acmm` → `acmmLevel`
  - `issueToMerge.median_minutes` / `p90_minutes` → merge stats
  - `repos[]` → derived config (org, repos list)

## Dependency

Requires [kubestellar/hive#669](https://github.com/kubestellar/hive/pull/669) to be merged so `publish-snapshot.sh` writes `snapshot.json` alongside the HTML files (with `HIVE_DOCS_SUBDIR=bluefin`).