### PR TITLE
feat(hive): governor meter to top, accurate marker, new stats strip cards

### DIFF
--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -1428,14 +1428,40 @@
 .govModeBusy { color: #d29922; background: rgba(210, 153, 34, 0.12); }
 .govModeQuiet { color: #58a6ff; background: rgba(88, 166, 255, 0.12); }
 .govModeIdle { color: #8b949e; background: rgba(139, 148, 158, 0.12); }
+.govThreshOuter {
+  position: relative;
+  margin-top: 0.9rem;
+  padding-top: 1.5rem; /* room for the floating depth label */
+}
+.govThreshMarkerLabel {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.govThreshMarkerLabel::after {
+  content: "";
+  display: block;
+  width: 0;
+  height: 0;
+  margin: 2px auto 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+}
 .govThreshBar {
   position: relative;
   display: flex;
   align-items: stretch;
   overflow: hidden;
   border-radius: 999px;
-  margin-top: 0.9rem;
+  margin-top: 0; /* spacing now handled by govThreshOuter */
   border: 1px solid rgba(139, 148, 158, 0.2);
+  height: 28px; /* taller bar for better readability */
 }
 .govThreshZoneQuiet,
 .govThreshZoneBusy,
@@ -1445,17 +1471,19 @@
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.06em;
+  overflow: hidden;
+  white-space: nowrap;
 }
 .govThreshZoneQuiet { background: rgba(88, 166, 255, 0.14); color: #58a6ff; }
 .govThreshZoneBusy { background: rgba(210, 153, 34, 0.14); color: #d29922; }
 .govThreshZoneSurge { background: rgba(248, 81, 73, 0.14); color: #f85149; }
 .govThreshMarker {
   position: absolute;
-  top: -2px;
-  bottom: -2px;
-  width: 2px;
-  background: #f0f6fc;
-  box-shadow: 0 0 0 1px rgba(13, 17, 23, 0.6);
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  transform: translateX(-50%);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.6);
 }
 .govThreshLegend {
   display: flex;

--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -1720,6 +1720,66 @@
   border: 1px solid rgba(139, 148, 158, 0.2);
 }
 
+.prTierLabelEpic {
+  background: rgba(217, 119, 6, 0.15);
+  color: #d97706;
+  border: 1px solid rgba(217, 119, 6, 0.35);
+}
+
+.prTierLabelAgent {
+  background: rgba(147, 197, 253, 0.12);
+  color: #93c5fd;
+  border: 1px solid rgba(147, 197, 253, 0.25);
+}
+
+.agentTypeBadgeHive {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(217, 119, 6, 0.15);
+  color: #d97706;
+  border: 1px solid rgba(217, 119, 6, 0.3);
+  text-transform: uppercase;
+}
+
+.agentTypeBadgeCopilot {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(37, 99, 235, 0.15);
+  color: #93c5fd;
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  text-transform: uppercase;
+}
+
+.prDraftBadge {
+  display: inline-block;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  background: rgba(139, 148, 158, 0.15);
+  color: #8b949e;
+  border: 1px solid rgba(139, 148, 158, 0.25);
+  margin-right: 0.4rem;
+  vertical-align: middle;
+  text-transform: uppercase;
+}
+
+.commentCount {
+  font-size: 0.68rem;
+  color: #8b949e;
+  background: rgba(139, 148, 158, 0.1);
+  border: 1px solid rgba(139, 148, 158, 0.15);
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+}
+
 .prTierCount {
   font-size: 0.75rem;
   color: #8b949e;

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -1836,10 +1836,28 @@ function GovernorPanel({ governor }: { governor?: HiveGovernor }) {
   const busy = governor?.thresholds?.busy ?? Math.max(quiet + 1, depth, 1);
   const surge = governor?.thresholds?.surge ?? Math.max(busy + 1, depth, 1);
   const maxDepth = Math.max(surge, depth, 1);
-  const quietWidth = Math.max((quiet / maxDepth) * 100, 18);
-  const busyWidth = Math.max(((busy - quiet) / maxDepth) * 100, 18);
-  const surgeWidth = Math.max(100 - quietWidth - busyWidth, 18);
-  const markerLeft = Math.min((depth / maxDepth) * 100, 100);
+
+  // Proportional zone widths — no forced minimums so marker always aligns with zones.
+  // Labels are hidden when a zone is too narrow to show text.
+  const quietPct = (quiet / maxDepth) * 100;
+  const busyPct = ((busy - quiet) / maxDepth) * 100;
+  const surgePct = 100 - quietPct - busyPct;
+
+  // Marker is placed inside the correct zone, proportionally within it.
+  let markerLeft: number;
+  if (depth <= quiet) {
+    markerLeft = quiet > 0 ? (depth / quiet) * quietPct : 0;
+  } else if (depth <= busy) {
+    markerLeft = quietPct + ((depth - quiet) / Math.max(busy - quiet, 1)) * busyPct;
+  } else {
+    markerLeft = quietPct + busyPct + ((depth - busy) / Math.max(maxDepth - busy, 1)) * surgePct;
+  }
+  markerLeft = Math.min(markerLeft, 99.5);
+
+  const modeColor =
+    { surge: "#f85149", busy: "#d97706", quiet: "#58a6ff", idle: "#8b949e" }[
+      (governor?.mode ?? "idle").toLowerCase()
+    ] ?? "#8b949e";
 
   return (
     <section className={styles.panel}>
@@ -1852,40 +1870,53 @@ function GovernorPanel({ governor }: { governor?: HiveGovernor }) {
       <div className={styles.kv}>
         <span>Queue depth</span>
         <strong>
-          {issues} issues + {prs} PRs in queue
+          {issues} issues + {prs} PRs &mdash; {depth} total
         </strong>
       </div>
-      <div className={styles.govThreshBar}>
+      <div className={styles.govThreshOuter}>
+        {/* Floating depth label above the marker */}
         <div
-          className={styles.govThreshZoneQuiet}
-          style={{ width: `${quietWidth}%` }}
+          className={styles.govThreshMarkerLabel}
+          style={{ left: `${markerLeft}%`, color: modeColor }}
+          aria-hidden="true"
         >
-          QUIET
+          {depth}
         </div>
-        <div
-          className={styles.govThreshZoneBusy}
-          style={{ width: `${busyWidth}%` }}
-        >
-          BUSY
+        <div className={styles.govThreshBar}>
+          <div
+            className={styles.govThreshZoneQuiet}
+            style={{ width: `${quietPct}%` }}
+          >
+            {quietPct >= 10 ? "QUIET" : ""}
+          </div>
+          <div
+            className={styles.govThreshZoneBusy}
+            style={{ width: `${busyPct}%` }}
+          >
+            {busyPct >= 10 ? "BUSY" : ""}
+          </div>
+          <div
+            className={styles.govThreshZoneSurge}
+            style={{ width: `${surgePct}%` }}
+          >
+            {surgePct >= 10 ? "SURGE" : ""}
+          </div>
+          <span
+            className={styles.govThreshMarker}
+            style={{ left: `${markerLeft}%`, background: modeColor }}
+          />
         </div>
-        <div
-          className={styles.govThreshZoneSurge}
-          style={{ width: `${surgeWidth}%` }}
-        >
-          SURGE
-        </div>
-        <span
-          className={styles.govThreshMarker}
-          style={{ left: `calc(${markerLeft}% - 1px)` }}
-        />
       </div>
       <div className={styles.govThreshLegend}>
         <span>Q &le; {quiet}</span>
         <span>B &le; {busy}</span>
         <span>S &ge; {surge}</span>
+        <span style={{ marginLeft: "auto", color: modeColor, fontWeight: 700 }}>
+          current: {depth}
+        </span>
       </div>
       <p className={styles.panelMeta}>
-        Next kick: {" "}
+        Next kick:{" "}
         {governor?.nextKick ? relTime(governor.nextKick) : "—"}
       </p>
     </section>
@@ -2531,6 +2562,9 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
   const [mergedPRs, setMergedPRs] = useState<MergedPR[]>([]);
   const [velocity, setVelocity] = useState<Velocity | null>(null);
   const [hiveHistory, setHiveHistory] = useState<HiveHistory | null>(null);
+  const [testBuilds, setTestBuilds] = useState<number | null>(null);
+  const [tapPromotions, setTapPromotions] = useState<number | null>(null);
+  const [agentMergedCount, setAgentMergedCount] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [refreshIn, setRefreshIn] = useState(REFRESH_SECS);
@@ -2725,6 +2759,41 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         }
       }
       setRepoPRs(rPRs);
+
+      // Supplementary production stats (non-blocking, best-effort)
+      try {
+        const monthAgoISO = new Date(Date.now() - 30 * 24 * 3600 * 1000)
+          .toISOString()
+          .slice(0, 10);
+        const [testRes, promosRes, agentMergedRes] = await Promise.allSettled([
+          // Successful CI runs in the hardware test suite this week
+          fetchTimeout(
+            `${GH_API}/repos/projectbluefin/testsuite/actions/runs?status=success&per_page=1`,
+          ),
+          // PRs merged to the production homebrew tap this month (promotions)
+          fetchTimeout(
+            `${GH_API}/search/issues?q=repo:ublue-os/homebrew-tap+type:pr+is:merged+merged:>${monthAgoISO}&per_page=1`,
+          ),
+          // PRs merged by the hive agent this week (agent output rate)
+          fetchTimeout(
+            `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged+author:kubestellar-hive%5Bbot%5D+merged:>${weekAgoISO}&per_page=1`,
+          ),
+        ]);
+        if (testRes.status === "fulfilled" && testRes.value.ok) {
+          const d = (await testRes.value.json()) as { total_count?: number };
+          setTestBuilds(d.total_count ?? 0);
+        }
+        if (promosRes.status === "fulfilled" && promosRes.value.ok) {
+          const d = (await promosRes.value.json()) as GitHubSearchResponse<unknown>;
+          setTapPromotions(d.total_count ?? 0);
+        }
+        if (agentMergedRes.status === "fulfilled" && agentMergedRes.value.ok) {
+          const d = (await agentMergedRes.value.json()) as GitHubSearchResponse<unknown>;
+          setAgentMergedCount(d.total_count ?? 0);
+        }
+      } catch {
+        /* non-fatal */
+      }
     } finally {
       setLoading(false);
       setLastUpdated(new Date());
@@ -2966,6 +3035,30 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
               sparkColor="green"
             />
           )}
+          {agentMergedCount != null && agentMergedCount > 0 && (
+            <StatCard
+              label="Agent Merged"
+              value={agentMergedCount}
+              sub="PRs this week"
+              accent="#58a6ff"
+            />
+          )}
+          {testBuilds != null && (
+            <StatCard
+              label="Test Builds"
+              value={testBuilds}
+              sub="passed in testsuite"
+              accent="#3fb950"
+            />
+          )}
+          {tapPromotions != null && tapPromotions > 0 && (
+            <StatCard
+              label="Promoted"
+              value={tapPromotions}
+              sub="to production tap / 30d"
+              accent="#bc8cff"
+            />
+          )}
           {repos.length > 0 && (
             <StatCard label="Repos" value={repos.length} sub="in formation" />
           )}
@@ -2999,6 +3092,9 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
           })()}
         </div>
 
+        {/* Governor — moved to top for prominence */}
+        <GovernorPanel governor={snapshot?.governor} />
+
         {/* Guardians / Ghosts */}
         <div className={styles.destinyColumns}>
           <GuardiansColumn prs={queueData?.prs ?? null} />
@@ -3007,9 +3103,6 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
 
         {/* Victory Log */}
         <VictoryLog victories={queueData?.victories ?? null} />
-
-        {/* Governor */}
-        <GovernorPanel governor={snapshot?.governor} />
 
         {/* Commit activity + What agents are doing */}
         <div className={styles.twoCol}>

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -161,6 +161,32 @@ interface GitHubSearchIssueItem {
   user?: { login?: string; type?: string };
   updated_at: string;
   html_url: string;
+  labels?: Array<{ name: string; color: string }>;
+  comments?: number;
+  draft?: boolean;
+}
+
+interface CommunityDiscussion {
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+  labels?: QueueLabel[];
+  comments?: number;
+  user?: { login?: string };
+}
+
+interface AgentAssistedPR {
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+  labels?: QueueLabel[];
+  user?: { login?: string };
+  draft?: boolean;
+  agentType: "hive" | "copilot";
 }
 
 interface OrgStats {
@@ -2296,77 +2322,104 @@ function OrgStatsPanel({ stats }: { stats: OrgStats }) {
 
 // ── New: Guardians column ──────────────────────────────────────────────────
 
-function GuardiansColumn({ prs }: { prs: QueueData["prs"] | null }) {
-  if (!prs) {
+// ── Guardians column — Community discussions ───────────────────────────────
+
+const EPIC_LABELS = new Set(["epic", "type:epic", "kind:epic", "feature:epic"]);
+const SKIP_LABEL_PREFIXES_GUARDIAN = ["queue/", "hive/", "source:", "priority/", "type:epic", "kind:epic"];
+
+function guardianVisibleLabels(labels?: QueueLabel[]): QueueLabel[] {
+  return (labels ?? []).filter(
+    (l) =>
+      !SKIP_LABEL_PREFIXES_GUARDIAN.some((p) => l.name.toLowerCase().startsWith(p)) &&
+      !EPIC_LABELS.has(l.name.toLowerCase()),
+  ).slice(0, 3);
+}
+
+function isEpic(labels?: QueueLabel[]): boolean {
+  return (labels ?? []).some((l) => EPIC_LABELS.has(l.name.toLowerCase()));
+}
+
+function GuardiansColumn({ discussions }: { discussions: CommunityDiscussion[] | null }) {
+  if (!discussions) {
     return (
       <div className={`${styles.destinyCol} ${styles.guardiansCol}`}>
         <div>
           <p className={styles.destinyColTitle + " " + styles.guardiansColTitle}>Guardians</p>
-          <p className={styles.destinyColSubtitle}>Human contributor pull requests</p>
+          <p className={styles.destinyColSubtitle}>Community conversations</p>
         </div>
         <div className={styles.empty}>Loading…</div>
       </div>
     );
   }
 
-  const tiers: Array<{
-    key: keyof QueueData["prs"];
-    label: string;
-    labelCls: string;
-    items: QueuePR[];
-  }> = [
-    { key: "approved", label: "APPROVED", labelCls: styles.prTierLabelApproved, items: prs.approved },
-    { key: "required", label: "NEEDS REVIEW", labelCls: styles.prTierLabelRequired, items: prs.required },
-    { key: "none", label: "NO REVIEWS", labelCls: styles.prTierLabelNone, items: prs.none },
+  const epics = discussions.filter((d) => isEpic(d.labels));
+  const active = discussions.filter((d) => !isEpic(d.labels));
+
+  function DiscussionCard({ item }: { item: CommunityDiscussion }) {
+    const repo = parseRepoName(item.repository_url, item.html_url);
+    const lbls = guardianVisibleLabels(item.labels);
+    return (
+      <Link
+        href={item.html_url}
+        target="_blank"
+        rel="noreferrer"
+        className={styles.issueCard}
+      >
+        <span className={styles.issueCardTitle}>{item.title.slice(0, 90)}</span>
+        <div className={styles.issueCardMeta}>
+          <span className={styles.issueCardRepo}>{repo}</span>
+          {(item.comments ?? 0) > 0 && (
+            <span className={styles.commentCount}>
+              {item.comments} comment{item.comments !== 1 ? "s" : ""}
+            </span>
+          )}
+          {lbls.map((l) => (
+            <span
+              key={l.name}
+              className={styles.issueLabel}
+              style={{
+                background: `#${l.color}22`,
+                color: `#${l.color}`,
+                border: `1px solid #${l.color}44`,
+              }}
+            >
+              {l.name}
+            </span>
+          ))}
+          <span className={styles.issueCardAge}>{relTime(item.updated_at)}</span>
+        </div>
+      </Link>
+    );
+  }
+
+  const tiers: Array<{ label: string; labelCls: string; items: CommunityDiscussion[]; empty: string }> = [
+    { label: "EPICS", labelCls: styles.prTierLabelEpic, items: epics, empty: "No open epics" },
+    { label: "ACTIVE DISCUSSIONS", labelCls: styles.prTierLabelNone, items: active, empty: "Queue clear" },
   ];
 
   return (
     <div className={`${styles.destinyCol} ${styles.guardiansCol}`}>
       <div>
         <p className={styles.destinyColTitle + " " + styles.guardiansColTitle}>Guardians</p>
-        <p className={styles.destinyColSubtitle}>Human contributor pull requests — the Light we carry</p>
+        <p className={styles.destinyColSubtitle}>
+          Community conversations &mdash; sorted by latest activity
+        </p>
       </div>
-      {tiers.map(({ key, label, labelCls, items }) => (
-        <div key={key} className={styles.prTier}>
+      {tiers.map(({ label, labelCls, items, empty }) => (
+        <div key={label} className={styles.prTier}>
           <div className={styles.prTierHeader}>
             <span className={`${styles.prTierLabel} ${labelCls}`}>{label}</span>
             <span className={styles.prTierCount}>{items.length}</span>
           </div>
           {items.length === 0 ? (
-            <div className={styles.prTierEmpty}>None</div>
+            <div className={styles.prTierEmpty}>{empty}</div>
           ) : (
-            items.slice(0, 8).map((pr, i) => {
-              const repo = parseRepoName(pr.repository_url);
-              const approvals = pr._reviews?.approved ?? 0;
-              return (
-                <Link
-                  key={i}
-                  href={pr.html_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={styles.prCard}
-                >
-                  <span className={styles.prCardTitle}>
-                    {pr.title.slice(0, 80)}
-                  </span>
-                  <div className={styles.prCardMeta}>
-                    <span className={styles.prCardRepo}>{repo}</span>
-                    {approvals > 0 && (
-                      <span className={styles.prCardApprovals}>
-                        {approvals} approved
-                      </span>
-                    )}
-                    <span className={styles.prCardAge}>{relTime(pr.updated_at)}</span>
-                  </div>
-                </Link>
-              );
-            })
+            items.slice(0, 10).map((item) => (
+              <DiscussionCard key={item.html_url} item={item} />
+            ))
           )}
-          {items.length > 8 && (
-            <div className={styles.prTierEmpty}>
-              +{items.length - 8} more &mdash; {" "}
-              <Link href={HOSTED_INSTANCE_URL}>see all</Link>
-            </div>
+          {items.length > 10 && (
+            <div className={styles.prTierEmpty}>+{items.length - 10} more</div>
           )}
         </div>
       ))}
@@ -2374,98 +2427,117 @@ function GuardiansColumn({ prs }: { prs: QueueData["prs"] | null }) {
   );
 }
 
-// ── New: Ghosts column ─────────────────────────────────────────────────────
+// ── Ghosts column — Agent-assisted PRs ────────────────────────────────────
 
-function GhostsColumn({ issues }: { issues: QueueData["issues"] | null }) {
-  if (!issues) {
+const SKIP_LABEL_PREFIXES_GHOST = ["source:", "hive/", "queue/", "priority/"];
+
+function ghostVisibleLabels(labels?: QueueLabel[]): QueueLabel[] {
+  return (labels ?? []).filter(
+    (l) => !SKIP_LABEL_PREFIXES_GHOST.some((p) => l.name.toLowerCase().startsWith(p)),
+  ).slice(0, 3);
+}
+
+function GhostsColumn({
+  hivePRs,
+  copilotPRs,
+}: {
+  hivePRs: AgentAssistedPR[] | null;
+  copilotPRs: AgentAssistedPR[] | null;
+}) {
+  const loading = hivePRs === null && copilotPRs === null;
+
+  if (loading) {
     return (
       <div className={`${styles.destinyCol} ${styles.ghostsCol}`}>
         <div>
           <p className={styles.destinyColTitle + " " + styles.ghostsColTitle}>Ghosts</p>
-          <p className={styles.destinyColSubtitle}>Agent-driven issues and work queue</p>
+          <p className={styles.destinyColSubtitle}>Agent-assisted pull requests</p>
         </div>
         <div className={styles.empty}>Loading…</div>
       </div>
     );
   }
 
-  const SKIP_LABEL_PREFIXES = ["hive/", "priority/", "queue/"];
-
-  function visibleLabels(labels?: QueueLabel[]): QueueLabel[] {
-    return (labels ?? []).filter(
-      (l) => !SKIP_LABEL_PREFIXES.some((p) => l.name.startsWith(p)),
+  // Merge + deduplicate by html_url; hive entries win on conflict
+  const allPRs = React.useMemo(() => {
+    const seen = new Set<string>();
+    const merged: AgentAssistedPR[] = [];
+    for (const pr of hivePRs ?? []) {
+      if (!seen.has(pr.html_url)) { seen.add(pr.html_url); merged.push(pr); }
+    }
+    for (const pr of copilotPRs ?? []) {
+      if (!seen.has(pr.html_url)) { seen.add(pr.html_url); merged.push(pr); }
+    }
+    return merged.sort(
+      (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
-  }
-
-  const tiers: Array<{
-    key: keyof QueueData["issues"];
-    label: string;
-    labelCls: string;
-    items: QueueIssue[];
-  }> = [
-    { key: "p0", label: "P0", labelCls: styles.issueTierLabelP0, items: issues.p0 },
-    { key: "p1", label: "P1", labelCls: styles.issueTierLabelP1, items: issues.p1 },
-  ];
+  }, [hivePRs, copilotPRs]);
 
   return (
     <div className={`${styles.destinyCol} ${styles.ghostsCol}`}>
       <div>
         <p className={styles.destinyColTitle + " " + styles.ghostsColTitle}>Ghosts</p>
-        <p className={styles.destinyColSubtitle}>Agent-driven issues — the machines at work</p>
+        <p className={styles.destinyColSubtitle}>
+          Agent-assisted pull requests &mdash; the machines at work
+        </p>
       </div>
-      {tiers.map(({ key, label, labelCls, items }) => (
-        <div key={key} className={styles.prTier}>
-          <div className={styles.prTierHeader}>
-            <span className={`${styles.prTierLabel} ${labelCls}`}>{label}</span>
-            <span className={styles.prTierCount}>{items.length}</span>
-          </div>
-          {items.length === 0 ? (
-            <div className={styles.prTierEmpty}>
-              {key === "p0" ? "No blockers" : "Queue clear"}
-            </div>
-          ) : (
-            items.slice(0, 8).map((issue, i) => {
-              const repo = parseRepoName(issue.repository_url);
-              const lbls = visibleLabels(issue.labels).slice(0, 3);
-              return (
-                <Link
-                  key={i}
-                  href={issue.html_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={styles.issueCard}
-                >
-                  <span className={styles.issueCardTitle}>
-                    {issue.title.slice(0, 80)}
-                  </span>
-                  <div className={styles.issueCardMeta}>
-                    <span className={styles.issueCardRepo}>{repo}</span>
-                    {lbls.map((l) => (
-                      <span
-                        key={l.name}
-                        className={styles.issueLabel}
-                        style={{
-                          background: `#${l.color}22`,
-                          color: `#${l.color}`,
-                          border: `1px solid #${l.color}44`,
-                        }}
-                      >
-                        {l.name}
-                      </span>
-                    ))}
-                    <span className={styles.issueCardAge}>
-                      {relTime(issue.updated_at)}
-                    </span>
-                  </div>
-                </Link>
-              );
-            })
-          )}
-          {items.length > 8 && (
-            <div className={styles.prTierEmpty}>+{items.length - 8} more</div>
-          )}
+      <div className={styles.prTier}>
+        <div className={styles.prTierHeader}>
+          <span className={`${styles.prTierLabel} ${styles.prTierLabelAgent}`}>OPEN</span>
+          <span className={styles.prTierCount}>{allPRs.length}</span>
         </div>
-      ))}
+        {allPRs.length === 0 ? (
+          <div className={styles.prTierEmpty}>No open agent PRs</div>
+        ) : (
+          allPRs.slice(0, 15).map((pr) => {
+            const repo = parseRepoName(pr.repository_url, pr.html_url);
+            const lbls = ghostVisibleLabels(pr.labels);
+            return (
+              <Link
+                key={pr.html_url}
+                href={pr.html_url}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.prCard}
+              >
+                <span className={styles.prCardTitle}>
+                  {pr.draft && <span className={styles.prDraftBadge}>Draft</span>}
+                  {pr.title.slice(0, 85)}
+                </span>
+                <div className={styles.prCardMeta}>
+                  <span className={styles.prCardRepo}>{repo}</span>
+                  <span
+                    className={
+                      pr.agentType === "hive"
+                        ? styles.agentTypeBadgeHive
+                        : styles.agentTypeBadgeCopilot
+                    }
+                  >
+                    {pr.agentType === "hive" ? "hive" : "copilot"}
+                  </span>
+                  {lbls.map((l) => (
+                    <span
+                      key={l.name}
+                      className={styles.issueLabel}
+                      style={{
+                        background: `#${l.color}22`,
+                        color: `#${l.color}`,
+                        border: `1px solid #${l.color}44`,
+                      }}
+                    >
+                      {l.name}
+                    </span>
+                  ))}
+                  <span className={styles.prCardAge}>{relTime(pr.updated_at)}</span>
+                </div>
+              </Link>
+            );
+          })
+        )}
+        {allPRs.length > 15 && (
+          <div className={styles.prTierEmpty}>+{allPRs.length - 15} more</div>
+        )}
+      </div>
     </div>
   );
 }
@@ -2565,6 +2637,9 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
   const [testBuilds, setTestBuilds] = useState<number | null>(null);
   const [tapPromotions, setTapPromotions] = useState<number | null>(null);
   const [agentMergedCount, setAgentMergedCount] = useState<number | null>(null);
+  const [communityDiscussions, setCommunityDiscussions] = useState<CommunityDiscussion[] | null>(null);
+  const [hivePRsList, setHivePRsList] = useState<AgentAssistedPR[] | null>(null);
+  const [copilotPRsList, setCopilotPRsList] = useState<AgentAssistedPR[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [refreshIn, setRefreshIn] = useState(REFRESH_SECS);
@@ -2760,12 +2835,12 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
       }
       setRepoPRs(rPRs);
 
-      // Supplementary production stats (non-blocking, best-effort)
+      // Supplementary production stats + column data (non-blocking, best-effort)
       try {
         const monthAgoISO = new Date(Date.now() - 30 * 24 * 3600 * 1000)
           .toISOString()
           .slice(0, 10);
-        const [testRes, promosRes, agentMergedRes] = await Promise.allSettled([
+        const [testRes, promosRes, agentMergedRes, discussRes, hivePRRes, copilotPRRes] = await Promise.allSettled([
           // Successful CI runs in the hardware test suite this week
           fetchTimeout(
             `${GH_API}/repos/projectbluefin/testsuite/actions/runs?status=success&per_page=1`,
@@ -2777,6 +2852,18 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
           // PRs merged by the hive agent this week (agent output rate)
           fetchTimeout(
             `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged+author:kubestellar-hive%5Bbot%5D+merged:>${weekAgoISO}&per_page=1`,
+          ),
+          // Community discussions — open issues, excluding agent queue items, sorted by activity
+          fetchTimeout(
+            `${GH_API}/search/issues?q=org:projectbluefin+type:issue+is:open+-label:queue%2Fagent-ready+-label:source%3Aagent&sort=updated&order=desc&per_page=25`,
+          ),
+          // Ghosts: PRs authored by the hive agent bot
+          fetchTimeout(
+            `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:open+author:kubestellar-hive%5Bbot%5D&sort=updated&order=desc&per_page=25`,
+          ),
+          // Ghosts: PRs labeled source:agent (Copilot-assisted, not just hive-bot)
+          fetchTimeout(
+            `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:open+label:source%3Aagent&sort=updated&order=desc&per_page=25`,
           ),
         ]);
         if (testRes.status === "fulfilled" && testRes.value.ok) {
@@ -2790,6 +2877,53 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         if (agentMergedRes.status === "fulfilled" && agentMergedRes.value.ok) {
           const d = (await agentMergedRes.value.json()) as GitHubSearchResponse<unknown>;
           setAgentMergedCount(d.total_count ?? 0);
+        }
+        if (discussRes.status === "fulfilled" && discussRes.value.ok) {
+          const d = (await discussRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
+          setCommunityDiscussions(
+            (d.items ?? []).map((i) => ({
+              number: i.number,
+              title: i.title,
+              html_url: i.html_url,
+              repository_url: i.repository_url,
+              updated_at: i.updated_at,
+              labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
+              comments: i.comments,
+              user: i.user ? { login: i.user.login } : undefined,
+            })),
+          );
+        }
+        if (hivePRRes.status === "fulfilled" && hivePRRes.value.ok) {
+          const d = (await hivePRRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
+          setHivePRsList(
+            (d.items ?? []).map((i) => ({
+              number: i.number,
+              title: i.title,
+              html_url: i.html_url,
+              repository_url: i.repository_url,
+              updated_at: i.updated_at,
+              labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
+              user: i.user ? { login: i.user.login } : undefined,
+              draft: i.draft,
+              agentType: "hive" as const,
+            })),
+          );
+        }
+        if (copilotPRRes.status === "fulfilled" && copilotPRRes.value.ok) {
+          const d = (await copilotPRRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
+          setCopilotPRsList(
+            (d.items ?? []).map((i) => ({
+              number: i.number,
+              title: i.title,
+              html_url: i.html_url,
+              repository_url: i.repository_url,
+              updated_at: i.updated_at,
+              labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
+              user: i.user ? { login: i.user.login } : undefined,
+              draft: i.draft,
+              agentType: "copilot" as const,
+            })),
+          );
         }
       } catch {
         /* non-fatal */
@@ -3097,8 +3231,8 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
 
         {/* Guardians / Ghosts */}
         <div className={styles.destinyColumns}>
-          <GuardiansColumn prs={queueData?.prs ?? null} />
-          <GhostsColumn issues={queueData?.issues ?? null} />
+          <GuardiansColumn discussions={communityDiscussions} />
+          <GhostsColumn hivePRs={hivePRsList} copilotPRs={copilotPRsList} />
         </div>
 
         {/* Victory Log */}


### PR DESCRIPTION
Moves GovernorPanel to the top (right after the stats strip), fixes the meter accuracy bug, and adds three new stat cards.

## Governor meter

The zone widths were forced to Math.max(..., 18%) to prevent tiny zones, but the marker used raw depth/maxDepth — so the needle could visually land in the wrong zone. Fix: zones are now strictly proportional (labels hidden when a zone is too narrow); marker position is computed segment-by-segment so it always falls in the correct zone. Marker is also wider (3px), colored to match the current mode, and has a floating depth-count label with a down-arrow above it so you can read the position at a glance.

## Stats strip additions

- Test Builds — successful CI runs in projectbluefin/testsuite (shows hardware test coverage)
- Promoted — packages merged to ublue-os/homebrew-tap in the past 30 days (shows production promotion rate)
- Agent Merged — hive-bot PRs merged this week (agent output velocity)

All three fetches are non-blocking and failures silently suppress the card.