### PR TITLE
feat(hive): contributor leaderboard with weekly/monthly milestones

### DIFF
--- a/scripts/fetch-hive-history.js
+++ b/scripts/fetch-hive-history.js
@@ -4,15 +4,31 @@
  *
  * Runs every 2 hours via update-hive-cache.yml.
  * Appends a snapshot of key Hive metrics to static/data/hive-history.json.
- * Also refreshes all-time contributor stats from every active factory repo.
+ * Refreshes all-time contributor counts once per day (contributors endpoint).
+ * Refreshes weekly contributor stats once per day (stats/contributors endpoint).
  *
  * History file format:
  * {
  *   "entries": [ { t, acmmLevel, govMode, budgetPct, queue, agents, advisories,
  *                  mergedToday, mergedWeek, runningAgents } ... ],
+ *
+ *   // All-time totals from /contributors endpoint
  *   "contributors": { "login": totalCommits, ... },
  *   "contributorsByRepo": { "repo": { "login": commits } },
- *   "lastContributorFetch": "ISO timestamp"
+ *   "lastContributorFetch": "ISO timestamp",
+ *
+ *   // Weekly breakdown from /stats/contributors endpoint
+ *   // Enables monthly/weekly leaderboard windows
+ *   "contributorStats": {
+ *     "login": {
+ *       "total": 5680,
+ *       "lastWeek": 12,        // commits in last 7 days
+ *       "lastMonth": 45,       // commits in last 28 days (4 weeks)
+ *       "last3Months": 150,    // commits in last 91 days (13 weeks)
+ *       "byRepo": { "repo": commits }
+ *     }
+ *   },
+ *   "lastWeeklyStatsFetch": "ISO timestamp"
  * }
  */
 
@@ -26,8 +42,11 @@ const OUTPUT_FILE = path.join(__dirname, "../static/data/hive-history.json");
 // 14 days at one entry per 2h = 168 entries
 const MAX_ENTRIES = 168;
 
