### PR TITLE
ci: add copilot-setup-steps with Wrangler (Cloudflare CLI)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,41 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    environment: copilot
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Wrangler (Cloudflare CLI)
+        run: npm install -g wrangler@latest
+
+      - name: Verify Wrangler auth
+        if: env.CLOUDFLARE_API_TOKEN != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: wrangler whoami


### PR DESCRIPTION
Adds `.github/workflows/copilot-setup-steps.yml` so the Copilot cloud agent starts every session with:

- Node 24 + `npm ci` (full docs build environment pre-installed)
- `wrangler` (Cloudflare CLI) globally installed

**To enable Cloudflare management**, add the API token to the `copilot` environment:

> Settings → Environments → copilot → Add environment secret → `CLOUDFLARE_API_TOKEN`

Once the secret is present, `wrangler whoami` verifies auth on every session startup. Agents can then purge the cache, inspect DNS/zones, deploy Workers, and manage Pages rules without manual auth steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated setup workflow for development environment configuration. This workflow runs on manual dispatch, code changes, and pull requests to ensure consistent environment initialization with Node.js, npm dependencies, and Cloudflare authentication verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/documentation/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->