### PR TITLE
fix(hive): bypass CORS by fetching registry data at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "generate-report": "node scripts/generate-report.mjs",
     "fetch-sbom": "node scripts/fetch-github-sbom.js",
     "fetch-hive-history": "node scripts/fetch-hive-history.js",
+    "fetch-registry-data": "node scripts/fetch-registry-data.js",
     "fetch-firehose": "node scripts/fetch-firehose.js",
     "generate-card-images": "node scripts/generate-card-images.mjs",
     "fetch-data": "npm run fetch-data:independent && npm run fetch-pin-state && npm run fetch-data:dependent",
-    "fetch-data:independent": "npm run fetch-feeds & npm run fetch-playlists & npm run fetch-github-profiles & npm run fetch-github-repos & npm run fetch-contributors & npm run fetch-gnome-extensions & wait",
+    "fetch-data:independent": "npm run fetch-feeds & npm run fetch-playlists & npm run fetch-github-profiles & npm run fetch-github-repos & npm run fetch-contributors & npm run fetch-gnome-extensions & npm run fetch-registry-data & wait",
     "fetch-data:dependent": "npm run fetch-github-driver-versions & npm run fetch-github-images & npm run fetch-firehose & wait",
     "test": "node --test scripts/*.test.js",
     "fetch-pin-state": "node scripts/fetch-pin-state.js"

--- a/scripts/fetch-registry-data.js
+++ b/scripts/fetch-registry-data.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Fetches registry data from hive.kubestellar.io/api/registry at build time.
+ * Saves the projectbluefin entry to static/data/registry-data.json.
+ *
+ * The registry API has no CORS headers, so browser-side fetches are blocked.
+ * This script runs in Node.js (no CORS restriction) and bakes the data in.
+ *
+ * Respects 24-hour file cache unless --force is passed.
+ */
+
+import { writeFileSync, existsSync, statSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, "../static/data/registry-data.json");
+const REGISTRY_URL = "https://hive.kubestellar.io/api/registry";
+const TARGET_ORG = "projectbluefin";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const force = process.argv.includes("--force");
+
+if (!force && existsSync(OUT)) {
+  const age = Date.now() - statSync(OUT).mtimeMs;
+  if (age < CACHE_TTL_MS) {
+    console.log(`fetch-registry-data: cache fresh (${Math.round(age / 60000)}m old), skipping`);
+    process.exit(0);
+  }
+}
+
+console.log(`fetch-registry-data: fetching ${REGISTRY_URL}`);
+try {
+  const res = await fetch(REGISTRY_URL);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  const entry = data.hives?.find((h) => h.org === TARGET_ORG) ?? null;
+  if (!entry) {
+    console.warn(`fetch-registry-data: no entry for org=${TARGET_ORG}, writing null`);
+    writeFileSync(OUT, "null\n");
+  } else {
+    writeFileSync(OUT, JSON.stringify(entry, null, 2) + "\n");
+    console.log(`fetch-registry-data: wrote ${OUT} (acmmLevel=${entry.acmmLevel}, mode=${entry.governorMode})`);
+  }
+} catch (err) {
+  console.error(`fetch-registry-data: fetch failed: ${err.message}`);
+  // Write a null file so the build doesn't fail and the dashboard degrades gracefully
+  if (!existsSync(OUT)) writeFileSync(OUT, "null\n");
+  process.exit(0);
+}

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -400,8 +400,8 @@ const HOSTED_INSTANCE_URL =
   "https://hosted-projectbluefin-knuckle-gjvq.hive.kubestellar.io";
 
 // Public registry — no auth required, updated every ~15 min by the hub
-const REGISTRY_URL = "https://hive.kubestellar.io/api/registry";
-const REGISTRY_ORG = "projectbluefin";
+// Registry data is fetched at build time via scripts/fetch-registry-data.js
+// and served from /data/registry-data.json (avoids browser CORS block on live API)
 
 // Snapshot: fetch /api/status directly from the hosted Knuckle instance.
 // Credentials are included so authenticated hive users get live governor/agent data.
@@ -1920,7 +1920,6 @@ function GovernorPanel({ governor, registry }: { governor?: HiveGovernor; regist
   const sparkMax = Math.max(...sparkVals, 1);
 
   const hasData = governor != null || registry != null;
-  if (!hasData) return null;
 
   return (
     <section className={styles.panel}>
@@ -2717,7 +2716,6 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         mergedRes,
         openedRes,
         closedRes,
-        registryRes,
       ] = await Promise.allSettled([
         fetchTimeout(SNAPSHOT_API_URL, 12000, { credentials: "include" }),
         fetchQueueData(),
@@ -2734,17 +2732,7 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         fetchTimeout(
           `${GH_API}/search/issues?q=org:projectbluefin+type:issue+closed:>${weekAgoISO}&per_page=1`,
         ),
-        fetchTimeout(REGISTRY_URL, 10000),
       ]);
-
-      // Public registry — no auth, always available
-      if (registryRes.status === "fulfilled" && registryRes.value.ok) {
-        try {
-          const regData = (await registryRes.value.json()) as { hives?: RegistryEntry[] };
-          const entry = regData.hives?.find((h) => h.org === REGISTRY_ORG) ?? null;
-          if (entry) setRegistryData(entry);
-        } catch { /* non-fatal */ }
-      }
 
       // Hive snapshot — /api/status returns JSON directly (same shape as old render() payload)
       if (htmlRes.status === "fulfilled" && htmlRes.value.ok) {
@@ -2968,6 +2956,14 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
     fetch("/data/hive-history.json")
       .then((r) => r.ok ? r.json() as Promise<HiveHistory> : null)
       .then((data) => { if (data) setHiveHistory(data); })
+      .catch(() => {/* non-fatal */});
+  }, []);
+
+  // Fetch registry data (baked at build time — avoids CORS block on live API)
+  useEffect(() => {
+    fetch("/data/registry-data.json")
+      .then((r) => r.ok ? r.json() as Promise<RegistryEntry | null> : null)
+      .then((data) => { if (data) setRegistryData(data); })
       .catch(() => {/* non-fatal */});
   }, []);
 


### PR DESCRIPTION
The hive.kubestellar.io/api/registry endpoint has no Access-Control-Allow-Origin header. Browser fetches from docs.projectbluefin.io are blocked, causing all registry-derived data (governor mode, ACMM level, agents, health checks, leaderboard, issue history sparkline) to show — and causing GovernorPanel to disappear from the sidebar.

Root cause confirmed by:
```
curl -si https://hive.kubestellar.io/api/registry -H 'Origin: https://docs.projectbluefin.io' | grep -i access-control
```
Returns nothing — no CORS headers present.

Fix: add scripts/fetch-registry-data.js which fetches the registry at build time (Node.js has no CORS restriction). Output goes to static/data/registry-data.json, served from same origin. Dashboard reads it via useEffect fetch on /data/registry-data.json.

- scripts/fetch-registry-data.js: build-time script with 24h cache, graceful null fallback
- package.json: fetch-registry-data in fetch-data:independent phase (runs in parallel with other fetches)
- HiveFactoryDashboard.tsx: remove live API fetch, add static file useEffect, fix GovernorPanel to always render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced build-time registry data fetching with intelligent 24-hour caching to reduce runtime API calls.

* **Improvements**
  * Registry data now sourced from static assets built at compile-time, improving dashboard load performance.
  * Governor panel in the sidebar now renders with enhanced fallback state handling when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->