-// Refresh contributor stats at most once every 6 hours
-const CONTRIBUTOR_TTL_MS = 6 * 60 * 60 * 1000;
+// Refresh all-time contributor counts once per day
+const CONTRIBUTOR_TTL_MS = 24 * 60 * 60 * 1000;
+
+// Refresh weekly stats once per day (stats/contributors is expensive: 1 req/repo)
+const WEEKLY_STATS_TTL_MS = 24 * 60 * 60 * 1000;
 
 // All active factory repos
 const FACTORY_REPOS = [
@@ -224,6 +243,92 @@ async function fetchContributors() {
   return { totals, byRepo };
 }
 
+/**
+ * Fetch weekly contributor stats via /repos/{owner}/{repo}/stats/contributors.
+ * Returns lastWeek / lastMonth / last3Months windows per contributor.
+ *
+ * The endpoint may return 202 while GitHub computes stats. We retry up to 3 times
+ * with a 2-second back-off per repo.
+ *
+ * Returns: { [login]: { total, lastWeek, lastMonth, last3Months, byRepo: { repo: commits } } }
+ */
+async function fetchContributorWeeklyStats() {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const weekAgo = nowSec - 7 * 86400;
+  const monthAgo = nowSec - 28 * 86400;  // 4 weeks
+  const threeMonthsAgo = nowSec - 91 * 86400;  // 13 weeks
+
+  // stats[login] = { total, lastWeek, lastMonth, last3Months, byRepo }
+  const stats = {};
+
+  await Promise.allSettled(
+    FACTORY_REPOS.map(async (repo) => {
+      const url = `${GH_API}/repos/projectbluefin/${repo}/stats/contributors`;
+      let attempts = 0;
+      let data = null;
+      while (attempts < 4) {
+        attempts++;
+        let res;
+        try {
+          res = await fetch(url, { headers: ghHeaders() });
+        } catch {
+          break;
+        }
+        if (res.status === 404 || res.status === 403 || res.status === 204) break;
+        if (res.status === 202) {
+          // GitHub is computing stats — wait and retry
+          await new Promise((r) => setTimeout(r, 2000 * attempts));
+          continue;
+        }
+        if (!res.ok) break;
+        try {
+          data = await res.json();
+        } catch {
+          break;
+        }
+        break;
+      }
+      if (!Array.isArray(data)) return;
+
+      for (const entry of data) {
+        const login = entry?.author?.login;
+        if (!login) continue;
+        if (login.endsWith("[bot]") || BOT_LOGINS.has(login)) continue;
+        const total = typeof entry.total === "number" ? entry.total : 0;
+        if (total === 0) continue;
+
+        // Sum weekly commit counts for each time window
+        let lastWeek = 0;
+        let lastMonth = 0;
+        let last3Months = 0;
+        if (Array.isArray(entry.weeks)) {
+          for (const w of entry.weeks) {
+            const wt = typeof w.w === "number" ? w.w : 0;
+            const wc = typeof w.c === "number" ? w.c : 0;
+            if (wc === 0) continue;
+            if (wt >= weekAgo) lastWeek += wc;
+            if (wt >= monthAgo) lastMonth += wc;
+            if (wt >= threeMonthsAgo) last3Months += wc;
+          }
+        }
+
+        if (!stats[login]) {
+          stats[login] = { total: 0, lastWeek: 0, lastMonth: 0, last3Months: 0, byRepo: {} };
+        }
+        stats[login].total += total;
+        stats[login].lastWeek += lastWeek;
+        stats[login].lastMonth += lastMonth;
+        stats[login].last3Months += last3Months;
+        if (total > 0) {
+          stats[login].byRepo[repo] = (stats[login].byRepo[repo] || 0) + total;
+        }
+      }
+    })
+  );
+
+  return stats;
+}
+
 function loadHistory() {
   try {
     if (fs.existsSync(OUTPUT_FILE)) {
@@ -236,7 +341,9 @@ function loadHistory() {
     entries: [],
     contributors: {},
     contributorsByRepo: {},
+    contributorStats: {},
     lastContributorFetch: null,
+    lastWeeklyStatsFetch: null,
   };
 }
 
@@ -247,6 +354,7 @@ async function main() {
   if (!Array.isArray(history.entries)) history.entries = [];
   if (!history.contributors) history.contributors = {};
   if (!history.contributorsByRepo) history.contributorsByRepo = {};
+  if (!history.contributorStats) history.contributorStats = {};
 
   // ── Fetch hive snapshot ──────────────────────────────────────────────────
   let metrics = null;
@@ -279,14 +387,14 @@ async function main() {
     );
   }
 
-  // ── Refresh contributor stats if stale ───────────────────────────────────
+  // ── Refresh all-time contributor counts (daily) ───────────────────────────
   const lastFetch = history.lastContributorFetch
     ? new Date(history.lastContributorFetch).getTime()
     : 0;
   const needsContributorRefresh = Date.now() - lastFetch > CONTRIBUTOR_TTL_MS;
 
   if (needsContributorRefresh) {
-    console.log("[hive-history] Fetching contributor stats from factory repos...");
+    console.log("[hive-history] Fetching all-time contributor counts from factory repos...");
     try {
       const { totals, byRepo } = await fetchContributors();
       history.contributors = totals;
@@ -301,7 +409,31 @@ async function main() {
       console.warn(`[hive-history] Contributor fetch failed: ${err.message}`);
     }
   } else {
-    console.log("[hive-history] Contributor stats still fresh, skipping fetch");
+    console.log("[hive-history] All-time contributor counts still fresh, skipping");
+  }
+
+  // ── Refresh weekly contributor stats (daily) ─────────────────────────────
+  const lastWeeklyFetch = history.lastWeeklyStatsFetch
+    ? new Date(history.lastWeeklyStatsFetch).getTime()
+    : 0;
+  const needsWeeklyRefresh = Date.now() - lastWeeklyFetch > WEEKLY_STATS_TTL_MS;
+
+  if (needsWeeklyRefresh) {
+    console.log("[hive-history] Fetching weekly contributor stats (stats/contributors)...");
+    try {
+      const stats = await fetchContributorWeeklyStats();
+      history.contributorStats = stats;
+      history.lastWeeklyStatsFetch = new Date().toISOString();
+      const count = Object.keys(stats).length;
+      const activeThisWeek = Object.values(stats).filter((s) => s.lastWeek > 0).length;
+      console.log(
+        `[hive-history] Weekly stats: ${count} contributors, ${activeThisWeek} active this week`,
+      );
+    } catch (err) {
+      console.warn(`[hive-history] Weekly stats fetch failed: ${err.message}`);
+    }
+  } else {
+    console.log("[hive-history] Weekly contributor stats still fresh, skipping");
   }
 
   // ── Write output ─────────────────────────────────────────────────────────

--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -2221,3 +2221,190 @@
   font-style: italic;
   padding: 0.2rem 0;
 }
+
+/* ── Contributor Leaderboard ─────────────────────────────────────────────── */
+
+.lbTabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #21262d;
+  padding-bottom: 0.5rem;
+}
+
+.lbTab {
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.75rem;
+  font-family: inherit;
+  padding: 0.3rem 0.9rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.lbTab:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+
+.lbTabActive {
+  border-color: #d29922;
+  color: #d29922;
+  background: rgba(210, 153, 34, 0.1);
+}
+
+.lbTable {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  font-size: 0.8rem;
+}
+
+.lbHeader {
+  display: grid;
+  grid-template-columns: 2rem 1fr 6rem 10rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.3rem 0.5rem;
+  color: #484f58;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid #21262d;
+  margin-bottom: 0.25rem;
+}
+
+.lbRow {
+  display: grid;
+  grid-template-columns: 2rem 1fr 6rem 10rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: #c9d1d9;
+  transition: background 0.12s;
+}
+
+.lbRow:hover {
+  background: #161b22;
+  text-decoration: none;
+  color: #c9d1d9;
+}
+
+.lbColRank {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.7rem;
+  color: #484f58;
+  text-align: right;
+}
+
+.lbTopRank {
+  color: #d29922;
+  font-weight: 700;
+}
+
+.lbColUser {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.lbAvatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid #21262d;
+}
+
+.lbLogin {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #58a6ff;
+}
+
+.lbColCommits {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.lbCommitCount {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.82rem;
+  color: #c9d1d9;
+  font-weight: 600;
+}
+
+.lbDelta {
+  font-size: 0.68rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.lbDeltaUp {
+  color: #3fb950;
+}
+
+.lbDeltaDown {
+  color: #f85149;
+}
+
+.lbColRepos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.lbRepoChip {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 4px;
+  color: #8b949e;
+  white-space: nowrap;
+}
+
+.lbRepoMore {
+  font-size: 0.65rem;
+  color: #484f58;
+}
+
+.lbColBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.lbBadge {
+  font-size: 0.62rem;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid;
+  border-radius: 20px;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .lbHeader,
+  .lbRow {
+    grid-template-columns: 2rem 1fr 5rem;
+  }
+
+  .lbColRepos,
+  .lbColBadges {
+    display: none;
+  }
+}

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -209,14 +209,84 @@ interface OrgContributor {
   repos: string[];
 }
 
+interface ContributorStat {
+  total: number;
+  lastWeek: number;
+  lastMonth: number;
+  last3Months: number;
+  byRepo: Record<string, number>;
+}
+
 interface HiveHistory {
   entries: HiveHistoryEntry[];
   contributors: Record<string, number>;
   contributorsByRepo: Record<string, Record<string, number>>;
   lastContributorFetch?: string;
+  // Weekly windowed stats (populated by stats/contributors endpoint)
+  contributorStats?: Record<string, ContributorStat>;
+  lastWeeklyStatsFetch?: string;
 }
 
-// ── Queue types ────────────────────────────────────────────────────────────
+// ── Milestone badge definitions ───────────────────────────────────────────
+
+type MilestoneTier =
+  | "contributor"   // 10+ all-time commits
+  | "veteran"       // 100+ all-time commits
+  | "elite"         // 500+ all-time commits
+  | "legend"        // 1000+ all-time commits
+  | "mythic"        // 5000+ all-time commits
+  | "sprint"        // 10+ commits this week
+  | "rising"        // this week > rolling avg
+  | "cross";        // 3+ repos
+
+interface MilestoneBadge {
+  tier: MilestoneTier;
+  label: string;
+  title: string;
+  color: string;
+}
+
+function computeMilestones(
+  total: number,
+  lastWeek: number,
+  lastMonth: number,
+  repos: string[],
+): MilestoneBadge[] {
+  const badges: MilestoneBadge[] = [];
+
+  // All-time tier (only show the highest earned)
+  if (total >= 5000) {
+    badges.push({ tier: "mythic", label: "Mythic", title: "5000+ lifetime commits", color: "#ff7b72" });
+  } else if (total >= 1000) {
+    badges.push({ tier: "legend", label: "Legend", title: "1000+ lifetime commits", color: "#f0883e" });
+  } else if (total >= 500) {
+    badges.push({ tier: "elite", label: "Elite", title: "500+ lifetime commits", color: "#bc8cff" });
+  } else if (total >= 100) {
+    badges.push({ tier: "veteran", label: "Veteran", title: "100+ lifetime commits", color: "#58a6ff" });
+  } else if (total >= 10) {
+    badges.push({ tier: "contributor", label: "Contributor", title: "10+ lifetime commits", color: "#3fb950" });
+  }
+
+  // Activity badges
+  if (lastWeek >= 10) {
+    badges.push({ tier: "sprint", label: "Sprint", title: `${lastWeek} commits this week`, color: "#d29922" });
+  }
+
+  // Weekly vs monthly avg (rising star)
+  const weeklyAvg = lastMonth > 0 ? lastMonth / 4 : 0;
+  if (lastWeek > 0 && weeklyAvg > 0 && lastWeek > weeklyAvg * 1.5) {
+    badges.push({ tier: "rising", label: "Rising", title: "Trending up this week", color: "#3fb950" });
+  }
+
+  // Cross-formation
+  if (repos.length >= 3) {
+    badges.push({ tier: "cross", label: "Multi-repo", title: `Active in ${repos.length} repos`, color: "#a371f7" });
+  }
+
+  return badges;
+}
+
+
 
 interface QueueLabel { name: string; color: string; }
 
@@ -1298,6 +1368,191 @@ function HistoryTrends({ history }: { history: HiveHistory | null }) {
   );
 }
 
+// ── Contributor Leaderboard ───────────────────────────────────────────────
+
+type LeaderboardTab = "alltime" | "monthly" | "weekly";
+
+interface LeaderboardEntry {
+  rank: number;
+  login: string;
+  commits: number;
+  delta?: number;      // change vs previous window (weekly only)
+  repos: string[];
+  badges: MilestoneBadge[];
+  hasStats: boolean;
+}
+
+function ContributorLeaderboard({ history }: { history: HiveHistory | null }) {
+  const [tab, setTab] = React.useState<LeaderboardTab>("alltime");
+
+  const hasWeeklyStats =
+    history?.contributorStats != null &&
+    Object.keys(history.contributorStats).length > 0;
+
+  const ranked = React.useMemo((): LeaderboardEntry[] => {
+    if (!history) return [];
+
+    const stats = history.contributorStats ?? {};
+    const allTimeMap = history.contributors ?? {};
+    const byRepo = history.contributorsByRepo ?? {};
+
+    // Build a unified map of all known contributors
+    const allLogins = new Set([...Object.keys(stats), ...Object.keys(allTimeMap)]);
+    const rows: LeaderboardEntry[] = [];
+
+    for (const login of allLogins) {
+      const s = stats[login];
+      const allTime = s?.total ?? allTimeMap[login] ?? 0;
+      const lastWeek = s?.lastWeek ?? 0;
+      const lastMonth = s?.lastMonth ?? 0;
+      const last3Months = s?.last3Months ?? 0;
+
+      let commits = 0;
+      if (tab === "alltime") commits = allTime;
+      else if (tab === "monthly") commits = lastMonth;
+      else commits = lastWeek;
+
+      if (commits === 0) continue;
+
+      // Repos from stats.byRepo or contributorsByRepo
+      const repoMap = s?.byRepo ?? {};
+      const repos = Object.keys(
+        Object.keys(repoMap).length > 0
+          ? repoMap
+          : Object.fromEntries(
+              Object.entries(byRepo)
+                .filter(([, rc]) => rc[login] != null)
+                .map(([r, rc]) => [r, rc[login]])
+            ),
+      ).sort((a, b) => {
+        const ma = (repoMap[a] ?? byRepo[a]?.[login] ?? 0);
+        const mb = (repoMap[b] ?? byRepo[b]?.[login] ?? 0);
+        return mb - ma;
+      });
+
+      // Delta: for weekly tab, this week vs weekly avg of last month
+      let delta: number | undefined;
+      if (tab === "weekly" && lastMonth > 0) {
+        const avg = lastMonth / 4;
+        delta = Math.round(lastWeek - avg);
+      } else if (tab === "monthly" && last3Months > 0) {
+        const avg = last3Months / 3;
+        delta = Math.round(lastMonth - avg);
+      }
+
+      rows.push({
+        rank: 0,
+        login,
+        commits,
+        delta,
+        repos,
+        badges: computeMilestones(allTime, lastWeek, lastMonth, repos),
+        hasStats: s != null,
+      });
+    }
+
+    rows.sort((a, b) => b.commits - a.commits);
+    rows.forEach((r, i) => { r.rank = i + 1; });
+    return rows.slice(0, 25);
+  }, [history, tab]);
+
+  if (!history || ranked.length === 0) return null;
+
+  const lastUpdated = history.lastWeeklyStatsFetch
+    ? new Date(history.lastWeeklyStatsFetch).toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    : null;
+
+  return (
+    <section className={styles.panel}>
+      <Heading as="h2" className={styles.panelTitle}>
+        Contributor Leaderboard
+      </Heading>
+      <p className={styles.panelMeta}>
+        Factory-wide commit rankings across all 15 repos
+        {lastUpdated ? ` · stats as of ${lastUpdated}` : ""}
+        {!hasWeeklyStats ? " · weekly/monthly windows accumulating" : ""}
+      </p>
+
+      <div className={styles.lbTabs}>
+        {(["alltime", "monthly", "weekly"] as LeaderboardTab[]).map((t) => (
+          <button
+            key={t}
+            className={`${styles.lbTab} ${tab === t ? styles.lbTabActive : ""}`}
+            onClick={() => setTab(t)}
+          >
+            {t === "alltime" ? "All Time" : t === "monthly" ? "This Month" : "This Week"}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.lbTable}>
+        <div className={styles.lbHeader}>
+          <span className={styles.lbColRank}>#</span>
+          <span className={styles.lbColUser}>Contributor</span>
+          <span className={styles.lbColCommits}>Commits</span>
+          <span className={styles.lbColRepos}>Repos</span>
+          <span className={styles.lbColBadges}>Milestones</span>
+        </div>
+        {ranked.map(({ rank, login, commits, delta, repos, badges }) => (
+          <Link
+            key={login}
+            href={`https://github.com/${login}`}
+            target="_blank"
+            rel="noreferrer"
+            className={styles.lbRow}
+          >
+            <span className={`${styles.lbColRank} ${rank <= 3 ? styles.lbTopRank : ""}`}>
+              {rank === 1 ? "01" : rank === 2 ? "02" : rank === 3 ? "03" : String(rank).padStart(2, "0")}
+            </span>
+            <span className={styles.lbColUser}>
+              <img
+                src={`https://github.com/${login}.png?size=24`}
+                alt={login}
+                className={styles.lbAvatar}
+                loading="lazy"
+              />
+              <span className={styles.lbLogin}>{login}</span>
+            </span>
+            <span className={styles.lbColCommits}>
+              <span className={styles.lbCommitCount}>
+                {commits >= 1000 ? `${(commits / 1000).toFixed(1)}k` : commits}
+              </span>
+              {delta != null && delta !== 0 && (
+                <span className={`${styles.lbDelta} ${delta > 0 ? styles.lbDeltaUp : styles.lbDeltaDown}`}>
+                  {delta > 0 ? `+${delta}` : delta}
+                </span>
+              )}
+            </span>
+            <span className={styles.lbColRepos}>
+              {repos.slice(0, 3).map((r) => (
+                <span key={r} className={styles.lbRepoChip}>{r}</span>
+              ))}
+              {repos.length > 3 && <span className={styles.lbRepoMore}>+{repos.length - 3}</span>}
+            </span>
+            <span className={styles.lbColBadges}>
+              {badges.map((b) => (
+                <span
+                  key={b.tier}
+                  className={styles.lbBadge}
+                  style={{ borderColor: b.color, color: b.color }}
+                  title={b.title}
+                >
+                  {b.label}
+                </span>
+              ))}
+            </span>
+          </Link>
+        ))}
+      </div>
+
+      {ranked.length >= 25 && (
+        <p className={styles.panelMeta} style={{ marginTop: "0.5rem" }}>
+          Showing top 25 of {Object.keys(history.contributors ?? {}).length} contributors
+        </p>
+      )}
+    </section>
+  );
+}
 
 function VelocityPanel({
   velocity,
@@ -2669,6 +2924,7 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         <MergedPRFeed prs={mergedPRs} />
         <ContributorWall prs={mergedPRs} history={hiveHistory} />
         <HistoryTrends history={hiveHistory} />
+        <ContributorLeaderboard history={hiveHistory} />
 
         {/* Velocity + Org stats */}
         <div className={styles.twoCol}>


### PR DESCRIPTION
Adds a full contributor leaderboard to the Bluefin Operating System Factory dashboard.

## What's new

**Contributor Leaderboard panel** (below Factory Trends):
- Three tabs: All Time / This Month / This Week  
- Top 25 ranked contributors with avatar, commit count, active repos, and milestone badges
- Milestone tiers: Contributor (10+), Veteran (100+), Elite (500+), Legend (1000+), Mythic (5000+) all-time commits
- Activity badges: Sprint (10+ this week), Rising (trending above 4-week avg), Multi-repo (3+ repos)
- Delta indicator vs rolling average on weekly/monthly tabs
- Graceful fallback to all-time view while weekly stats accumulate (GitHub stats API is async)
- Mobile responsive

**Data pipeline (fetch-hive-history.js)**:
- New `fetchContributorWeeklyStats()` using GitHub `/stats/contributors` endpoint (52-week weekly history per contributor)
- Computes `lastWeek`, `lastMonth`, `last3Months` windows from raw weekly data
- 202-retry logic with backoff (GitHub computes these stats async on cold cache)
- Separate 24h TTL from all-time counts
- New `contributorStats` and `lastWeeklyStatsFetch` fields in hive-history.json schema

Weekly stats will start appearing after the next few CI runs warm up the GitHub stats cache.