### PR TITLE
fix(hive): remove hardcoded Level 6 claim from About section

### DIFF
--- a/src/components/HiveDashboard.tsx
+++ b/src/components/HiveDashboard.tsx
@@ -1806,7 +1806,7 @@ export default function HiveDashboard(): React.JSX.Element {
                   AI Codebase Maturity Model
                 </Link>{" "}
                 (ACMM) — a six-level framework from AI-assisted coding to fully
-                autonomous development. This formation runs at Level 6.
+                autonomous development. The current level is shown live in the Formation Status panel above.
               </p>
               <div className={styles.aboutLinks}>
                 <Link href="https://kubestellar.io/live/hive/bluefin/">


### PR DESCRIPTION
The About the Hive section incorrectly claimed the formation runs at Level 6. Live snapshot data shows `"acmmLevel": 3`. Replaced the false claim with a pointer to the Formation Status panel which shows the live level.