### PR TITLE
feat(hive): ops center layout — factory floor hero, 3-col intelligence zone, fixed stats grid

### DIFF
--- a/src/components/HiveFactoryDashboard.module.css
+++ b/src/components/HiveFactoryDashboard.module.css
@@ -176,12 +176,20 @@
   font-family: "SFMono-Regular", Consolas, monospace;
 }
 
-/* ── Stats row ──────────────────────────────────────────────────────────── */
+/* ── Stats row — always fixed 6 columns ─────────────────────────────────── */
 .statsRow {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  grid-template-columns: repeat(6, 1fr);
   gap: 0.875rem;
   margin-bottom: 1.75rem;
+}
+
+@media (max-width: 1100px) {
+  .statsRow { grid-template-columns: repeat(3, 1fr); }
+}
+
+@media (max-width: 600px) {
+  .statsRow { grid-template-columns: repeat(2, 1fr); }
 }
 
 .statCard {
@@ -375,6 +383,43 @@
   .twoCol {
     grid-template-columns: 1fr;
   }
+}
+
+/* ── Factory floor (asymmetric 2-col: main | sidebar) ───────────────────── */
+.factoryFloor {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 1024px) {
+  .factoryFloor { grid-template-columns: 1fr; }
+}
+
+/* Sidebar stack inside factory floor right column */
+.factorySidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ── Intelligence zone (3 equal columns) ────────────────────────────────── */
+.intelligenceZone {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 1024px) {
+  .intelligenceZone { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 640px) {
+  .intelligenceZone { grid-template-columns: 1fr; }
 }
 
 /* ── Agent grid ─────────────────────────────────────────────────────────── */
@@ -953,6 +998,21 @@
   border-color: rgba(245, 158, 11, 0.4);
   background: rgba(245, 158, 11, 0.08);
   box-shadow: 0 0 8px rgba(245, 158, 11, 0.2);
+}
+.modeBusy {
+  color: #d97706;
+  border-color: rgba(217, 119, 6, 0.4);
+  background: rgba(217, 119, 6, 0.08);
+}
+.modeQuiet {
+  color: #3b82f6;
+  border-color: rgba(59, 130, 246, 0.3);
+  background: rgba(59, 130, 246, 0.06);
+}
+.modeIdle {
+  color: #484f58;
+  border-color: rgba(72, 79, 88, 0.3);
+  background: rgba(72, 79, 88, 0.04);
 }
 .modeNormal {
   color: #58a6ff;

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -2987,178 +2987,126 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
           </div>
           <div className={styles.heroRight}>
             <LivePulse />
-            {snapshot?.acmmMode && (
-              <span
-                className={`${styles.modeBadge} ${
-                  snapshot.acmmMode === "SURGE"
-                    ? styles.modeSurge
-                    : styles.modeNormal
-                }`}
-              >
-                {snapshot.acmmMode}
-              </span>
-            )}
+            {snapshot?.acmmMode && (() => {
+              const mode = snapshot.acmmMode!.toUpperCase();
+              const cls = mode === "SURGE" ? styles.modeSurge
+                : mode === "BUSY" ? styles.modeBusy
+                : mode === "QUIET" ? styles.modeQuiet
+                : mode === "IDLE" ? styles.modeIdle
+                : styles.modeNormal;
+              return <span className={`${styles.modeBadge} ${cls}`}>{mode}</span>;
+            })()}
             {dakotaStats && <CiBadge status={dakotaStats.ciStatus} />}
           </div>
         </header>
 
-        {/* Stats strip */}
+        {/* Stats strip — always 6 canonical tiles */}
         <div className={styles.statsRow}>
-          {p0Count > 0 && (
-            <StatCard
-              label="P0 Blockers"
-              value={p0Count}
-              accent="#f85149"
-            />
-          )}
-          <StatCard label="P1 This Cycle" value={p1Count} />
+          <StatCard
+            label={p0Count > 0 ? `P0 / P1 Issues` : "P1 This Cycle"}
+            value={p0Count > 0 ? `${p0Count}+${p1Count}` : p1Count}
+            accent={p0Count > 0 ? "#f85149" : undefined}
+            sub={p0Count > 0 ? `${p0Count} blocker${p0Count > 1 ? "s" : ""}` : undefined}
+          />
           <StatCard
             label="Frames"
-            value={`${activeAgents.length}/${agents.length}`}
-            sub={
-              workingAgents.length > 0
-                ? `${workingAgents.length} working`
-                : "standing by"
-            }
+            value={agents.length > 0 ? `${activeAgents.length}/${agents.length}` : "—"}
+            sub={workingAgents.length > 0 ? `${workingAgents.length} working` : agents.length > 0 ? "standing by" : "no snapshot"}
             accent={formationColor}
           />
-          {prsNeedingReview > 0 && (
-            <StatCard
-              label="PRs Need Review"
-              value={prsNeedingReview}
-              accent="#d97706"
-            />
-          )}
-          {queueData && (
-            <StatCard
-              label="Approved PRs"
-              value={queueData.prs.approved.length}
-              sub="ready to merge"
-              accent="#3fb950"
-            />
-          )}
-          {queueData && (
-            <StatCard
-              label="Shipped This Cycle"
-              value={
-                (queueData.victories.dreams.count ?? 0) +
-                (queueData.victories.relief.count ?? 0)
-              }
-              sub="features + fixes"
-              accent="#3fb950"
-              spark={victorySparkData([
-                ...queueData.victories.dreams.recent,
-                ...queueData.victories.relief.recent,
-              ].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()), 14)}
-              sparkColor="green"
-            />
-          )}
-          {agentMergedCount != null && agentMergedCount > 0 && (
-            <StatCard
-              label="Agent Merged"
-              value={agentMergedCount}
-              sub="PRs this week"
-              accent="#58a6ff"
-            />
-          )}
-          {testBuilds != null && (
-            <StatCard
-              label="Test Builds"
-              value={testBuilds}
-              sub="passed in testsuite"
-              accent="#3fb950"
-            />
-          )}
-          {tapPromotions != null && tapPromotions > 0 && (
-            <StatCard
-              label="Promoted"
-              value={tapPromotions}
-              sub="to production tap / 30d"
-              accent="#bc8cff"
-            />
-          )}
-          {repos.length > 0 && (
-            <StatCard label="Repos" value={repos.length} sub="in formation" />
-          )}
-          {snapshot?.medianMergeMins != null && (
-            <StatCard
-              label="Merge Time"
-              value={
-                snapshot.medianMergeMins < 60
-                  ? `${snapshot.medianMergeMins}m`
-                  : `${Math.round((snapshot.medianMergeMins / 60) * 10) / 10}h`
-              }
-              sub="median PR cycle"
-              accent="#39d2c0"
-            />
-          )}
-          {snapshot?.acmmLevel != null && (() => {
-            const info =
-              ACMM_LEVELS[snapshot.acmmLevel!] ?? {
-                label: "Unknown",
-                desc: "",
-                color: "#8b949e",
-              };
-            return (
-              <StatCard
-                label="ACMM Level"
-                value={`L${snapshot.acmmLevel}`}
-                sub={info.label}
-                accent={info.color}
-              />
-            );
-          })()}
+          <StatCard
+            label="Approved PRs"
+            value={queueData?.prs.approved.length ?? "—"}
+            sub="ready to merge"
+            accent={queueData && queueData.prs.approved.length > 0 ? "#3fb950" : undefined}
+          />
+          <StatCard
+            label="Shipped This Cycle"
+            value={queueData
+              ? (queueData.victories.dreams.count ?? 0) + (queueData.victories.relief.count ?? 0)
+              : "—"}
+            sub="features + fixes"
+            accent="#3fb950"
+            spark={queueData ? victorySparkData([
+              ...queueData.victories.dreams.recent,
+              ...queueData.victories.relief.recent,
+            ].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()), 14) : undefined}
+            sparkColor="green"
+          />
+          <StatCard
+            label="Test Builds"
+            value={testBuilds ?? "—"}
+            sub="passed in testsuite"
+            accent={testBuilds != null && testBuilds > 0 ? "#3fb950" : undefined}
+          />
+          <StatCard
+            label="Merge Time"
+            value={snapshot?.medianMergeMins != null
+              ? snapshot.medianMergeMins < 60
+                ? `${snapshot.medianMergeMins}m`
+                : `${Math.round((snapshot.medianMergeMins / 60) * 10) / 10}h`
+              : "—"}
+            sub="median PR cycle"
+            accent={snapshot?.medianMergeMins != null ? "#39d2c0" : undefined}
+          />
         </div>
 
