### PR TITLE
feat(dakota): add Alpha 3 ISO to downloads testing page

### DIFF
--- a/src/components/DownloadSectionTesting.tsx
+++ b/src/components/DownloadSectionTesting.tsx
@@ -26,6 +26,17 @@ export const DakotaSection: React.FC = () => (
     ]}
     sections={[
       {
+        label: "Alpha 3",
+        entries: [
+          {
+            label: "AMD / Intel",
+            isoUrl: `${BASE}/dakota-live-alpha3.iso`,
+            isoFilename: "dakota-live-alpha3.iso",
+            checksumUrl: `${BASE}/dakota-live-alpha3.iso-CHECKSUM`,
+          },
+        ],
+      },
+      {
         label: "Alpha 2",
         entries: [
           {


### PR DESCRIPTION
## What

Adds the Dakota Alpha 3 named release to the ISO testing downloads page.

- AMD/Intel entry added under a new **Alpha 3** section
- No Nvidia variant for Alpha 3 yet (not built)
- Alpha 2 entries preserved for reference

## URL

https://projectbluefin.dev/dakota-live-alpha3.iso

---

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alpha 3 release download option for AMD and Intel architectures, including checksum files for verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->