### PR TITLE
feat(hive): The Bluefin Operating System Factory

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -118,7 +118,7 @@ const config: Config = {
           "style-src 'self' 'unsafe-inline'",
           "img-src 'self' data: https:",
           "font-src 'self' data:",
-          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh",
+          "connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://giscus.app https://formulae.brew.sh https://queue.projectbluefin.io",
           "frame-src https://giscus.app https://www.youtube.com https://youtube.com https://insights.linuxfoundation.org",
         ].join("; "),
       },

--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -1,0 +1,1819 @@
+/* ══════════════════════════════════════════════════════════════════════════
+   HiveDashboard.module.css
+   Dark OS-factory dashboard — independent of Docusaurus light/dark theme
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Container ──────────────────────────────────────────────────────────── */
+.dashboard {
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+    sans-serif;
+  min-height: 100vh;
+  padding: 2rem 2.5rem 3rem;
+  /* Break out of Docusaurus container centering while staying full-width */
+  margin: 0 calc(-1 * var(--ifm-spacing-horizontal, 0px));
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 1.25rem 1rem 2rem;
+  }
+}
+
+/* ── Hero ───────────────────────────────────────────────────────────────── */
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding-bottom: 1.75rem;
+  margin-bottom: 1.75rem;
+  border-bottom: 1px solid #21262d;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    flex-direction: column;
+  }
+}
+
+.heroLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.heroTitle {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.heroBee {
+  font-size: 2.75rem;
+  filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.6));
+  flex-shrink: 0;
+}
+
+.heroH1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #e6edf3;
+  margin: 0 0 0.2rem;
+  line-height: 1.1;
+}
+
+.heroSub {
+  color: #8b949e;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.heroLink {
+  color: #58a6ff;
+  text-decoration: none;
+}
+.heroLink:hover {
+  text-decoration: underline;
+  color: #79b8ff;
+}
+
+.heroRight {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+/* ── Live pulse ─────────────────────────────────────────────────────────── */
+.livePulse {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #3fb950;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  background: rgba(63, 185, 80, 0.08);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+  border-radius: 20px;
+  padding: 4px 10px;
+}
+
+.pulseDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #3fb950;
+  box-shadow: 0 0 5px #3fb950;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.75);
+  }
+}
+
+/* ── CI badge ───────────────────────────────────────────────────────────── */
+.ciBadge {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  padding: 4px 10px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #30363d;
+  transition: border-color 0.15s;
+}
+.ciBadge:hover {
+  border-color: #58a6ff;
+  text-decoration: none;
+}
+
+/* ── Formation bar ──────────────────────────────────────────────────────── */
+.formationRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.healthBar {
+  display: flex;
+  gap: 3px;
+}
+
+.hFilled,
+.hEmpty {
+  width: 18px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+.hFilled {
+  background: #3fb950;
+  box-shadow: 0 0 4px rgba(63, 185, 80, 0.5);
+}
+
+.hEmpty {
+  background: #21262d;
+  border: 1px solid #30363d;
+}
+
+.formationLabel {
+  font-size: 0.8rem;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+/* ── Stats row ──────────────────────────────────────────────────────────── */
+.statsRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 0.875rem;
+  margin-bottom: 1.75rem;
+}
+
+.statCard {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.statCard:hover {
+  border-color: #30363d;
+  transform: translateY(-1px);
+}
+
+.statIcon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+
+.statValue {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #e6edf3;
+  line-height: 1;
+}
+
+.statLabel {
+  font-size: 0.7rem;
+  color: #6e7681;
+  margin-top: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.statSub {
+  font-size: 0.7rem;
+  color: #8b949e;
+  margin-top: 2px;
+}
+
+/* ── Panels ─────────────────────────────────────────────────────────────── */
+.panel {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.panelTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.3rem;
+}
+
+.panelMeta {
+  font-size: 0.75rem;
+  color: #484f58;
+  margin: 0 0 1rem;
+}
+
+/* ── Two-column layout ──────────────────────────────────────────────────── */
+.twoCol {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+@media (max-width: 860px) {
+  .twoCol {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Agent grid ─────────────────────────────────────────────────────────── */
+.agentGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.75rem;
+}
+
+.agentCard {
+  background: #1c2128;
+  border: 1px solid #21262d;
+  border-left: 3px solid var(--ac, #58a6ff);
+  border-radius: 8px;
+  padding: 0.9rem;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.agentCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.agentOn {
+  opacity: 1;
+}
+.agentOff {
+  opacity: 0.45;
+  filter: grayscale(0.5);
+}
+
+.agentHead {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.agentEmoji {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.agentMeta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.agentName {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #cdd9e5;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 130px;
+}
+
+.agentPill {
+  font-size: 0.6rem;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.sWorking {
+  background: rgba(63, 185, 80, 0.12);
+  color: #3fb950;
+  border: 1px solid rgba(63, 185, 80, 0.3);
+}
+.sIdle {
+  background: rgba(88, 166, 255, 0.08);
+  color: #58a6ff;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+}
+.sPaused {
+  background: rgba(210, 153, 34, 0.12);
+  color: #d29922;
+  border: 1px solid rgba(210, 153, 34, 0.25);
+}
+.sStopped {
+  background: rgba(248, 81, 73, 0.08);
+  color: #f85149;
+  border: 1px solid rgba(248, 81, 73, 0.2);
+}
+
+.agentModel {
+  font-size: 0.6rem;
+  color: #484f58;
+  background: #0d1117;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.agentSnippet {
+  font-size: 0.75rem;
+  color: #6e7681;
+  line-height: 1.45;
+  font-style: italic;
+  margin-bottom: 0.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.agentFoot {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.agentTag {
+  font-size: 0.6rem;
+  color: #484f58;
+  background: #0d1117;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.agentTagWarn {
+  color: #d29922;
+  background: rgba(210, 153, 34, 0.08);
+}
+
+.agentTagMuted {
+  font-size: 0.6rem;
+  color: #30363d;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  padding: 2px 0;
+}
+
+/* ── Sparkline ──────────────────────────────────────────────────────────── */
+.sparkWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sparkline {
+  width: 100%;
+  height: 72px;
+  display: block;
+  border-radius: 6px;
+  overflow: visible;
+}
+
+.sparkLabels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.65rem;
+  color: #484f58;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.sparkTotal {
+  color: #3fb950;
+  font-weight: 600;
+}
+
+/* Mini bar chart below sparkline */
+.sparkBar {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 44px;
+  padding-top: 4px;
+}
+
+.sparkBarItem {
+  flex: 1;
+  background: rgba(63, 185, 80, 0.25);
+  border-radius: 2px 2px 0 0;
+  min-height: 1px;
+  transition: background 0.15s;
+}
+.sparkBarItem:hover {
+  background: rgba(63, 185, 80, 0.6);
+}
+
+/* ── Activity list ──────────────────────────────────────────────────────── */
+.activityList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.activityItem {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.activityEmoji {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.activityAgent {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #58a6ff;
+  margin-bottom: 3px;
+}
+
+.activityText {
+  font-size: 0.8rem;
+  color: #8b949e;
+  line-height: 1.5;
+}
+
+/* ── Queue bar ──────────────────────────────────────────────────────────── */
+.queueWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.875rem;
+}
+
+.queueBar {
+  height: 12px;
+  background: #21262d;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+}
+
+.queueClaimed {
+  background: #58a6ff;
+  height: 100%;
+  transition: width 0.4s;
+}
+
+.queueReady {
+  background: #3fb950;
+  height: 100%;
+  transition: width 0.4s;
+}
+
+.queueLegend {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+}
+
+.queueLegendClaimed {
+  color: #58a6ff;
+}
+.queueLegendReady {
+  color: #3fb950;
+}
+.queueLegendP0 {
+  color: #f85149;
+  font-weight: 600;
+}
+
+.queueLinks {
+  display: flex;
+  gap: 1rem;
+}
+
+.queueLink {
+  font-size: 0.8rem;
+  color: #58a6ff;
+  text-decoration: none;
+}
+.queueLink:hover {
+  text-decoration: underline;
+}
+
+/* ── Repo chips ─────────────────────────────────────────────────────────── */
+.repoGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.repoChip {
+  background: #1c2128;
+  border: 1px solid #30363d;
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 0.8rem;
+  color: #8b949e;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+.repoChip:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.repoChipDakota {
+  border-color: rgba(245, 158, 11, 0.5);
+  color: #f59e0b;
+}
+.repoChipDakota:hover {
+  border-color: #f59e0b;
+  color: #fbbf24;
+}
+
+/* ── About section ──────────────────────────────────────────────────────── */
+.aboutGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .aboutGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.aboutText p {
+  font-size: 0.875rem;
+  color: #8b949e;
+  line-height: 1.6;
+  margin: 0 0 1rem;
+}
+
+.aboutLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.aboutLinks a {
+  font-size: 0.8rem;
+  color: #58a6ff;
+  text-decoration: none;
+  padding: 4px 12px;
+  border: 1px solid rgba(88, 166, 255, 0.25);
+  border-radius: 20px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.aboutLinks a:hover {
+  border-color: #58a6ff;
+  background: rgba(88, 166, 255, 0.08);
+  text-decoration: none;
+}
+
+.agentRoles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.aboutReadingList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.aboutReadingList a {
+  font-size: 0.8rem;
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.aboutReadingList a:hover {
+  text-decoration: underline;
+}
+
+.readingListLabel {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #484f58;
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.roleRow {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.roleName {
+  color: #cdd9e5;
+  font-weight: 600;
+}
+
+.roleDesc {
+  color: #6e7681;
+}
+
+/* ── Footer ─────────────────────────────────────────────────────────────── */
+.dashFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 1.5rem;
+  border-top: 1px solid #21262d;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.72rem;
+  color: #484f58;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.footerRight a {
+  color: #8b949e;
+  text-decoration: none;
+}
+.footerRight a:hover {
+  color: #58a6ff;
+}
+
+/* ── Org stats panel ───────────────────────────────────────────────────────── */
+.orgGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+@media (max-width: 700px) {
+  .orgGrid { grid-template-columns: 1fr; }
+}
+.orgOverview {}
+.orgStats {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-top: 0.875rem;
+  background: #1c2128;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.orgStat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.875rem 0.5rem;
+  gap: 3px;
+}
+.orgStatDivider {
+  width: 1px;
+  height: 40px;
+  background: #21262d;
+  flex-shrink: 0;
+}
+.orgStatValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+  line-height: 1;
+}
+.orgStatLabel {
+  font-size: 0.65rem;
+  color: #6e7681;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+.orgAgentActivity {}
+.orgAgentRows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.875rem;
+}
+.orgAgentRow {
+  display: grid;
+  grid-template-columns: 8px 120px 2.5rem 1fr;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.875rem;
+  background: #1c2128;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+.orgAgentRow:hover {
+  border-color: #30363d;
+  text-decoration: none;
+}
+.orgAgentRowDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 5px currentColor;
+}
+.orgAgentRowLabel {
+  font-size: 0.8rem;
+  color: #8b949e;
+  font-weight: 500;
+}
+.orgAgentRowCount {
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-align: right;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+.orgAgentRowSub {
+  font-size: 0.7rem;
+  color: #484f58;
+}
+.orgAgentTotal {
+  font-size: 0.75rem;
+  color: #484f58;
+  text-align: center;
+  padding: 0.4rem;
+  border-top: 1px solid #21262d;
+  margin-top: 0.25rem;
+}
+
+/* ── Mode badge ─────────────────────────────────────────────────────────── */
+.modeBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1px solid;
+}
+.modeSurge {
+  color: #f59e0b;
+  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.08);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.2);
+}
+.modeNormal {
+  color: #58a6ff;
+  border-color: rgba(88, 166, 255, 0.3);
+  background: rgba(88, 166, 255, 0.06);
+}
+
+/* ── ACMM panel ──────────────────────────────────────────────────────────── */
+.acmmRow {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1.5rem;
+  align-items: start;
+}
+@media (max-width: 640px) {
+  .acmmRow { grid-template-columns: 3rem 1fr; }
+  .acmmScale { grid-column: 1 / -1; }
+}
+.acmmLevelBig {
+  font-size: 2.5rem;
+  font-weight: 900;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  line-height: 1;
+  text-shadow: 0 0 20px currentColor;
+}
+.acmmInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.acmmLabel {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.acmmDesc {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+.acmmStat {
+  font-size: 0.78rem;
+  color: #6e7681;
+  margin-top: 0.35rem;
+}
+.acmmStat strong {
+  color: #39d2c0;
+}
+.acmmScale {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.acmmStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid;
+  min-width: 60px;
+  cursor: default;
+}
+.acmmStepNum {
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+.acmmStepLabel {
+  font-size: 0.55rem;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.acmmStepActive {
+  font-weight: 700;
+  background: rgba(255,255,255,0.04);
+  box-shadow: 0 0 8px rgba(255,255,255,0.1);
+}
+.acmmStepPast {
+  opacity: 0.6;
+}
+.acmmStepFuture {
+  color: #30363d;
+  border-color: #21262d;
+}
+
+
+.loadingWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  gap: 1rem;
+}
+
+.loadingBee {
+  font-size: 3.5rem;
+  animation: sway 2s ease-in-out infinite;
+}
+
+@keyframes sway {
+  0%,
+  100% {
+    transform: rotate(-8deg);
+  }
+  50% {
+    transform: rotate(8deg);
+  }
+}
+
+.loadingText {
+  color: #8b949e;
+  font-size: 0.95rem;
+}
+
+/* ── PR queue chart ─────────────────────────────────────────────────────── */
+.prChart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.prRow {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  align-items: center;
+  gap: 0.75rem;
+}
+.prRepoLabel {
+  font-size: 0.78rem;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  color: #8b949e;
+  text-decoration: none;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.prRepoLabel:hover { color: #58a6ff; }
+.prBarWrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.prBarTrack {
+  flex: 1;
+  height: 18px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.prBarFill {
+  height: 100%;
+  background: rgba(88, 166, 255, 0.25);
+  border-radius: 4px;
+  transition: width 0.4s ease;
+  position: relative;
+  display: flex;
+}
+.prBarAgent {
+  height: 100%;
+  background: #3fb950;
+  border-radius: 4px 0 0 4px;
+  transition: width 0.4s ease;
+}
+.prCount {
+  font-size: 0.78rem;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  color: #e6edf3;
+  min-width: 2rem;
+  text-align: right;
+}
+.prAgentCount {
+  color: #3fb950;
+  font-size: 0.7rem;
+}
+.prLegend {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.7rem;
+  margin-top: 0.25rem;
+  padding-left: 108px;
+}
+.prLegendHuman { color: #58a6ff; }
+.prLegendAgent { color: #3fb950; }
+
+/* ── Agent work log ──────────────────────────────────────────────────────── */
+.workLog {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.workLogAgent {
+  border-bottom: 1px solid #21262d;
+  padding: 0.875rem 0;
+}
+.workLogAgent:last-child { border-bottom: none; }
+.workLogHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+.workLogEmoji { font-size: 1.1rem; flex-shrink: 0; margin-top: 1px; }
+.workLogAgentMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.workLogName {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #cdd9e5;
+}
+.workLogRepos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.workLogRepoChip {
+  font-size: 0.62rem;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 4px;
+  padding: 1px 6px;
+  text-decoration: none;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+.workLogRepoChip:hover { border-color: #f59e0b; text-decoration: none; }
+.workLogCount {
+  font-size: 0.7rem;
+  color: #484f58;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  flex-shrink: 0;
+}
+.workLogItems {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-left: 1.7rem;
+}
+.workLogItem {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.4rem 0.6rem;
+  background: #1c2128;
+  border-radius: 6px;
+  border: 1px solid #21262d;
+}
+.workLogIcon { font-size: 0.85rem; flex-shrink: 0; margin-top: 1px; }
+.workLogItemBody {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.workLogTitle {
+  font-size: 0.8rem;
+  color: #cdd9e5;
+  line-height: 1.4;
+}
+.workLogMeta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.workLogSev {
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.workLogType {
+  font-size: 0.62rem;
+  color: #484f58;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  background: #0d1117;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.workLogRepo {
+  font-size: 0.62rem;
+  color: #58a6ff;
+  text-decoration: none;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+.workLogRepo:hover { text-decoration: underline; }
+.workLogTime {
+  font-size: 0.62rem;
+  color: #484f58;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  margin-left: auto;
+}
+.workLogToggle {
+  background: none;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #8b949e;
+  font-size: 0.72rem;
+  padding: 3px 10px;
+  cursor: pointer;
+  margin-top: 0.25rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+.workLogToggle:hover { border-color: #58a6ff; color: #58a6ff; }
+.workLogEmpty {
+  font-size: 0.75rem;
+  color: #484f58;
+  font-style: italic;
+  margin-left: 1.7rem;
+}
+.workLogFooter {
+  padding-top: 0.875rem;
+  text-align: center;
+}
+.workLogDigestLink {
+  font-size: 0.8rem;
+  color: #58a6ff;
+  text-decoration: none;
+}
+.workLogDigestLink:hover { text-decoration: underline; }
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+.empty {
+  color: #484f58;
+  font-size: 0.85rem;
+  font-style: italic;
+  padding: 0.75rem 0;
+}
+
+
+/* ── New dense panels ─────────────────────────────────────────────────────── */
+.feedList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 300px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+.feedItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(139, 148, 158, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  text-decoration: none;
+  color: inherit;
+}
+.feedItem:hover {
+  border-color: rgba(88, 166, 255, 0.38);
+  background: rgba(88, 166, 255, 0.05);
+}
+.feedRepo {
+  flex: 0 0 auto;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(88, 166, 255, 0.35);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.feedTitle {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.feedMeta {
+  flex: 0 0 auto;
+  color: #8b949e;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.contributorGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+.contributorCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  width: 68px;
+  text-decoration: none;
+  color: inherit;
+}
+.contributorAvatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid rgba(88, 166, 255, 0.22);
+}
+.contributorName {
+  font-size: 0.72rem;
+  color: #c9d1d9;
+  text-align: center;
+  word-break: break-word;
+}
+.botCountChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.9rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(210, 153, 34, 0.12);
+  color: #d29922;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.velocityRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 0.8rem;
+}
+.velocityNum {
+  font-size: clamp(2rem, 4vw, 2.7rem);
+  line-height: 1;
+  font-weight: 800;
+  color: #f0f6fc;
+}
+.miniLabel {
+  margin-top: 0.35rem;
+  color: #8b949e;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.velocityDelta {
+  margin-top: 0.85rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.velocityDeltaUp { color: #f85149; }
+.velocityDeltaDown { color: #3fb950; }
+.velocityDeltaFlat { color: #8b949e; }
+.p0Alert {
+  margin-top: 0.75rem;
+  color: #f85149;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+.govMode {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120px;
+  margin: 0.55rem 0 0.9rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+.govModeSurge { color: #f85149; background: rgba(248, 81, 73, 0.12); }
+.govModeBusy { color: #d29922; background: rgba(210, 153, 34, 0.12); }
+.govModeQuiet { color: #58a6ff; background: rgba(88, 166, 255, 0.12); }
+.govModeIdle { color: #8b949e; background: rgba(139, 148, 158, 0.12); }
+.govThreshBar {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  border-radius: 999px;
+  margin-top: 0.9rem;
+  border: 1px solid rgba(139, 148, 158, 0.2);
+}
+.govThreshZoneQuiet,
+.govThreshZoneBusy,
+.govThreshZoneSurge {
+  padding: 0.4rem 0;
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.govThreshZoneQuiet { background: rgba(88, 166, 255, 0.14); color: #58a6ff; }
+.govThreshZoneBusy { background: rgba(210, 153, 34, 0.14); color: #d29922; }
+.govThreshZoneSurge { background: rgba(248, 81, 73, 0.14); color: #f85149; }
+.govThreshMarker {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: #f0f6fc;
+  box-shadow: 0 0 0 1px rgba(13, 17, 23, 0.6);
+}
+.govThreshLegend {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.45rem;
+  color: #8b949e;
+  font-size: 0.72rem;
+}
+.beadsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.75rem 0 1rem;
+  color: #c9d1d9;
+  font-weight: 700;
+}
+.cadenceTable {
+  display: grid;
+  gap: 0.45rem;
+}
+.cadenceHeader {
+  color: #8b949e;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+}
+.cadenceRow {
+  display: grid;
+  grid-template-columns: minmax(110px, 1.4fr) repeat(4, minmax(80px, 1fr));
+  gap: 0.45rem;
+}
+.cadenceCell {
+  padding: 0.45rem 0.55rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+  font-size: 0.78rem;
+}
+.cadenceCellActive {
+  border-color: rgba(88, 166, 255, 0.45);
+  background: rgba(88, 166, 255, 0.12);
+  color: #f0f6fc;
+  font-weight: 700;
+}
+.agentOfDayCard {
+  border-color: #d29922;
+  background: rgba(210, 153, 34, 0.1);
+}
+.agentOfDayHero {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.agentHeroEmoji {
+  font-size: 2.8rem;
+  line-height: 1;
+}
+.agentOfDayLabel {
+  color: #d29922;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.agentHeroName {
+  margin-top: 0.2rem;
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: #f0f6fc;
+}
+.agentHeroMeta {
+  margin-top: 0.2rem;
+  color: #c9d1d9;
+  font-size: 0.84rem;
+}
+.agentOfDaySummary {
+  margin-top: 0.95rem;
+  display: grid;
+  gap: 0.45rem;
+  color: #f0f6fc;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+.formationLogList {
+  display: grid;
+  gap: 0.55rem;
+}
+.formationLogEntry {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+  font-size: 0.84rem;
+}
+.formationLogStamp {
+  color: #8b949e;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.healthList {
+  display: grid;
+  gap: 0.55rem;
+}
+.healthItem {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.12);
+}
+.healthDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.healthDotPass { background: #3fb950; box-shadow: 0 0 10px rgba(63, 185, 80, 0.45); }
+.healthDotFail { background: #f85149; box-shadow: 0 0 10px rgba(248, 81, 73, 0.45); }
+.healthDotWarn { background: #d29922; box-shadow: 0 0 10px rgba(210, 153, 34, 0.45); }
+
+@media (max-width: 900px) {
+  .feedItem,
+  .healthItem {
+    grid-template-columns: 1fr;
+  }
+  .feedItem {
+    flex-wrap: wrap;
+  }
+  .cadenceRow {
+    grid-template-columns: minmax(90px, 1.2fr) repeat(4, minmax(64px, 1fr));
+  }
+  .formationLogEntry {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Destiny columns (Guardians / Ghosts) ─────────────────────────────── */
+.destinyColumns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .destinyColumns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.destinyCol {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.destinyColTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #e6edf3;
+  margin: 0 0 0.15rem;
+  letter-spacing: 0.02em;
+}
+
+.destinyColSubtitle {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin: 0;
+}
+
+.guardiansCol {
+  border-top: 3px solid #d97706;
+}
+
+.guardiansColTitle {
+  color: #d97706;
+}
+
+.ghostsCol {
+  border-top: 3px solid #2563eb;
+}
+
+.ghostsColTitle {
+  color: #93c5fd;
+}
+
+.prTier {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.prTierHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.prTierLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.prTierLabelApproved {
+  background: rgba(63, 185, 80, 0.15);
+  color: #3fb950;
+  border: 1px solid rgba(63, 185, 80, 0.3);
+}
+
+.prTierLabelRequired {
+  background: rgba(210, 153, 34, 0.15);
+  color: #d29922;
+  border: 1px solid rgba(210, 153, 34, 0.3);
+}
+
+.prTierLabelNone {
+  background: rgba(139, 148, 158, 0.1);
+  color: #8b949e;
+  border: 1px solid rgba(139, 148, 158, 0.2);
+}
+
+.prTierCount {
+  font-size: 0.75rem;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+.prCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.6rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.prCard:hover {
+  border-color: #388bfd;
+  color: inherit;
+  text-decoration: none;
+}
+
+.prCardTitle {
+  font-size: 0.82rem;
+  color: #e6edf3;
+  line-height: 1.35;
+}
+
+.prCardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.prCardRepo {
+  font-size: 0.7rem;
+  color: #58a6ff;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+}
+
+.prCardApprovals {
+  font-size: 0.7rem;
+  color: #3fb950;
+  background: rgba(63, 185, 80, 0.1);
+  border: 1px solid rgba(63, 185, 80, 0.2);
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+  font-weight: 600;
+}
+
+.prCardAge {
+  font-size: 0.7rem;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+.prTierEmpty {
+  font-size: 0.8rem;
+  color: #484f58;
+  padding: 0.5rem 0;
+}
+
+/* ── P0/P1 issue cards (Ghosts column) ─────────────────────────────────── */
+.issueTierLabelP0 {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+  border: 1px solid rgba(248, 81, 73, 0.3);
+}
+
+.issueTierLabelP1 {
+  background: rgba(210, 153, 34, 0.15);
+  color: #d29922;
+  border: 1px solid rgba(210, 153, 34, 0.3);
+}
+
+.issueCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.6rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.issueCard:hover {
+  border-color: #388bfd;
+  color: inherit;
+  text-decoration: none;
+}
+
+.issueCardTitle {
+  font-size: 0.82rem;
+  color: #e6edf3;
+  line-height: 1.35;
+}
+
+.issueCardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.issueCardRepo {
+  font-size: 0.7rem;
+  color: #8b949e;
+  background: rgba(139, 148, 158, 0.1);
+  border: 1px solid rgba(139, 148, 158, 0.15);
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+}
+
+.issueLabel {
+  font-size: 0.65rem;
+  border-radius: 3px;
+  padding: 0.1rem 0.35rem;
+  font-weight: 500;
+}
+
+.issueCardAge {
+  font-size: 0.7rem;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+/* ── Victory Log ────────────────────────────────────────────────────────── */
+.victoryLog {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+}
+
+.victoryLogHeader {
+  margin-bottom: 1rem;
+}
+
+.victoryLogTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #e6edf3;
+  margin: 0 0 0.2rem;
+}
+
+.victoryLogSubtitle {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin: 0;
+}
+
+.victoryColumns {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 768px) {
+  .victoryColumns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.victoryCol {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.victoryColHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.victoryCategoryLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+}
+
+.victoryCategoryFeatures {
+  background: rgba(188, 140, 255, 0.12);
+  color: #bc8cff;
+  border: 1px solid rgba(188, 140, 255, 0.25);
+}
+
+.victoryCategoryFixed {
+  background: rgba(63, 185, 80, 0.12);
+  color: #3fb950;
+  border: 1px solid rgba(63, 185, 80, 0.25);
+}
+
+.victoryCategoryAutomated {
+  background: rgba(88, 166, 255, 0.1);
+  color: #58a6ff;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+}
+
+.victoryCount {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #e6edf3;
+  line-height: 1;
+}
+
+.victoryCountSub {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+.victoryList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.victoryItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.45rem 0.6rem;
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 5px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s;
+}
+
+.victoryItem:hover {
+  border-color: #388bfd;
+  color: inherit;
+  text-decoration: none;
+}
+
+.victoryItemTitle {
+  font-size: 0.78rem;
+  color: #e6edf3;
+  line-height: 1.3;
+}
+
+.victoryItemMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.victoryItemRepo {
+  font-size: 0.68rem;
+  color: #58a6ff;
+}
+
+.victoryItemAge {
+  font-size: 0.68rem;
+  color: #8b949e;
+  margin-left: auto;
+}

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -1,0 +1,2139 @@
+import React, { useCallback, useEffect, useState } from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import Heading from "@theme/Heading";
+import styles from "./HiveFactoryDashboard.module.css";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface HiveAgent {
+  name: string;
+  id: string;
+  displayName: string;
+  role: string;
+  emoji: string;
+  color: string;
+  state: string;
+  busy: string;
+  paused: boolean;
+  model?: string;
+  cli?: string;
+  cadence?: string;
+  lastKick?: string;
+  nextKick?: string;
+  liveSummary?: string;
+  restarts?: number;
+}
+
+interface AdvisoryItem {
+  agent: string;
+  timestamp: string;
+  type: string;
+  severity: "low" | "medium" | "high";
+  title: string;
+}
+
+interface HiveSnapshot {
+  timestamp: string;
+  hiveId: string;
+  agents: HiveAgent[];
+  governor?: HiveGovernor;
+  beads?: HiveBeads;
+  cadenceMatrix?: HiveCadenceRow[];
+  health?: Record<string, unknown>;
+  acmmLevel?: number;
+  acmmMode?: string;
+  medianMergeMins?: number;
+  p90MergeMins?: number;
+  advisoryCount?: number;
+  advisoryItems?: AdvisoryItem[];
+  advisoryIssue?: number;
+}
+
+interface HiveConfig {
+  org: string;
+  primaryRepo: string;
+  repos: string[];
+  ai_author: string;
+  eval_interval_s: number;
+}
+
+interface DakotaStats {
+  stars: number;
+  forks: number;
+  openIssues: number;
+  openPRs: number;
+  ciStatus: "success" | "failure" | "pending" | "unknown";
+}
+
+interface QueueStats {
+  ready: number;
+  claimed: number;
+  p0: number;
+}
+
+interface HiveGovernorThresholds {
+  quiet?: number;
+  busy?: number;
+  surge?: number;
+}
+
+interface HiveGovernor {
+  mode?: string;
+  active?: boolean;
+  issues?: number;
+  prs?: number;
+  nextKick?: string;
+  thresholds?: HiveGovernorThresholds;
+}
+
+interface HiveBeads {
+  workers: number;
+  supervisor: number;
+}
+
+interface HiveCadenceRow {
+  agent: string;
+  surge: string;
+  busy: string;
+  quiet: string;
+  idle: string;
+}
+
+interface HiveHealthEntry {
+  status?: string;
+  passed?: boolean;
+  lastRun?: string;
+  name?: string;
+}
+
+interface MergedPR {
+  number: number;
+  title: string;
+  repo: string;
+  author: string;
+  isBot: boolean;
+  updatedAt: string;
+  url: string;
+}
+
+interface Velocity {
+  opened: number;
+  closed: number;
+}
+
+interface GitHubSearchResponse<T> {
+  total_count?: number;
+  items?: T[];
+}
+
+interface GitHubSearchIssueItem {
+  number: number;
+  title: string;
+  repository_url?: string;
+  pull_request?: { url?: string };
+  user?: { login?: string; type?: string };
+  updated_at: string;
+  html_url: string;
+}
+
+interface OrgStats {
+  totalRepos: number;
+  openIssues: number;
+  openPRs: number;
+  mergedThisWeek: number;
+  agentReadyIssues: number;
+  agentOpenPRs: number;
+  sourceAgentOpen: number;
+}
+
+interface RepoPRs {
+  repo: string;
+  total: number;
+  agentPRs: number;
+  label: string;
+}
+
+// ── Queue types ────────────────────────────────────────────────────────────
+
+interface QueueLabel { name: string; color: string; }
+
+interface QueueIssue {
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+  labels?: QueueLabel[];
+}
+
+interface QueuePR {
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+  labels?: QueueLabel[];
+  _reviews?: { approved: number; changes: number };
+}
+
+interface VictoryItem {
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+}
+
+interface VictoryCategory { count: number; recent: VictoryItem[]; }
+
+interface QueueData {
+  generated: string;
+  repos: string[];
+  issues: { p0: QueueIssue[]; p1: QueueIssue[] };
+  prs: { approved: QueuePR[]; required: QueuePR[]; none: QueuePR[] };
+  victories: {
+    startDate: string;
+    dreams: VictoryCategory;
+    relief: VictoryCategory;
+    toil: VictoryCategory;
+  };
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const SNAPSHOT_HTML_URL =
+  "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html";
+const QUEUE_URL = "https://queue.projectbluefin.io/data.json";
+const GH_API = "https://api.github.com";
+const DAKOTA = "projectbluefin/dakota";
+const BUILD_WORKFLOW = "246164114";
+const REFRESH_SECS = 300;
+
+const SEV_COLOR: Record<string, string> = {
+  high: "#f85149",
+  medium: "#d29922",
+  low: "#8b949e",
+};
+
+const TYPE_ICON: Record<string, string> = {
+  "ci-failure": "CI",
+  finding: ">>",
+  bug: "!",
+  feature: "+",
+  "coverage-gap": "cov",
+  security: "sec",
+  refactor: "ref",
+};
+
+const ACMM_LEVELS: Record<number, { label: string; desc: string; color: string }> = {
+  1: { label: "Triage Assist", desc: "Scanner reads and reports", color: "#8b949e" },
+  2: { label: "Advisory", desc: "Agents suggest, humans act", color: "#58a6ff" },
+  3: { label: "Supervised Autonomy", desc: "Agents act, supervisor monitors", color: "#d29922" },
+  4: { label: "Full Autonomy", desc: "Agents operate independently", color: "#f0883e" },
+  5: { label: "Self-Directing", desc: "Agents define their own goals", color: "#bc8cff" },
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseSnapshotJson(data: Record<string, unknown>): {
+  snapshot: HiveSnapshot | null;
+  config: HiveConfig | null;
+} {
+  try {
+    const agents = (data.agents as HiveAgent[]) ?? [];
+    const governor = (data.governor as HiveGovernor) ?? {};
+    const beads = isRecord(data.beads)
+      ? {
+          workers: typeof data.beads.workers === "number" ? data.beads.workers : 0,
+          supervisor: typeof data.beads.supervisor === "number" ? data.beads.supervisor : 0,
+        }
+      : undefined;
+    const cadenceMatrix = Array.isArray(data.cadenceMatrix)
+      ? (data.cadenceMatrix as HiveCadenceRow[])
+      : undefined;
+    const health = isRecord(data.health) ? data.health : undefined;
+    const agentMetrics = data.agentMetrics as { outreach?: { acmm?: number } } | undefined;
+    const issueToMerge = data.issueToMerge as {
+      avg_minutes?: number;
+      median_minutes?: number;
+      p90_minutes?: number;
+    } | undefined;
+    const advisoryItems = (data.advisoryItems as AdvisoryItem[]) ?? [];
+
+    const snapshot: HiveSnapshot = {
+      timestamp: (data.timestamp as string) ?? new Date().toISOString(),
+      hiveId: (data.hiveId as string) ?? "",
+      agents,
+      governor,
+      beads,
+      cadenceMatrix,
+      health,
+      acmmLevel: agentMetrics?.outreach?.acmm ?? undefined,
+      acmmMode: governor.mode,
+      medianMergeMins: issueToMerge?.median_minutes ?? issueToMerge?.avg_minutes,
+      p90MergeMins: issueToMerge?.p90_minutes,
+      advisoryCount: advisoryItems.length,
+      advisoryItems,
+      advisoryIssue: (data.advisoryIssue as number) ?? undefined,
+    };
+
+    const rawRepos = (data.repos as Array<{ full?: string; name?: string }>) ?? [];
+    const config: HiveConfig | null =
+      rawRepos.length > 0
+        ? {
+            org:
+              (data.hiveId as string ?? "").replace(/^hive-[^-]+-/, "") ||
+              "projectbluefin",
+            primaryRepo: rawRepos[0]?.full ?? "",
+            repos: rawRepos.map((r) => r.full ?? r.name ?? "").filter(Boolean),
+            ai_author: "",
+            eval_interval_s: 300,
+          }
+        : null;
+
+    return { snapshot, config };
+  } catch {
+    return { snapshot: null, config: null };
+  }
+}
+
+async function extractRenderJson(
+  html: string,
+): Promise<Record<string, unknown> | null> {
+  const idx = html.indexOf("render(");
+  if (idx === -1) return null;
+  const start = html.indexOf("{", idx);
+  if (start === -1) return null;
+  let depth = 0;
+  let inStr = false;
+  let strChar = "";
+  let escaped = false;
+  for (let i = start; i < html.length; i++) {
+    const ch = html[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === "\\" && inStr) { escaped = true; continue; }
+    if (inStr) { if (ch === strChar) inStr = false; continue; }
+    if (ch === '"' || ch === "'") { inStr = true; strChar = ch; continue; }
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(html.slice(start, i + 1)) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+async function fetchTimeout(url: string, ms = 12000): Promise<Response> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, { signal: ctrl.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function cleanSummaryLine(line: string): string {
+  return line
+    .replace(/^[-*>#\s]+/, "")
+    .replace(/\*\*/g, "")
+    .replace(/`/g, "")
+    .trim();
+}
+
+function meaningfulSummaryLines(raw: string, count = 2): string[] {
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .map(cleanSummaryLine)
+    .filter(
+      (l) =>
+        l.length > 15 &&
+        !/^(summary|status|update|working on|currently):/i.test(l),
+    )
+    .slice(0, count);
+}
+
+function firstMeaningfulLines(raw: string, count = 2): string {
+  return meaningfulSummaryLines(raw, count).join(" · ");
+}
+
+function relTime(ts?: string): string {
+  if (!ts) return "—";
+  try {
+    const diff = Math.max(Date.now() - new Date(ts).getTime(), 0);
+    const d = Math.floor(diff / 86400000);
+    const h = Math.floor(diff / 3600000);
+    const m = Math.floor(diff / 60000);
+    if (d > 0) return `${d}d ago`;
+    if (h > 0) return `${h}h ago`;
+    return `${m}m ago`;
+  } catch {
+    return "—";
+  }
+}
+
+function parseRepoName(...sources: Array<string | undefined>): string {
+  const source = sources.find(Boolean) ?? "";
+  const match = source.match(/\/repos\/[^/]+\/([^/]+)(?:\/|$)/);
+  if (match?.[1]) return match[1];
+  const parts = source.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? "repo";
+}
+
+function repoAccent(repo: string): string {
+  const palette = ["#58a6ff", "#3fb950", "#d29922", "#bc8cff", "#f85149", "#f0883e"];
+  const hash = Array.from(repo).reduce((sum, ch) => sum + ch.charCodeAt(0), 0);
+  return palette[hash % palette.length] ?? "#58a6ff";
+}
+
+function pickAgentOfDay(agents: HiveAgent[]): HiveAgent | null {
+  const working = agents
+    .filter((a) => a.state === "running" && a.busy === "working")
+    .sort(
+      (a, b) =>
+        (b.restarts ?? 0) - (a.restarts ?? 0) ||
+        new Date(b.lastKick ?? 0).getTime() - new Date(a.lastKick ?? 0).getTime(),
+    );
+  if (working[0]) return working[0];
+  return (
+    [...agents].sort(
+      (a, b) =>
+        new Date(b.lastKick ?? 0).getTime() - new Date(a.lastKick ?? 0).getTime(),
+    )[0] ?? null
+  );
+}
+
+function governorModeClass(mode?: string): string {
+  switch ((mode ?? "idle").toLowerCase()) {
+    case "surge": return styles.govModeSurge;
+    case "busy": return styles.govModeBusy;
+    case "quiet": return styles.govModeQuiet;
+    default: return styles.govModeIdle;
+  }
+}
+
+function healthTone(entry: unknown): "pass" | "fail" | "warn" {
+  if (!isRecord(entry)) return "warn";
+  const status = typeof entry.status === "string" ? entry.status.toLowerCase() : "";
+  if (status === "ok" || status === "pass" || entry.passed === true) return "pass";
+  if (status === "fail" || status === "error" || entry.passed === false) return "fail";
+  return "warn";
+}
+
+async function parseSearchCount(
+  result: PromiseSettledResult<Response>,
+): Promise<number> {
+  if (result.status !== "fulfilled" || !result.value.ok) return 0;
+  const data = (await result.value.json()) as GitHubSearchResponse<unknown>;
+  return data.total_count ?? 0;
+}
+
+async function parseMergedPRs(
+  result: PromiseSettledResult<Response>,
+): Promise<MergedPR[]> {
+  if (result.status !== "fulfilled" || !result.value.ok) return [];
+  const data = (await result.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
+  const items = Array.isArray(data.items) ? data.items : [];
+  return items.map((item) => ({
+    number: item.number,
+    title: item.title,
+    repo: parseRepoName(item.repository_url),
+    author: item.user?.login ?? "unknown",
+    isBot:
+      item.user?.type === "Bot" ||
+      (item.user?.login ?? "").includes("[bot]") ||
+      (item.user?.login ?? "").includes("renovate"),
+    updatedAt: item.updated_at,
+    url: item.html_url,
+  }));
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+function LivePulse() {
+  return (
+    <span className={styles.livePulse}>
+      <span className={styles.liveDot} />
+      LIVE
+    </span>
+  );
+}
+
+function HealthBar({ active, total }: { active: number; total: number }) {
+  const filled = total > 0 ? Math.round((active / total) * 10) : 0;
+  return (
+    <div className={styles.healthBar}>
+      {Array.from({ length: 10 }, (_, i) => (
+        <span
+          key={i}
+          className={`${styles.healthBarSegment} ${
+            i < filled ? styles.healthBarFilled : styles.healthBarEmpty
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: string;
+}) {
+  return (
+    <div className={styles.statCard}>
+      <div
+        className={styles.statValue}
+        style={accent ? { color: accent } : undefined}
+      >
+        {value}
+      </div>
+      <div className={styles.statLabel}>{label}</div>
+      {sub ? <div className={styles.statSub}>{sub}</div> : null}
+    </div>
+  );
+}
+
+function AgentCard({ agent }: { agent: HiveAgent }) {
+  const isRunning = agent.state === "running";
+  const isWorking = agent.busy === "working";
+  const snippet = firstMeaningfulLines(agent.liveSummary ?? "", 2);
+  const shortModel = (agent.model ?? "")
+    .replace("claude-", "")
+    .replace("gpt-", "")
+    .replace("-latest", "");
+
+  return (
+    <div
+      className={`${styles.agentCard} ${
+        isRunning ? styles.agentCardActive : styles.agentCardIdle
+      }`}
+    >
+      <div className={styles.agentCardHeader}>
+        <span className={styles.agentInitial}>
+          {(agent.displayName || agent.name).slice(0, 1).toUpperCase()}
+        </span>
+        <div className={styles.agentMeta}>
+          <span className={styles.agentName}>
+            {agent.displayName || agent.name}
+          </span>
+          <span className={styles.agentRole}>{agent.role}</span>
+        </div>
+        <span
+          className={`${styles.agentState} ${
+            isWorking
+              ? styles.agentStateWorking
+              : isRunning
+                ? styles.agentStateRunning
+                : styles.agentStatePaused
+          }`}
+        >
+          {isWorking ? "working" : isRunning ? "running" : "paused"}
+        </span>
+      </div>
+      {shortModel ? (
+        <div className={styles.agentModel}>{shortModel}</div>
+      ) : null}
+      {snippet ? (
+        <div className={styles.agentSummary}>{snippet}</div>
+      ) : null}
+      {agent.cadence ? (
+        <div className={styles.agentCadence}>{agent.cadence}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function CiBadge({ status }: { status: DakotaStats["ciStatus"] }) {
+  const map = {
+    success: { label: "CI PASS", cls: styles.ciBadgePass },
+    failure: { label: "CI FAIL", cls: styles.ciBadgeFail },
+    pending: { label: "CI PENDING", cls: styles.ciBadgePending },
+    unknown: { label: "CI UNKNOWN", cls: styles.ciBadgeUnknown },
+  };
+  const { label, cls } = map[status] ?? map.unknown;
+  return <span className={`${styles.ciBadge} ${cls}`}>{label}</span>;
+}
+
+function Sparkline({ data }: { data: number[] }) {
+  if (data.length < 2) return null;
+  const W = 120;
+  const H = 36;
+  const max = Math.max(...data, 1);
+  const pts = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * W;
+    const y = H - 6 - (v / max) * (H - 12);
+    return `${x},${y}`;
+  });
+  const linePts = pts.join(" ");
+  const area = `M ${pts[0]} L ${pts.slice(1).join(" L ")} L ${W},${H} L 0,${H} Z`;
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className={styles.sparkline}
+      aria-hidden="true"
+    >
+      <path d={area} className={styles.sparklineArea} />
+      <polyline points={linePts} className={styles.sparklineLine} />
+    </svg>
+  );
+}
+
+function _QueueBar({ ready, claimed, p0 }: QueueStats) {
+  const total = Math.max(ready + claimed, 1);
+  const claimedPct = (claimed / total) * 100;
+  const readyPct = (ready / total) * 100;
+  return (
+    <div className={styles.queueBar}>
+      <div className={styles.queueBarTrack}>
+        <div
+          className={styles.queueBarClaimed}
+          style={{ width: `${claimedPct}%` }}
+          title={`${claimed} claimed`}
+        />
+        <div
+          className={styles.queueBarReady}
+          style={{ width: `${readyPct}%` }}
+          title={`${ready} ready`}
+        />
+      </div>
+      <div className={styles.queueBarLegend}>
+        <span className={styles.queueClaimedLegend}>{claimed} claimed</span>
+        <span className={styles.queueReadyLegend}>{ready} ready</span>
+        {p0 > 0 && (
+          <span className={styles.queueP0Legend}>{p0} P0</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PrQueueChart({ data }: { data: RepoPRs[] }) {
+  const max = Math.max(...data.map((d) => d.total), 1);
+  return (
+    <div className={styles.prQueueChart}>
+      {data.map((d) => {
+        const pct = (d.total / max) * 100;
+        const agentPct = d.total > 0 ? (d.agentPRs / d.total) * 100 : 0;
+        return (
+          <div key={d.repo} className={styles.prQueueRow}>
+            <span className={styles.prQueueLabel}>{d.label}</span>
+            <div className={styles.prQueueTrack}>
+              <div
+                className={styles.prQueueHuman}
+                style={{ width: `${pct - agentPct * (pct / 100)}%` }}
+              />
+              <div
+                className={styles.prQueueAgent}
+                style={{ width: `${agentPct * (pct / 100)}%` }}
+              />
+            </div>
+            <span className={styles.prQueueCount}>{d.total}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MergedPRFeed({ prs }: { prs: MergedPR[] }) {
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Recently Merged
+      </Heading>
+      <p className={styles.panelMeta}>Latest merged PRs across projectbluefin</p>
+      {prs.length > 0 ? (
+        <div className={styles.feedList}>
+          {prs.slice(0, 10).map((pr) => {
+            const accent = repoAccent(pr.repo);
+            return (
+              <Link
+                key={`${pr.repo}-${pr.number}`}
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.feedItem}
+              >
+                <span
+                  className={styles.feedRepo}
+                  style={{ color: accent, borderColor: accent }}
+                >
+                  {pr.repo}
+                </span>
+                <span className={styles.feedTitle}>{pr.title.slice(0, 80)}</span>
+                <span className={styles.feedMeta}>
+                  {pr.isBot ? "[agent]" : pr.author} · {relTime(pr.updatedAt)}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <div className={styles.empty}>No recently merged pull requests found.</div>
+      )}
+    </section>
+  );
+}
+
+function ContributorWall({ prs }: { prs: MergedPR[] }) {
+  const humans: string[] = [];
+  for (const pr of prs) {
+    if (pr.isBot || humans.includes(pr.author)) continue;
+    humans.push(pr.author);
+    if (humans.length >= 20) break;
+  }
+  const botCount = prs.filter((pr) => pr.isBot).length;
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Contributor Wall
+      </Heading>
+      <p className={styles.panelMeta}>
+        Humans landing code in the latest merged queue
+      </p>
+      {humans.length > 0 ? (
+        <div className={styles.contributorGrid}>
+          {humans.map((login) => (
+            <Link
+              key={login}
+              href={`https://github.com/${login}`}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.contributorCard}
+            >
+              <img
+                src={`https://github.com/${login}.png?size=40`}
+                alt={login}
+                className={styles.contributorAvatar}
+                loading="lazy"
+              />
+              <span className={styles.contributorName}>{login}</span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.empty}>Agents are running the show</div>
+      )}
+      {botCount > 0 ? (
+        <div className={styles.botCountChip}>{botCount} agent PRs</div>
+      ) : null}
+    </section>
+  );
+}
+
+function VelocityPanel({
+  velocity,
+  p0,
+}: {
+  velocity: Velocity | null;
+  p0?: number;
+}) {
+  const opened = velocity?.opened ?? 0;
+  const closed = velocity?.closed ?? 0;
+  const net = opened - closed;
+  const deltaLabel =
+    net > 0
+      ? `up net +${net}`
+      : net < 0
+        ? `down net ${net}`
+        : "flat net 0";
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Issue Velocity
+      </Heading>
+      <p className={styles.panelMeta}>Issues · last 7 days · projectbluefin org</p>
+      <div className={styles.velocityRow}>
+        <div>
+          <div className={styles.velocityNum}>{opened}</div>
+          <div className={styles.miniLabel}>opened this week</div>
+        </div>
+        <div>
+          <div className={styles.velocityNum}>{closed}</div>
+          <div className={styles.miniLabel}>closed this week</div>
+        </div>
+      </div>
+      <div
+        className={`${styles.velocityDelta} ${
+          net > 0
+            ? styles.velocityDeltaUp
+            : net < 0
+              ? styles.velocityDeltaDown
+              : styles.velocityDeltaFlat
+        }`}
+      >
+        {deltaLabel}
+      </div>
+      {typeof p0 === "number" && p0 > 0 ? (
+        <div className={styles.p0Alert}>P0 unresolved: {p0}</div>
+      ) : null}
+    </section>
+  );
+}
+
+function GovernorPanel({ governor }: { governor?: HiveGovernor }) {
+  const mode = (governor?.mode ?? "idle").toUpperCase();
+  const issues = governor?.issues ?? 0;
+  const prs = governor?.prs ?? 0;
+  const depth = issues + prs;
+  const quiet = governor?.thresholds?.quiet ?? 0;
+  const busy = governor?.thresholds?.busy ?? Math.max(quiet + 1, depth, 1);
+  const surge = governor?.thresholds?.surge ?? Math.max(busy + 1, depth, 1);
+  const maxDepth = Math.max(surge, depth, 1);
+  const quietWidth = Math.max((quiet / maxDepth) * 100, 18);
+  const busyWidth = Math.max(((busy - quiet) / maxDepth) * 100, 18);
+  const surgeWidth = Math.max(100 - quietWidth - busyWidth, 18);
+  const markerLeft = Math.min((depth / maxDepth) * 100, 100);
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Governor
+      </Heading>
+      <div className={`${styles.govMode} ${governorModeClass(governor?.mode)}`}>
+        {mode}
+      </div>
+      <div className={styles.kv}>
+        <span>Queue depth</span>
+        <strong>
+          {issues} issues + {prs} PRs in queue
+        </strong>
+      </div>
+      <div className={styles.govThreshBar}>
+        <div
+          className={styles.govThreshZoneQuiet}
+          style={{ width: `${quietWidth}%` }}
+        >
+          QUIET
+        </div>
+        <div
+          className={styles.govThreshZoneBusy}
+          style={{ width: `${busyWidth}%` }}
+        >
+          BUSY
+        </div>
+        <div
+          className={styles.govThreshZoneSurge}
+          style={{ width: `${surgeWidth}%` }}
+        >
+          SURGE
+        </div>
+        <span
+          className={styles.govThreshMarker}
+          style={{ left: `calc(${markerLeft}% - 1px)` }}
+        />
+      </div>
+      <div className={styles.govThreshLegend}>
+        <span>Q &le; {quiet}</span>
+        <span>B &le; {busy}</span>
+        <span>S &ge; {surge}</span>
+      </div>
+      <p className={styles.panelMeta}>
+        Next kick: {" "}
+        {governor?.nextKick ? relTime(governor.nextKick) : "—"}
+      </p>
+    </section>
+  );
+}
+
+function BeadsCadencePanel({
+  beads,
+  cadenceMatrix,
+  mode,
+}: {
+  beads?: HiveBeads;
+  cadenceMatrix?: HiveCadenceRow[];
+  mode?: string;
+}) {
+  const currentMode = (mode ?? "idle").toLowerCase();
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Beads + Cadence
+      </Heading>
+      <div className={styles.beadsRow}>
+        <span>{beads?.workers ?? 0} worker tasks</span>
+        <span>{beads?.supervisor ?? 0} supervisor tasks</span>
+      </div>
+      {cadenceMatrix?.length ? (
+        <div className={styles.cadenceTable}>
+          <div className={`${styles.cadenceRow} ${styles.cadenceHeader}`}>
+            <span className={styles.cadenceCell}>Agent</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "surge" ? styles.cadenceCellActive : ""}`}>SURGE</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "busy" ? styles.cadenceCellActive : ""}`}>BUSY</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "quiet" ? styles.cadenceCellActive : ""}`}>QUIET</span>
+            <span className={`${styles.cadenceCell} ${currentMode === "idle" ? styles.cadenceCellActive : ""}`}>IDLE</span>
+          </div>
+          {cadenceMatrix.map((row) => (
+            <div key={row.agent} className={styles.cadenceRow}>
+              <span className={styles.cadenceCell}>{row.agent}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "surge" ? styles.cadenceCellActive : ""}`}>{row.surge}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "busy" ? styles.cadenceCellActive : ""}`}>{row.busy}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "quiet" ? styles.cadenceCellActive : ""}`}>{row.quiet}</span>
+              <span className={`${styles.cadenceCell} ${currentMode === "idle" ? styles.cadenceCellActive : ""}`}>{row.idle}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function AgentOfDay({ agent }: { agent: HiveAgent | null }) {
+  if (!agent) {
+    return (
+      <section className={`${styles.panel} ${styles.agentOfDayCard}`}>
+        <Heading as="h2" className={styles.panelTitle}>
+          Agent of the Day
+        </Heading>
+        <div className={styles.empty}>No agent spotlight available.</div>
+      </section>
+    );
+  }
+  const summaryLines = meaningfulSummaryLines(agent.liveSummary ?? "", 3);
+  return (
+    <section className={`${styles.panel} ${styles.agentOfDayCard}`}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Agent of the Day
+      </Heading>
+      <div className={styles.agentOfDayHero}>
+        <div className={styles.agentHeroInitial}>
+          {(agent.displayName || agent.name).slice(0, 1).toUpperCase()}
+        </div>
+        <div>
+          <div className={styles.agentOfDayLabel}>
+            {agent.busy === "working" ? "Currently active" : "Most recently active"}
+          </div>
+          <div className={styles.agentHeroName}>{agent.displayName || agent.name}</div>
+          <div className={styles.agentHeroMeta}>
+            {agent.role || "Generalist"} · {agent.model || "Unknown model"}
+          </div>
+        </div>
+      </div>
+      <div className={styles.agentOfDaySummary}>
+        {summaryLines.length > 0
+          ? summaryLines.map((line) => <div key={line}>{line}</div>)
+          : "Awaiting next assignment…"}
+      </div>
+    </section>
+  );
+}
+
+function FormationLog({
+  supervisor,
+  timestamp,
+}: {
+  supervisor: HiveAgent | null;
+  timestamp?: string;
+}) {
+  const lines = supervisor?.liveSummary
+    ? meaningfulSummaryLines(supervisor.liveSummary, 8)
+    : [];
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Formation Log
+      </Heading>
+      {lines.length > 0 ? (
+        <div className={styles.formationLogList}>
+          {lines.map((line, idx) => (
+            <div key={`${idx}-${line}`} className={styles.formationLogEntry}>
+              <span className={styles.formationLogStamp}>
+                {timestamp ? relTime(timestamp) : "recent"}
+              </span>
+              <span>{line}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.empty}>No formation log available</div>
+      )}
+    </section>
+  );
+}
+
+function HealthPanel({ health }: { health?: Record<string, unknown> }) {
+  const entries = Object.entries(health ?? {}).filter(
+    ([, value]) => value !== null && value !== undefined,
+  );
+  if (entries.length === 0) return null;
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Health Checks
+      </Heading>
+      <div className={styles.healthList}>
+        {entries.map(([key, raw]) => {
+          const tone = healthTone(raw);
+          const entry = isRecord(raw) ? (raw as HiveHealthEntry) : {};
+          return (
+            <div key={key} className={styles.healthItem}>
+              <span
+                className={`${styles.healthDot} ${
+                  tone === "pass"
+                    ? styles.healthDotPass
+                    : tone === "fail"
+                      ? styles.healthDotFail
+                      : styles.healthDotWarn
+                }`}
+              />
+              <span>{entry.name || key}</span>
+              <span className={styles.feedMeta}>
+                {entry.lastRun
+                  ? relTime(entry.lastRun)
+                  : entry.status || "status unknown"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function AgentWorkLog({
+  agents,
+  items,
+  advisoryIssue,
+  config,
+}: {
+  agents: HiveAgent[];
+  items: AdvisoryItem[];
+  advisoryIssue?: number;
+  config: HiveConfig | null;
+}) {
+  const [expanded, setExpanded] = React.useState<string | null>(null);
+  const byAgent: Record<string, AdvisoryItem[]> = {};
+  for (const item of items) {
+    if (!byAgent[item.agent]) byAgent[item.agent] = [];
+    byAgent[item.agent].push(item);
+  }
+  for (const key of Object.keys(byAgent)) {
+    byAgent[key].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+  }
+
+  function repoFromTitle(title: string): string | null {
+    const m = title.match(
+      /\b(knuckle|documentation|testsuite|dakota|dakota-iso|website|bootc-installer)\b/i,
+    );
+    return m ? m[1] : null;
+  }
+
+  const org = config?.org ?? "projectbluefin";
+
+  return (
+    <div className={styles.workLog}>
+      {agents.map((agent) => {
+        const agentItems = byAgent[agent.name] ?? [];
+        const isExpandedAgent = expanded === agent.name;
+        const visible = isExpandedAgent ? agentItems : agentItems.slice(0, 3);
+        const repos = [
+          ...new Set(
+            agentItems.map((i) => repoFromTitle(i.title)).filter(Boolean),
+          ),
+        ];
+        return (
+          <div key={agent.id} className={styles.workLogAgent}>
+            <div className={styles.workLogHeader}>
+              <div className={styles.workLogAgentMeta}>
+                <span className={styles.workLogName}>{agent.displayName}</span>
+                {repos.length > 0 && (
+                  <div className={styles.workLogRepos}>
+                    {repos.map((r) => (
+                      <Link
+                        key={r}
+                        href={`https://github.com/${org}/${r}`}
+                        className={styles.workLogRepoChip}
+                      >
+                        {r}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <span className={styles.workLogCount}>{agentItems.length} items</span>
+            </div>
+            {visible.length > 0 && (
+              <div className={styles.workLogItems}>
+                {visible.map((item, i) => {
+                  const icon = TYPE_ICON[item.type] ?? "?";
+                  const color = SEV_COLOR[item.severity] ?? "#8b949e";
+                  const repo = repoFromTitle(item.title);
+                  return (
+                    <div key={i} className={styles.workLogItem}>
+                      <span className={styles.workLogIcon}>{icon}</span>
+                      <div className={styles.workLogItemBody}>
+                        <span className={styles.workLogTitle}>
+                          {item.title.slice(0, 110)}
+                        </span>
+                        <div className={styles.workLogMeta}>
+                          <span className={styles.workLogSev} style={{ color }}>
+                            {item.severity}
+                          </span>
+                          <span className={styles.workLogType}>{item.type}</span>
+                          {repo && (
+                            <Link
+                              href={`https://github.com/${org}/${repo}`}
+                              className={styles.workLogRepo}
+                            >
+                              {repo}
+                            </Link>
+                          )}
+                          <span className={styles.workLogTime}>
+                            {relTime(item.timestamp)}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+                {agentItems.length > 3 && (
+                  <button
+                    className={styles.workLogToggle}
+                    onClick={() =>
+                      setExpanded(isExpandedAgent ? null : agent.name)
+                    }
+                  >
+                    {isExpandedAgent
+                      ? "Show less"
+                      : `Show ${agentItems.length - 3} more`}
+                  </button>
+                )}
+              </div>
+            )}
+            {agentItems.length === 0 && (
+              <div className={styles.workLogEmpty}>No advisory items yet</div>
+            )}
+          </div>
+        );
+      })}
+      {advisoryIssue != null && (
+        <div className={styles.workLogFooter}>
+          <Link
+            href={`https://github.com/${org}/knuckle/issues/${advisoryIssue}`}
+            className={styles.workLogDigestLink}
+          >
+            View full advisory digest (issue #{advisoryIssue}) &rarr;
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OrgStatsPanel({ stats }: { stats: OrgStats }) {
+  const agentTotal =
+    stats.agentReadyIssues + stats.agentOpenPRs + stats.sourceAgentOpen;
+  return (
+    <div className={styles.orgGrid}>
+      <div className={styles.orgOverview}>
+        <Heading as="h2" className={styles.panelTitle}>
+          projectbluefin Org
+        </Heading>
+        <div className={styles.orgStats}>
+          <div className={styles.orgStat}>
+            <span className={styles.orgStatValue}>{stats.totalRepos}</span>
+            <span className={styles.orgStatLabel}>repos</span>
+          </div>
+          <div className={styles.orgStatDivider} />
+          <div className={styles.orgStat}>
+            <span className={styles.orgStatValue}>{stats.openIssues}</span>
+            <span className={styles.orgStatLabel}>open issues</span>
+          </div>
+          <div className={styles.orgStatDivider} />
+          <div className={styles.orgStat}>
+            <span className={styles.orgStatValue}>{stats.openPRs}</span>
+            <span className={styles.orgStatLabel}>open PRs</span>
+          </div>
+          <div className={styles.orgStatDivider} />
+          <div className={styles.orgStat}>
+            <span className={styles.orgStatValue} style={{ color: "#3fb950" }}>
+              {stats.mergedThisWeek}
+            </span>
+            <span className={styles.orgStatLabel}>merged this week</span>
+          </div>
+        </div>
+      </div>
+      <div className={styles.orgAgentActivity}>
+        <Heading as="h2" className={styles.panelTitle}>
+          Agent Activity
+        </Heading>
+        <div className={styles.orgAgentRows}>
+          <Link
+            href="https://github.com/issues?q=org%3Aprojectbluefin+label%3Aqueue%2Fagent-ready+state%3Aopen"
+            className={styles.orgAgentRow}
+          >
+            <span className={styles.orgAgentRowDot} style={{ background: "#3fb950" }} />
+            <span className={styles.orgAgentRowLabel}>Agent-ready</span>
+            <span className={styles.orgAgentRowCount} style={{ color: "#3fb950" }}>
+              {stats.agentReadyIssues}
+            </span>
+            <span className={styles.orgAgentRowSub}>issues awaiting pickup</span>
+          </Link>
+          <Link
+            href="https://github.com/issues?q=org%3Aprojectbluefin+author%3Akubestellar-hive%5Bbot%5D+state%3Aopen+type%3Apr"
+            className={styles.orgAgentRow}
+          >
+            <span className={styles.orgAgentRowDot} style={{ background: "#58a6ff" }} />
+            <span className={styles.orgAgentRowLabel}>Agent PRs open</span>
+            <span className={styles.orgAgentRowCount} style={{ color: "#58a6ff" }}>
+              {stats.agentOpenPRs}
+            </span>
+            <span className={styles.orgAgentRowSub}>awaiting review</span>
+          </Link>
+          <Link
+            href="https://github.com/issues?q=org%3Aprojectbluefin+label%3Asource%3Aagent+state%3Aopen"
+            className={styles.orgAgentRow}
+          >
+            <span className={styles.orgAgentRowDot} style={{ background: "#f59e0b" }} />
+            <span className={styles.orgAgentRowLabel}>Agent-sourced</span>
+            <span className={styles.orgAgentRowCount} style={{ color: "#f59e0b" }}>
+              {stats.sourceAgentOpen}
+            </span>
+            <span className={styles.orgAgentRowSub}>open items</span>
+          </Link>
+          <div className={styles.orgAgentTotal}>
+            <span>{agentTotal} total agent-tracked items across the org</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── New: Guardians column ──────────────────────────────────────────────────
+
+function GuardiansColumn({ prs }: { prs: QueueData["prs"] | null }) {
+  if (!prs) {
+    return (
+      <div className={`${styles.destinyCol} ${styles.guardiansCol}`}>
+        <div>
+          <p className={styles.destinyColTitle + " " + styles.guardiansColTitle}>Guardians</p>
+          <p className={styles.destinyColSubtitle}>Human contributor pull requests</p>
+        </div>
+        <div className={styles.empty}>Loading…</div>
+      </div>
+    );
+  }
+
+  const tiers: Array<{
+    key: keyof QueueData["prs"];
+    label: string;
+    labelCls: string;
+    items: QueuePR[];
+  }> = [
+    { key: "approved", label: "APPROVED", labelCls: styles.prTierLabelApproved, items: prs.approved },
+    { key: "required", label: "NEEDS REVIEW", labelCls: styles.prTierLabelRequired, items: prs.required },
+    { key: "none", label: "NO REVIEWS", labelCls: styles.prTierLabelNone, items: prs.none },
+  ];
+
+  return (
+    <div className={`${styles.destinyCol} ${styles.guardiansCol}`}>
+      <div>
+        <p className={styles.destinyColTitle + " " + styles.guardiansColTitle}>Guardians</p>
+        <p className={styles.destinyColSubtitle}>Human contributor pull requests — the Light we carry</p>
+      </div>
+      {tiers.map(({ key, label, labelCls, items }) => (
+        <div key={key} className={styles.prTier}>
+          <div className={styles.prTierHeader}>
+            <span className={`${styles.prTierLabel} ${labelCls}`}>{label}</span>
+            <span className={styles.prTierCount}>{items.length}</span>
+          </div>
+          {items.length === 0 ? (
+            <div className={styles.prTierEmpty}>None</div>
+          ) : (
+            items.slice(0, 8).map((pr, i) => {
+              const repo = parseRepoName(pr.repository_url);
+              const approvals = pr._reviews?.approved ?? 0;
+              return (
+                <Link
+                  key={i}
+                  href={pr.html_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.prCard}
+                >
+                  <span className={styles.prCardTitle}>
+                    {pr.title.slice(0, 80)}
+                  </span>
+                  <div className={styles.prCardMeta}>
+                    <span className={styles.prCardRepo}>{repo}</span>
+                    {approvals > 0 && (
+                      <span className={styles.prCardApprovals}>
+                        {approvals} approved
+                      </span>
+                    )}
+                    <span className={styles.prCardAge}>{relTime(pr.updated_at)}</span>
+                  </div>
+                </Link>
+              );
+            })
+          )}
+          {items.length > 8 && (
+            <div className={styles.prTierEmpty}>
+              +{items.length - 8} more &mdash; {" "}
+              <Link href="https://queue.projectbluefin.io/">see all</Link>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── New: Ghosts column ─────────────────────────────────────────────────────
+
+function GhostsColumn({ issues }: { issues: QueueData["issues"] | null }) {
+  if (!issues) {
+    return (
+      <div className={`${styles.destinyCol} ${styles.ghostsCol}`}>
+        <div>
+          <p className={styles.destinyColTitle + " " + styles.ghostsColTitle}>Ghosts</p>
+          <p className={styles.destinyColSubtitle}>Agent-driven issues and work queue</p>
+        </div>
+        <div className={styles.empty}>Loading…</div>
+      </div>
+    );
+  }
+
+  const SKIP_LABEL_PREFIXES = ["hive/", "priority/", "queue/"];
+
+  function visibleLabels(labels?: QueueLabel[]): QueueLabel[] {
+    return (labels ?? []).filter(
+      (l) => !SKIP_LABEL_PREFIXES.some((p) => l.name.startsWith(p)),
+    );
+  }
+
+  const tiers: Array<{
+    key: keyof QueueData["issues"];
+    label: string;
+    labelCls: string;
+    items: QueueIssue[];
+  }> = [
+    { key: "p0", label: "P0", labelCls: styles.issueTierLabelP0, items: issues.p0 },
+    { key: "p1", label: "P1", labelCls: styles.issueTierLabelP1, items: issues.p1 },
+  ];
+
+  return (
+    <div className={`${styles.destinyCol} ${styles.ghostsCol}`}>
+      <div>
+        <p className={styles.destinyColTitle + " " + styles.ghostsColTitle}>Ghosts</p>
+        <p className={styles.destinyColSubtitle}>Agent-driven issues — the machines at work</p>
+      </div>
+      {tiers.map(({ key, label, labelCls, items }) => (
+        <div key={key} className={styles.prTier}>
+          <div className={styles.prTierHeader}>
+            <span className={`${styles.prTierLabel} ${labelCls}`}>{label}</span>
+            <span className={styles.prTierCount}>{items.length}</span>
+          </div>
+          {items.length === 0 ? (
+            <div className={styles.prTierEmpty}>
+              {key === "p0" ? "No blockers" : "Queue clear"}
+            </div>
+          ) : (
+            items.slice(0, 8).map((issue, i) => {
+              const repo = parseRepoName(issue.repository_url);
+              const lbls = visibleLabels(issue.labels).slice(0, 3);
+              return (
+                <Link
+                  key={i}
+                  href={issue.html_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.issueCard}
+                >
+                  <span className={styles.issueCardTitle}>
+                    {issue.title.slice(0, 80)}
+                  </span>
+                  <div className={styles.issueCardMeta}>
+                    <span className={styles.issueCardRepo}>{repo}</span>
+                    {lbls.map((l) => (
+                      <span
+                        key={l.name}
+                        className={styles.issueLabel}
+                        style={{
+                          background: `#${l.color}22`,
+                          color: `#${l.color}`,
+                          border: `1px solid #${l.color}44`,
+                        }}
+                      >
+                        {l.name}
+                      </span>
+                    ))}
+                    <span className={styles.issueCardAge}>
+                      {relTime(issue.updated_at)}
+                    </span>
+                  </div>
+                </Link>
+              );
+            })
+          )}
+          {items.length > 8 && (
+            <div className={styles.prTierEmpty}>+{items.length - 8} more</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── New: Victory Log ───────────────────────────────────────────────────────
+
+function VictoryLog({
+  victories,
+}: {
+  victories: QueueData["victories"] | null;
+}) {
+  if (!victories) return null;
+
+  const cols: Array<{
+    key: keyof Omit<QueueData["victories"], "startDate">;
+    label: string;
+    labelCls: string;
+    data: VictoryCategory;
+  }> = [
+    { key: "dreams", label: "FEATURES", labelCls: styles.victoryCategoryFeatures, data: victories.dreams },
+    { key: "relief", label: "FIXED", labelCls: styles.victoryCategoryFixed, data: victories.relief },
+    { key: "toil", label: "AUTOMATED", labelCls: styles.victoryCategoryAutomated, data: victories.toil },
+  ];
+
+  return (
+    <div className={styles.victoryLog}>
+      <div className={styles.victoryLogHeader}>
+        <p className={styles.victoryLogTitle}>This Cycle</p>
+        <p className={styles.victoryLogSubtitle}>
+          Since {victories.startDate} &mdash; what the factory has shipped
+        </p>
+      </div>
+      <div className={styles.victoryColumns}>
+        {cols.map(({ key, label, labelCls, data }) => (
+          <div key={key} className={styles.victoryCol}>
+            <div className={styles.victoryColHeader}>
+              <span className={`${styles.victoryCategoryLabel} ${labelCls}`}>
+                {label}
+              </span>
+              <span className={styles.victoryCount}>{data.count}</span>
+              <span className={styles.victoryCountSub}>this cycle</span>
+            </div>
+            <div className={styles.victoryList}>
+              {data.recent.slice(0, 5).map((item, i) => {
+                const repo = parseRepoName(item.repository_url);
+                return (
+                  <Link
+                    key={i}
+                    href={item.html_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={styles.victoryItem}
+                  >
+                    <span className={styles.victoryItemTitle}>
+                      {item.title.slice(0, 72)}
+                    </span>
+                    <div className={styles.victoryItemMeta}>
+                      <span className={styles.victoryItemRepo}>{repo}</span>
+                      <span className={styles.victoryItemAge}>
+                        {relTime(item.updated_at)}
+                      </span>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function HiveFactoryDashboard(): React.JSX.Element {
+  const [snapshot, setSnapshot] = useState<HiveSnapshot | null>(null);
+  const [config, setConfig] = useState<HiveConfig | null>(null);
+  const [dakotaStats, setDakotaStats] = useState<DakotaStats | null>(null);
+  const [queue, setQueue] = useState<QueueStats | null>(null);
+  const [queueData, setQueueData] = useState<QueueData | null>(null);
+  const [commits, setCommits] = useState<number[]>([]);
+  const [orgStats, setOrgStats] = useState<OrgStats | null>(null);
+  const [repoPRs, setRepoPRs] = useState<RepoPRs[]>([]);
+  const [mergedPRs, setMergedPRs] = useState<MergedPR[]>([]);
+  const [velocity, setVelocity] = useState<Velocity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [refreshIn, setRefreshIn] = useState(REFRESH_SECS);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const weekAgoISO = new Date(Date.now() - 7 * 24 * 3600 * 1000)
+        .toISOString()
+        .slice(0, 10);
+
+      const [
+        htmlRes,
+        queueRes,
+        repoRes,
+        ciRes,
+        commitsRes,
+        mergedRes,
+        openedRes,
+        closedRes,
+      ] = await Promise.allSettled([
+        fetchTimeout(SNAPSHOT_HTML_URL),
+        fetchTimeout(QUEUE_URL),
+        fetchTimeout(`${GH_API}/repos/${DAKOTA}`),
+        fetchTimeout(
+          `${GH_API}/repos/${DAKOTA}/actions/workflows/${BUILD_WORKFLOW}/runs?per_page=1&status=completed`,
+        ),
+        fetchTimeout(`${GH_API}/repos/${DAKOTA}/stats/participation`),
+        fetchTimeout(
+          `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged&sort=updated&per_page=15`,
+        ),
+        fetchTimeout(
+          `${GH_API}/search/issues?q=org:projectbluefin+type:issue+created:>${weekAgoISO}&per_page=1`,
+        ),
+        fetchTimeout(
+          `${GH_API}/search/issues?q=org:projectbluefin+type:issue+closed:>${weekAgoISO}&per_page=1`,
+        ),
+      ]);
+
+      // Hive snapshot from embedded HTML
+      if (htmlRes.status === "fulfilled" && htmlRes.value.ok) {
+        const html = await htmlRes.value.text();
+        const data = await extractRenderJson(html);
+        if (data) {
+          const { snapshot: snap, config: cfg } = parseSnapshotJson(data);
+          if (snap) setSnapshot(snap);
+          if (cfg) setConfig(cfg);
+        }
+      }
+
+      // Queue data
+      if (queueRes.status === "fulfilled" && queueRes.value.ok) {
+        const qd = (await queueRes.value.json()) as QueueData;
+        setQueueData(qd);
+        // Derive legacy queue stats for QueueBar
+        const p0Count = qd.issues.p0.length;
+        const agentReady = qd.issues.p1.filter((i) =>
+          (i.labels ?? []).some((l) => l.name === "queue/agent-ready"),
+        ).length;
+        setQueue({ ready: agentReady, claimed: 0, p0: p0Count });
+      }
+
+      setMergedPRs(await parseMergedPRs(mergedRes));
+      const opened = await parseSearchCount(openedRes);
+      const closed = await parseSearchCount(closedRes);
+      setVelocity({ opened, closed });
+
+      // Repo stats + CI
+      if (repoRes.status === "fulfilled" && repoRes.value.ok) {
+        const repo = (await repoRes.value.json()) as {
+          stargazers_count: number;
+          forks_count: number;
+          open_issues_count: number;
+        };
+        let ciStatus: DakotaStats["ciStatus"] = "unknown";
+        if (ciRes.status === "fulfilled" && ciRes.value.ok) {
+          const ciData = (await ciRes.value.json()) as {
+            workflow_runs?: Array<{ conclusion?: string | null }>;
+          };
+          const run = ciData.workflow_runs?.[0];
+          if (run) {
+            ciStatus =
+              run.conclusion === "success"
+                ? "success"
+                : run.conclusion === "failure"
+                  ? "failure"
+                  : "pending";
+          }
+        }
+        let openPRs = 0;
+        try {
+          const prRes = await fetchTimeout(
+            `${GH_API}/search/issues?q=repo:${DAKOTA}+type:pr+state:open`,
+          );
+          if (prRes.ok) {
+            const prData =
+              (await prRes.json()) as GitHubSearchResponse<unknown>;
+            openPRs = prData.total_count ?? 0;
+          }
+        } catch {
+          /* non-fatal */
+        }
+        setDakotaStats({
+          stars: repo.stargazers_count,
+          forks: repo.forks_count,
+          openIssues: repo.open_issues_count,
+          openPRs,
+          ciStatus,
+        });
+      }
+
+      // Commit sparkline
+      if (commitsRes.status === "fulfilled" && commitsRes.value.ok) {
+        const commitData =
+          (await commitsRes.value.json()) as { all?: number[] };
+        if (Array.isArray(commitData.all))
+          setCommits(commitData.all.slice(-12));
+      }
+
+      // Org-wide stats
+      try {
+        const weekAgo = new Date(Date.now() - 7 * 86400000)
+          .toISOString()
+          .slice(0, 10);
+        const orgQueries: [string, string][] = [
+          ["openIssues", `org:projectbluefin+state:open+type:issue`],
+          ["openPRs", `org:projectbluefin+state:open+type:pr`],
+          ["mergedThisWeek", `org:projectbluefin+type:pr+merged:>${weekAgo}`],
+          ["agentReadyIssues", `org:projectbluefin+label:queue%2Fagent-ready+state:open`],
+          ["agentOpenPRs", `org:projectbluefin+author:kubestellar-hive%5Bbot%5D+state:open+type:pr`],
+          ["sourceAgentOpen", `org:projectbluefin+label:source%3Aagent+state:open`],
+        ];
+        const orgRepoRes = await fetchTimeout(`${GH_API}/orgs/projectbluefin`);
+        const orgRepo = orgRepoRes.ok ? ((await orgRepoRes.json()) as { public_repos?: number }) : {};
+        const counts: Record<string, number> = {};
+        for (const [key, q] of orgQueries) {
+          try {
+            const res = await fetchTimeout(
+              `${GH_API}/search/issues?q=${q}&per_page=1`,
+            );
+            if (res.ok) {
+              const d = (await res.json()) as GitHubSearchResponse<unknown>;
+              counts[key] = d.total_count ?? 0;
+            } else {
+              counts[key] = 0;
+            }
+          } catch {
+            counts[key] = 0;
+          }
+        }
+        setOrgStats({
+          totalRepos: orgRepo.public_repos ?? 0,
+          openIssues: counts.openIssues ?? 0,
+          openPRs: counts.openPRs ?? 0,
+          mergedThisWeek: counts.mergedThisWeek ?? 0,
+          agentReadyIssues: counts.agentReadyIssues ?? 0,
+          agentOpenPRs: counts.agentOpenPRs ?? 0,
+          sourceAgentOpen: counts.sourceAgentOpen ?? 0,
+        });
+      } catch {
+        /* non-fatal */
+      }
+
+      // Per-repo PR breakdown
+      const HIVE_REPOS = [
+        "knuckle",
+        "documentation",
+        "testsuite",
+        "dakota",
+        "dakota-iso",
+      ];
+      const HIVE_BOT = "kubestellar-hive[bot]";
+      const prResults = await Promise.allSettled(
+        HIVE_REPOS.map((r) =>
+          fetchTimeout(
+            `${GH_API}/repos/projectbluefin/${r}/pulls?state=open&per_page=100`,
+          ),
+        ),
+      );
+      const rPRs: RepoPRs[] = [];
+      for (let i = 0; i < HIVE_REPOS.length; i++) {
+        const res = prResults[i];
+        if (res.status === "fulfilled" && res.value.ok) {
+          const prs = (await res.value.json()) as Array<{
+            user: { login: string };
+          }>;
+          rPRs.push({
+            repo: HIVE_REPOS[i],
+            total: prs.length,
+            agentPRs: prs.filter((p) => p.user.login === HIVE_BOT).length,
+            label: HIVE_REPOS[i],
+          });
+        }
+      }
+      setRepoPRs(rPRs);
+    } finally {
+      setLoading(false);
+      setLastUpdated(new Date());
+      setRefreshIn(REFRESH_SECS);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchAll();
+    const iv = setInterval(() => void fetchAll(), REFRESH_SECS * 1000);
+    return () => clearInterval(iv);
+  }, [fetchAll]);
+
+  useEffect(() => {
+    const t = setInterval(
+      () => setRefreshIn((n) => (n > 0 ? n - 1 : REFRESH_SECS)),
+      1000,
+    );
+    return () => clearInterval(t);
+  }, []);
+
+  // Derived state
+  const agents = snapshot?.agents ?? [];
+  const advisoryItems = snapshot?.advisoryItems ?? [];
+  const activeAgents = agents.filter((a) => a.state === "running");
+  const workingAgents = activeAgents.filter((a) => a.busy === "working");
+  const repos = config?.repos ?? [];
+  const agentOfDay = pickAgentOfDay(agents);
+  const supervisorAgent =
+    agents.find(
+      (a) =>
+        a.role?.toLowerCase().includes("supervisor") ||
+        a.name.toLowerCase().includes("supervisor"),
+    ) ?? null;
+  const hasHealth = Boolean(
+    snapshot?.health && Object.keys(snapshot.health).length > 0,
+  );
+
+  let formation = "Formation broken";
+  let formationColor = "#f85149";
+  if (activeAgents.length >= Math.ceil(agents.length * 0.6)) {
+    formation = "Formation coherent";
+    formationColor = "#3fb950";
+  } else if (activeAgents.length >= 1) {
+    formation = "Coverage reduced";
+    formationColor = "#d29922";
+  }
+
+  const totalCommits = commits.reduce((a, b) => a + b, 0);
+  const p0Count = queueData?.issues.p0.length ?? 0;
+  const p1Count = queueData?.issues.p1.length ?? 0;
+  const prsNeedingReview =
+    (queueData?.prs.required.length ?? 0) + (queueData?.prs.none.length ?? 0);
+
+  if (loading) {
+    return (
+      <Layout
+        title="The Bluefin Operating System Factory"
+        description="Community Driven Agentic OS Development — live AI agent dashboard for projectbluefin"
+      >
+        <div className={styles.dashboard}>
+          <div className={styles.loadingWrap}>
+            <div className={styles.loadingText}>
+              Connecting to the factory…
+            </div>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout
+      title="The Bluefin Operating System Factory"
+      description="Community Driven Agentic OS Development — live AI agent dashboard for projectbluefin"
+    >
+      <div className={styles.dashboard}>
+        {/* Hero */}
+        <header className={styles.hero}>
+          <div className={styles.heroLeft}>
+            <div className={styles.heroTitle}>
+              <div>
+                <Heading as="h1" className={styles.heroH1}>
+                  The Bluefin Operating System Factory
+                </Heading>
+                <p className={styles.heroSub}>
+                  Community Driven Agentic OS Development &mdash; live AI agent
+                  dashboard for{" "}
+                  <Link
+                    href="https://github.com/projectbluefin"
+                    className={styles.heroLink}
+                  >
+                    projectbluefin
+                  </Link>
+                </p>
+              </div>
+            </div>
+            {agents.length > 0 && (
+              <div className={styles.formationRow}>
+                <HealthBar
+                  active={activeAgents.length}
+                  total={agents.length}
+                />
+                <span
+                  className={styles.formationLabel}
+                  style={{ color: formationColor }}
+                >
+                  {formation} &middot; {activeAgents.length}/{agents.length}{" "}
+                  active
+                  {workingAgents.length > 0 && (
+                    <> &middot; {workingAgents.length} working</>
+                  )}
+                </span>
+              </div>
+            )}
+          </div>
+          <div className={styles.heroRight}>
+            <LivePulse />
+            {snapshot?.acmmMode && (
+              <span
+                className={`${styles.modeBadge} ${
+                  snapshot.acmmMode === "SURGE"
+                    ? styles.modeSurge
+                    : styles.modeNormal
+                }`}
+              >
+                {snapshot.acmmMode}
+              </span>
+            )}
+            {dakotaStats && <CiBadge status={dakotaStats.ciStatus} />}
+          </div>
+        </header>
+
+        {/* Stats strip */}
+        <div className={styles.statsRow}>
+          {p0Count > 0 && (
+            <StatCard
+              label="P0 Blockers"
+              value={p0Count}
+              accent="#f85149"
+            />
+          )}
+          <StatCard label="P1 This Cycle" value={p1Count} />
+          <StatCard
+            label="Agents"
+            value={`${activeAgents.length}/${agents.length}`}
+            sub={
+              workingAgents.length > 0
+                ? `${workingAgents.length} working`
+                : "standing by"
+            }
+            accent={formationColor}
+          />
+          {prsNeedingReview > 0 && (
+            <StatCard
+              label="PRs Need Review"
+              value={prsNeedingReview}
+              accent="#d97706"
+            />
+          )}
+          {queueData && (
+            <StatCard
+              label="Approved PRs"
+              value={queueData.prs.approved.length}
+              sub="ready to merge"
+              accent="#3fb950"
+            />
+          )}
+          {queueData && (
+            <StatCard
+              label="Shipped This Cycle"
+              value={
+                (queueData.victories.dreams.count ?? 0) +
+                (queueData.victories.relief.count ?? 0)
+              }
+              sub="features + fixes"
+              accent="#3fb950"
+            />
+          )}
+          {repos.length > 0 && (
+            <StatCard label="Repos" value={repos.length} sub="in formation" />
+          )}
+          {snapshot?.medianMergeMins != null && (
+            <StatCard
+              label="Merge Time"
+              value={
+                snapshot.medianMergeMins < 60
+                  ? `${snapshot.medianMergeMins}m`
+                  : `${Math.round((snapshot.medianMergeMins / 60) * 10) / 10}h`
+              }
+              sub="median PR cycle"
+              accent="#39d2c0"
+            />
+          )}
+          {snapshot?.acmmLevel != null && (() => {
+            const info =
+              ACMM_LEVELS[snapshot.acmmLevel!] ?? {
+                label: "Unknown",
+                desc: "",
+                color: "#8b949e",
+              };
+            return (
+              <StatCard
+                label="ACMM Level"
+                value={`L${snapshot.acmmLevel}`}
+                sub={info.label}
+                accent={info.color}
+              />
+            );
+          })()}
+        </div>
+
+        {/* Guardians / Ghosts */}
+        <div className={styles.destinyColumns}>
+          <GuardiansColumn prs={queueData?.prs ?? null} />
+          <GhostsColumn issues={queueData?.issues ?? null} />
+        </div>
+
+        {/* Victory Log */}
+        <VictoryLog victories={queueData?.victories ?? null} />
+
+        {/* Governor */}
+        <GovernorPanel governor={snapshot?.governor} />
+
+        {/* Commit activity + What agents are doing */}
+        <div className={styles.twoCol}>
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>
+              Commit Activity
+            </Heading>
+            <p className={styles.panelMeta}>
+              Last 12 weeks &middot; projectbluefin/dakota
+            </p>
+            {commits.length > 1 ? (
+              <div className={styles.sparkWrap}>
+                <Sparkline data={commits} />
+                <div className={styles.sparkLabels}>
+                  <span>12 weeks ago</span>
+                  <span className={styles.sparkTotal}>
+                    {totalCommits} commits
+                  </span>
+                  <span>now</span>
+                </div>
+                <div className={styles.sparkBar}>
+                  {commits.map((v, i) => {
+                    const max = Math.max(...commits, 1);
+                    const h = Math.max((v / max) * 40, v > 0 ? 3 : 1);
+                    return (
+                      <div
+                        key={i}
+                        className={styles.sparkBarItem}
+                        style={{ height: `${h}px` }}
+                        title={`Week ${i + 1}: ${v} commits`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <div className={styles.empty}>Fetching data…</div>
+            )}
+          </section>
+
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>
+              What Agents Are Doing
+            </Heading>
+            {workingAgents.length > 0 ? (
+              <div className={styles.activityList}>
+                {workingAgents.map((a) => {
+                  const snippet = firstMeaningfulLines(a.liveSummary ?? "", 3);
+                  if (!snippet) return null;
+                  return (
+                    <div key={a.id} className={styles.activityItem}>
+                      <span className={styles.activityInitial}>
+                        {(a.displayName || a.name)
+                          .slice(0, 1)
+                          .toUpperCase()}
+                      </span>
+                      <div>
+                        <div className={styles.activityAgent}>
+                          {a.displayName}
+                        </div>
+                        <div className={styles.activityText}>
+                          {snippet.slice(0, 180)}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className={styles.empty}>
+                {agents.length > 0
+                  ? "Agents are between tasks"
+                  : "No agent data — snapshot updating"}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Agent formation */}
+        {agents.length > 0 && (
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>
+              Agent Formation
+            </Heading>
+            <div className={styles.agentGrid}>
+              {agents.map((a) => (
+                <AgentCard key={a.id} agent={a} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Agent work log */}
+        {advisoryItems.length > 0 && (
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>
+              What Agents Are Working On
+            </Heading>
+            <p className={styles.panelMeta}>
+              Advisory digest — findings, bugs, CI failures logged by each agent
+            </p>
+            <AgentWorkLog
+              agents={agents}
+              items={advisoryItems}
+              advisoryIssue={snapshot?.advisoryIssue}
+              config={config}
+            />
+          </section>
+        )}
+
+        {/* PR queue chart */}
+        {repoPRs.length > 0 && (
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>PR Queue</Heading>
+            <p className={styles.panelMeta}>
+              Open pull requests across formation repos &middot; [agent] = hive
+              agent authored
+            </p>
+            <PrQueueChart data={repoPRs} />
+          </section>
+        )}
+
+        {/* Merged + Contributors */}
+        <div className={styles.twoCol}>
+          <MergedPRFeed prs={mergedPRs} />
+          <ContributorWall prs={mergedPRs} />
+        </div>
+
+        {/* Velocity + Org stats */}
+        <div className={styles.twoCol}>
+          <VelocityPanel velocity={velocity} p0={queue?.p0} />
+          {orgStats ? (
+            <section className={styles.panel}>
+              <OrgStatsPanel stats={orgStats} />
+            </section>
+          ) : null}
+        </div>
+
+        {/* Beads + Agent of Day */}
+        <div className={styles.twoCol}>
+          <BeadsCadencePanel
+            beads={snapshot?.beads}
+            cadenceMatrix={snapshot?.cadenceMatrix}
+            mode={snapshot?.governor?.mode}
+          />
+          <AgentOfDay agent={agentOfDay} />
+        </div>
+
+        {/* Formation log */}
+        <FormationLog
+          supervisor={supervisorAgent}
+          timestamp={snapshot?.timestamp}
+        />
+
+        {hasHealth ? <HealthPanel health={snapshot?.health} /> : null}
+
+        {/* About */}
+        <section className={styles.panel}>
+          <Heading as="h2" className={styles.panelTitle}>
+            About the Factory
+          </Heading>
+          <div className={styles.aboutGrid}>
+            <div className={styles.aboutText}>
+              <p>
+                Project Bluefin is built and maintained by this formation.
+                Autonomous agents triage issues, write fixes, review pull
+                requests, and keep CI green — around the clock, across every
+                repository in the formation.
+              </p>
+              <p>
+                <strong>Hive</strong> is an open-source AI agent orchestration
+                system by Andy Anderson. The system implements the{" "}
+                <Link href="https://arxiv.org/abs/2604.09388">
+                  AI Codebase Maturity Model
+                </Link>{" "}
+                (ACMM) — a framework from AI-assisted coding to fully autonomous
+                development.
+              </p>
+              <p>
+                No one has ever built an agentic OS like this before. This
+                dashboard is the control surface.
+              </p>
+              <div className={styles.aboutLinks}>
+                <Link href="https://kubestellar.io/live/hive/bluefin/">
+                  Full Hive Dashboard
+                </Link>
+                <Link href={`https://github.com/${DAKOTA}`}>Dakota Repo</Link>
+                <Link href="https://github.com/kubestellar/hive">Hive Project</Link>
+                <Link href="https://arxiv.org/abs/2604.09388">
+                  ACMM Paper
+                </Link>
+                <Link href="https://www.cncf.io/blog/2026/05/14/when-ai-agents-become-contributors-how-kubestellar-reached-81-pr-acceptance/">
+                  CNCF Blog
+                </Link>
+              </div>
+            </div>
+            <div className={styles.agentRoles}>
+              {[
+                { n: "Supervisor", d: "Monitors all agents, detects stalls" },
+                { n: "Scanner", d: "Triages issues, dispatches fixes" },
+                { n: "Reviewer", d: "Code review, quality checks" },
+                { n: "Architect", d: "Cross-cutting RFCs, new features" },
+                { n: "Outreach", d: "Community engagement, coverage tracking" },
+              ].map(({ n, d }) => (
+                <div key={n} className={styles.roleRow}>
+                  <span className={styles.roleName}>{n}</span>
+                  <span className={styles.roleDesc}>{d}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <footer className={styles.dashFooter}>
+          <div className={styles.footerLeft}>
+            {lastUpdated && (
+              <span>
+                Updated {lastUpdated.toLocaleTimeString()} &middot; Next refresh
+                in {Math.floor(refreshIn / 60)}:
+                {String(refreshIn % 60).padStart(2, "0")}
+              </span>
+            )}
+          </div>
+          <div className={styles.footerRight}>
+            Data:{" "}
+            <Link href="https://kubestellar.io/live/hive/bluefin/">
+              Hive snapshot
+            </Link>{" "}
+            +{" "}
+            <Link href="https://queue.projectbluefin.io/">
+              queue.projectbluefin.io
+            </Link>{" "}
+            +{" "}
+            <Link href="https://docs.github.com/en/rest">GitHub API</Link>
+          </div>
+        </footer>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/hive.tsx
+++ b/src/pages/hive.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import HiveDashboard from "../components/HiveDashboard";
+import HiveFactoryDashboard from "../components/HiveFactoryDashboard";
 
 export default function HivePage(): React.JSX.Element {
-  return <HiveDashboard />;
+  return <HiveFactoryDashboard />;
 }


### PR DESCRIPTION
## The Bluefin Operating System Factory

Adds `/hive/` — a unified dashboard replacing both `hive.projectbluefin.io` and `queue.projectbluefin.io`.

Closes #916 (conflict-free rebase of that PR).

### Data sources

- **Hive snapshot**: `raw.githubusercontent.com/kubestellar/docs` `index.html` — parses the embedded `render({...})` JSON with a brace-counting extractor
- **Queue data**: `queue.projectbluefin.io/data.json` — live PRs and hive issues
- **GitHub API**: commit sparklines, CI status, merged PRs, org velocity

### Features

- **Guardians column** (warm amber): human contributor PRs bucketed by review state
- **Ghosts column** (sapphire): hive P0 blockers, P1 items, and agent-ready queue
- **Victory Log**: dreams/relief/toil achievements with sparkline history
- Hive agent health cards, formation ACMM level, governor panel
- Merged PR feed, contributor wall, velocity metrics
- 300s auto-refresh countdown
- Dark OS-factory aesthetic, no emojis, Destiny lore

### Changes

- `src/pages/hive.tsx` — updated to use new `HiveFactoryDashboard` component
- `src/components/HiveFactoryDashboard.tsx` — 2139-line main component
- `src/components/HiveFactoryDashboard.module.css` — 1819-line stylesheet
- `docusaurus.config.ts` — CSP adds `queue.projectbluefin.io` to `connect-src`

### Validation

- TypeScript: 0 errors in src/
- ESLint: 0 errors
- Dev server: compiled and serving at `/hive/` (HTTP 200)