-        {/* Governor — moved to top for prominence */}
-        <GovernorPanel governor={snapshot?.governor} />
+        {/* ── Factory Floor: Frame Formation (left) + sidebar (right) ── */}
+        <div className={styles.factoryFloor}>
+          {/* Left: Frame Formation — the factory floor */}
+          <section className={styles.panel}>
+            <Heading as="h2" className={styles.panelTitle}>
+              Factory Floor — Live
+            </Heading>
+            {agents.length > 0 ? (
+              <div className={styles.agentGrid}>
+                {agents.map((a) => (
+                  <FrameCard key={a.id} agent={a} advisoryItems={advisoriesByAgent[a.name] ?? []} />
+                ))}
+              </div>
+            ) : (
+              <div className={styles.empty}>No Frame data — snapshot updating</div>
+            )}
+          </section>
 
-        {/* Guardians / Ghosts */}
-        <div className={styles.destinyColumns}>
+          {/* Right: Governor + Victory Log + What Frames Are Working On */}
+          <div className={styles.factorySidebar}>
+            <GovernorPanel governor={snapshot?.governor} />
+            <VictoryLog victories={queueData?.victories ?? null} />
+            {advisoryItems.length > 0 && (
+              <section className={styles.panel}>
+                <Heading as="h2" className={styles.panelTitle}>
+                  What Frames Are Working On
+                </Heading>
+                <p className={styles.panelMeta}>
+                  Advisory digest — findings, bugs, CI failures logged by each Frame
+                </p>
+                <AgentWorkLog
+                  agents={agents}
+                  items={advisoryItems}
+                  advisoryIssue={snapshot?.advisoryIssue}
+                  config={config}
+                />
+              </section>
+            )}
+          </div>
+        </div>
+
+        {/* ── Intelligence Zone: Guardians | Ghosts | Recently Merged ── */}
+        <div className={styles.intelligenceZone}>
           <GuardiansColumn discussions={communityDiscussions} />
           <GhostsColumn hivePRs={hivePRsList} copilotPRs={copilotPRsList} />
