### PR TITLE
fix(hive): add raw.githubusercontent.com to CSP; fix 202 sparkline

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -118,7 +118,7 @@ const config: Config = {
           "style-src 'self' 'unsafe-inline'",
           "img-src 'self' data: https:",
           "font-src 'self' data:",
-          "connect-src 'self' https://api.github.com https://giscus.app https://formulae.brew.sh",
+          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh",
           "frame-src https://giscus.app https://www.youtube.com https://youtube.com https://insights.linuxfoundation.org",
         ].join("; "),
       },

--- a/src/components/HiveDashboard.tsx
+++ b/src/components/HiveDashboard.tsx
@@ -1258,7 +1258,8 @@ export default function HiveDashboard(): React.JSX.Element {
       }
 
       // ── Commit sparkline (52-week participation)
-      if (commitsRes.status === "fulfilled" && commitsRes.value.ok) {
+      // GitHub returns 202 when stats are being computed — status 200 means real data
+      if (commitsRes.status === "fulfilled" && commitsRes.value.status === 200) {
         const commitData = (await commitsRes.value.json()) as { all?: number[] };
         if (Array.isArray(commitData.all)) setCommits(commitData.all.slice(-12));
       }


### PR DESCRIPTION
Two bugs causing blank charts on /hive:

**1. CSP blocked the snapshot fetch**
`connect-src` was missing `raw.githubusercontent.com`. The hive snapshot fetch (both `snapshot.json` and the HTML fallback) was silently blocked by the browser's CSP enforcement — so agent cards, ACMM panel, repos, governor mode, and agent-of-day never rendered.

**2. GitHub participation API returns 202 → blank sparkline**
`GET /repos/:owner/:repo/stats/participation` returns HTTP 202 (Accepted, computing) when stats aren't cached. `response.ok` is true for 202, but the body is `{}` — so `commitData.all` was `undefined` and the sparkline stayed blank forever. Fixed by checking `status === 200` explicitly.