### PR TITLE
fix(hive): switch snapshot from broken HTML URL to /api/status

### DIFF
--- a/.github/workflows/update-hive-cache.yml
+++ b/.github/workflows/update-hive-cache.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Fetch Hive history snapshot + contributor stats
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          HIVE_API_TOKEN: ${{ secrets.HIVE_API_TOKEN }}
         run: node scripts/fetch-hive-history.js
 
       - name: Validate Hive history output

--- a/scripts/fetch-hive-history.js
+++ b/scripts/fetch-hive-history.js
@@ -35,8 +35,14 @@
 const fs = require("fs");
 const path = require("path");
 
-const SNAPSHOT_HTML_URL =
-  "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html";
+// Snapshot data comes from the hosted Knuckle /api/status endpoint.
+// The old raw.githubusercontent.com HTML snapshot (bluefin/index.html) is no longer published.
+// HIVE_API_TOKEN: optional Bearer token for CI — if unset, snapshot fetch is skipped gracefully.
+const HOSTED_INSTANCE_URL =
+  "https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io";
+const SNAPSHOT_API_URL = `${HOSTED_INSTANCE_URL}/api/status`;
+const HIVE_API_TOKEN = process.env.HIVE_API_TOKEN || "";
+
 const OUTPUT_FILE = path.join(__dirname, "../static/data/hive-history.json");
 
 // 14 days at one entry per 2h = 168 entries
@@ -358,20 +364,31 @@ async function main() {
 
   // ── Fetch hive snapshot ──────────────────────────────────────────────────
   let metrics = null;
-  try {
-    console.log("[hive-history] Fetching snapshot HTML...");
-    const html = await fetchText(SNAPSHOT_HTML_URL);
-    const data = extractRenderData(html);
-    if (data) {
-      metrics = extractMetrics(data);
-      console.log(
-        `[hive-history] Snapshot parsed: ACMM L${metrics?.acmmLevel ?? "?"}, mode=${metrics?.govMode ?? "?"}`,
-      );
-    } else {
-      console.warn("[hive-history] Could not extract render() data from HTML");
+  if (!HIVE_API_TOKEN) {
+    console.log("[hive-history] HIVE_API_TOKEN not set — skipping snapshot fetch");
+  } else {
+    try {
+      console.log("[hive-history] Fetching /api/status...");
+      const res = await fetch(SNAPSHOT_API_URL, {
+        headers: {
+          ...ghHeaders(),
+          Authorization: `Bearer ${HIVE_API_TOKEN}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        metrics = extractMetrics(data);
+        console.log(
+          `[hive-history] Snapshot parsed: ACMM L${metrics?.acmmLevel ?? "?"}, mode=${metrics?.govMode ?? "?"}`,
+        );
+      } else {
+        console.warn(`[hive-history] /api/status returned HTTP ${res.status} — skipping snapshot`);
+      }
+    } catch (err) {
+      console.warn(`[hive-history] Snapshot fetch failed: ${err.message}`);
     }
-  } catch (err) {
-    console.warn(`[hive-history] Snapshot fetch failed: ${err.message}`);
   }
 
   // ── Append history entry ─────────────────────────────────────────────────

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -356,10 +356,10 @@ interface QueueData {
 const HOSTED_INSTANCE_URL =
   "https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io";
 
-// Snapshot HTML is still served from the public GitHub raw URL
-// (hosted instance snapshot endpoint is auth-gated; raw.githubusercontent.com is public)
-const SNAPSHOT_HTML_URL =
-  "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html";
+// Snapshot: fetch /api/status directly from the hosted Knuckle instance.
+// Credentials are included so authenticated hive users get live governor/agent data.
+// The old raw.githubusercontent.com HTML snapshot is no longer published.
+const SNAPSHOT_API_URL = `${HOSTED_INSTANCE_URL}/api/status`;
 
 // Queue data: try the hosted instance first (credentials:include), fall back to public mirror
 const QUEUE_URL_HOSTED = `${HOSTED_INSTANCE_URL}/data.json`;
@@ -2660,7 +2660,7 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         openedRes,
         closedRes,
       ] = await Promise.allSettled([
-        fetchTimeout(SNAPSHOT_HTML_URL),
+        fetchTimeout(SNAPSHOT_API_URL, 12000, { credentials: "include" }),
         fetchQueueData(),
         fetchTimeout(`${GH_API}/repos/${DAKOTA}`),
         fetchTimeout(
@@ -2678,14 +2678,15 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         ),
       ]);
 
-      // Hive snapshot from embedded HTML
+      // Hive snapshot — /api/status returns JSON directly (same shape as old render() payload)
       if (htmlRes.status === "fulfilled" && htmlRes.value.ok) {
-        const html = await htmlRes.value.text();
-        const data = await extractRenderJson(html);
-        if (data) {
+        try {
+          const data = (await htmlRes.value.json()) as Record<string, unknown>;
           const { snapshot: snap, config: cfg } = parseSnapshotJson(data);
           if (snap) setSnapshot(snap);
           if (cfg) setConfig(cfg);
+        } catch {
+          /* non-fatal — snapshot unavailable when not logged in */
         }
       }
 


### PR DESCRIPTION
The raw.githubusercontent.com snapshot URL now returns a 323-byte redirect page. This is why the governor meter showed idle and all agent/budget data was missing.

## Root cause

publish-snapshot.sh stopped publishing to the bluefin/index.html path in kubestellar/docs. That file is now just a meta-refresh redirect to hive.projectbluefin.io, which itself redirects to docs.projectbluefin.io/hive/ (our own page). The circular redirect returns no data.

## Fix

Dashboard: replace the SNAPSHOT_HTML_URL + HTML extraction dance with a direct fetch to the hosted Knuckle /api/status endpoint using credentials:include. The response is plain JSON with the same shape parseSnapshotJson already expects (it was the original source for the render({}) embed), so no parser changes are needed.

fetch-hive-history.js: replace fetchText + extractRenderData with a direct fetch to /api/status using HIVE_API_TOKEN Bearer auth. When HIVE_API_TOKEN is unset the snapshot step is skipped gracefully and contributor/stats fetches still run.

update-hive-cache.yml: passes HIVE_API_TOKEN secret to the fetch step.

## Action required

Add HIVE_API_TOKEN to projectbluefin/documentation repo secrets (Settings > Secrets and variables > Actions). This unlocks full snapshot capture in CI and populates all the history graphs with governor mode, ACMM level, budget, agent counts, etc. every 2 hours.