+          <MergedPRFeed prs={mergedPRs} />
         </div>
 
-        {/* Victory Log */}
-        <VictoryLog victories={queueData?.victories ?? null} />
-
-        {/* Frame formation */}
-        {agents.length > 0 && (
-          <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>
-              Frame Formation
-            </Heading>
-            <div className={styles.agentGrid}>
-              {agents.map((a) => (
-                <FrameCard key={a.id} agent={a} advisoryItems={advisoriesByAgent[a.name] ?? []} />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* Frame work log */}
-        {advisoryItems.length > 0 && (
-          <section className={styles.panel}>
-            <Heading as="h2" className={styles.panelTitle}>
-              What Frames Are Working On
-            </Heading>
-            <p className={styles.panelMeta}>
-              Advisory digest — findings, bugs, CI failures logged by each Frame
-            </p>
-            <AgentWorkLog
-              agents={agents}
-              items={advisoryItems}
-              advisoryIssue={snapshot?.advisoryIssue}
-              config={config}
-            />
-          </section>
-        )}
-
-        {/* Merged + Contributors */}
-        <MergedPRFeed prs={mergedPRs} />
+        {/* ── Community ── */}
         <ContributorWall prs={mergedPRs} history={hiveHistory} />
-        <HistoryTrends history={hiveHistory} />
-        <ContributorLeaderboard history={hiveHistory} />
+
+        {/* ── History Zone: Trends | Community Builders ── */}
+        <div className={styles.twoCol}>
+          <HistoryTrends history={hiveHistory} />
+          <ContributorLeaderboard history={hiveHistory} />
+        </div>
 
         {/* Velocity + Org stats */}
         <div className={styles.twoCol}>


### PR DESCRIPTION
Redesigns the hive dashboard from a linear stack into purpose-built zones that read like a factory status screen.

Stats strip: fixed 6-column grid (repeat(6,1fr)) — always the same 6 canonical tiles: P1 Issues, Frames, Approved PRs, Shipped, Test Builds, Merge Time. No more auto-fill that produces orphaned wide cards. Shows — for unavailable data instead of hiding tiles.

Factory Floor zone (3fr | 2fr): Frame Formation is now the dominant above-the-fold element, renamed to "Factory Floor — Live". Governor panel, Victory Log, and What Frames Are Working On stack in the right sidebar as ambient context alongside the main floor.

Intelligence Zone (1fr | 1fr | 1fr): Guardians | Ghosts | Recently Merged share a 3-column row, replacing the previous 2-col Guardians/Ghosts block + standalone full-width MergedPRFeed.

History Zone: HistoryTrends and Community Builders leaderboard side by side in twoCol instead of two consecutive full-width panels.

Governor mode chip: full 4-mode coloring — SURGE / BUSY / QUIET / IDLE each get distinct color classes.

All zones collapse to single column on mobile.