### PR TITLE
feat(hive): fetch all GitHub Search data at build time using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,8 @@ jobs:
             static/data/images.json
             static/data/playlist-metadata.json
             static/data/stream-pins.json
+            static/data/registry-data.json
+            static/data/hive-live-data.json
           key: github-data-${{ hashFiles('scripts/fetch-*.js') }}
           restore-keys: |
             github-data-
@@ -124,6 +126,9 @@ jobs:
           # page shows current releases. The committed seed is an empty array;
           # without this the cache check sees a fresh mtime and skips the fetch.
           FIREHOSE_CACHE_HOURS: "0"
+          # Always re-fetch hive live data (Guardians, Ghosts, PRs, stats) on
+          # every build so the factory dashboard shows current GitHub state.
+          HIVE_LIVE_CACHE_HOURS: "0"
         run: npm run fetch-data
 
       - name: Restore card image cache

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "fetch-sbom": "node scripts/fetch-github-sbom.js",
     "fetch-hive-history": "node scripts/fetch-hive-history.js",
     "fetch-registry-data": "node scripts/fetch-registry-data.js",
+    "fetch-hive-live-data": "node scripts/fetch-hive-live-data.js",
     "fetch-firehose": "node scripts/fetch-firehose.js",
     "generate-card-images": "node scripts/generate-card-images.mjs",
     "fetch-data": "npm run fetch-data:independent && npm run fetch-pin-state && npm run fetch-data:dependent",
-    "fetch-data:independent": "npm run fetch-feeds & npm run fetch-playlists & npm run fetch-github-profiles & npm run fetch-github-repos & npm run fetch-contributors & npm run fetch-gnome-extensions & npm run fetch-registry-data & wait",
+    "fetch-data:independent": "npm run fetch-feeds & npm run fetch-playlists & npm run fetch-github-profiles & npm run fetch-github-repos & npm run fetch-contributors & npm run fetch-gnome-extensions & npm run fetch-registry-data & npm run fetch-hive-live-data & wait",
     "fetch-data:dependent": "npm run fetch-github-driver-versions & npm run fetch-github-images & npm run fetch-firehose & wait",
     "test": "node --test scripts/*.test.js",
     "fetch-pin-state": "node scripts/fetch-pin-state.js"

--- a/scripts/fetch-hive-live-data.js
+++ b/scripts/fetch-hive-live-data.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Fetches all GitHub data needed by the Hive Factory Dashboard at build time.
+ * Saves to static/data/hive-live-data.json so the browser never makes
+ * unauthenticated GitHub API calls (10 req/min limit) for this data.
+ *
+ * Uses GITHUB_TOKEN (or GH_TOKEN) for authenticated requests (5000 req/hr).
+ * Cache TTL: 15 minutes (live operational data; controlled by HIVE_LIVE_CACHE_HOURS).
+ *
+ * Output shape:
+ * {
+ *   fetchedAt: ISO string,
+ *   mergedPRs: GitHubIssueItem[],
+ *   discussions: GitHubIssueItem[],   // Guardians — community issues
+ *   hivePRs: GitHubIssueItem[],       // Ghosts — hive-bot open PRs
+ *   copilotPRs: GitHubIssueItem[],    // Ghosts — source:agent open PRs
+ *   velocity: { opened: number, closed: number },
+ *   testBuilds: number,
+ *   tapPromotions: number,
+ *   agentMergedCount: number,
+ *   orgStats: {
+ *     totalRepos, openIssues, openPRs, mergedThisWeek,
+ *     agentReadyIssues, agentOpenPRs, sourceAgentOpen
+ *   }
+ * }
+ */
+
+import { writeFileSync, existsSync, statSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, "../static/data/hive-live-data.json");
+
+const CACHE_TTL_HOURS = parseFloat(process.env.HIVE_LIVE_CACHE_HOURS ?? "0.25"); // 15 min default
+const CACHE_TTL_MS = CACHE_TTL_HOURS * 60 * 60 * 1000;
+const force = process.argv.includes("--force");
+
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+if (!TOKEN) {
+  console.warn("fetch-hive-live-data: no GITHUB_TOKEN — API calls will be rate-limited");
+}
+
+if (!force && existsSync(OUT)) {
+  const age = Date.now() - statSync(OUT).mtimeMs;
+  if (age < CACHE_TTL_MS) {
+    console.log(`fetch-hive-live-data: cache fresh (${Math.round(age / 60000)}m old, TTL ${Math.round(CACHE_TTL_HOURS * 60)}m), skipping`);
+    process.exit(0);
+  }
+}
+
+const GH_API = "https://api.github.com";
+const headers = {
+  Accept: "application/vnd.github.v3+json",
+  ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+};
+
+async function ghSearch(q, perPage = 30) {
+  const url = `${GH_API}/search/issues?q=${encodeURIComponent(q)}&sort=updated&order=desc&per_page=${perPage}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const err = await res.text().catch(() => res.statusText);
+    throw new Error(`${res.status} for ${url}: ${err.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function ghGet(path) {
+  const url = path.startsWith("http") ? path : `${GH_API}${path}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${res.status} for ${url}`);
+  return res.json();
+}
+
+async function safeSearch(q, perPage = 30) {
+  try { return await ghSearch(q, perPage); } catch (e) {
+    console.warn(`  warn: ${q.slice(0, 80)} — ${e.message}`);
+    return { total_count: 0, items: [] };
+  }
+}
+
+async function safeGet(path) {
+  try { return await ghGet(path); } catch (e) {
+    console.warn(`  warn: GET ${path} — ${e.message}`);
+    return {};
+  }
+}
+
+console.log("fetch-hive-live-data: fetching GitHub data...");
+
+const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+const monthAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+const org = "projectbluefin";
+
+// All queries run in parallel — authenticated token handles the rate limit
+const [
+  mergedData,
+  discussData,
+  hivePRData,
+  copilotPRData,
+  openedData,
+  closedData,
+  testData,
+  promosData,
+  agentMergedData,
+  orgData,
+  openIssuesData,
+  openPRsData,
+  agentReadyData,
+] = await Promise.all([
+  safeSearch(`org:${org} type:pr is:merged`, 30),
+  safeSearch(`org:${org} type:issue is:open -label:queue/agent-ready -label:source:agent`, 25),
+  safeSearch(`org:${org} type:pr is:open author:kubestellar-hive[bot]`, 25),
+  safeSearch(`org:${org} type:pr is:open label:source:agent`, 25),
+  safeSearch(`org:${org} type:issue created:>${weekAgo}`, 1),
+  safeSearch(`org:${org} type:issue closed:>${weekAgo}`, 1),
+  safeGet(`/repos/${org}/testsuite/actions/runs?status=success&per_page=1`),
+  safeSearch(`repo:ublue-os/homebrew-tap type:pr is:merged merged:>${monthAgo}`, 1),
+  safeSearch(`org:${org} type:pr is:merged author:kubestellar-hive[bot] merged:>${weekAgo}`, 1),
+  safeGet(`/orgs/${org}`),
+  safeSearch(`org:${org} state:open type:issue`, 1),
+  safeSearch(`org:${org} state:open type:pr`, 1),
+  safeSearch(`org:${org} label:queue/agent-ready state:open`, 1),
+]);
+
+function mapItem(i) {
+  return {
+    number: i.number,
+    title: i.title,
+    html_url: i.html_url,
+    repository_url: i.repository_url,
+    updated_at: i.updated_at,
+    created_at: i.created_at,
+    labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
+    comments: i.comments ?? 0,
+    user: i.user ? { login: i.user.login, avatar_url: i.user.avatar_url } : undefined,
+    draft: i.draft ?? false,
+    pull_request: i.pull_request ? { merged_at: i.pull_request.merged_at } : undefined,
+  };
+}
+
+const output = {
+  fetchedAt: new Date().toISOString(),
+  mergedPRs: (mergedData.items ?? []).map(mapItem),
+  discussions: (discussData.items ?? []).map(mapItem),
+  hivePRs: (hivePRData.items ?? []).map(mapItem),
+  copilotPRs: (copilotPRData.items ?? []).map(mapItem),
+  velocity: {
+    opened: openedData.total_count ?? 0,
+    closed: closedData.total_count ?? 0,
+  },
+  testBuilds: testData.total_count ?? testData.workflow_runs?.length ?? 0,
+  tapPromotions: promosData.total_count ?? 0,
+  agentMergedCount: agentMergedData.total_count ?? 0,
+  orgStats: {
+    totalRepos: orgData.public_repos ?? 0,
+    openIssues: openIssuesData.total_count ?? 0,
+    openPRs: openPRsData.total_count ?? 0,
+    mergedThisWeek: closedData.total_count ?? 0,
+    agentReadyIssues: agentReadyData.total_count ?? 0,
+    agentOpenPRs: hivePRData.total_count ?? 0,
+    sourceAgentOpen: copilotPRData.total_count ?? 0,
+  },
+};
+
+writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n");
+console.log(
+  `fetch-hive-live-data: wrote ${OUT}` +
+  ` (${output.mergedPRs.length} merged, ${output.discussions.length} discussions,` +
+  ` ${output.hivePRs.length + output.copilotPRs.length} agent PRs)`,
+);

--- a/src/components/HiveFactoryDashboard.tsx
+++ b/src/components/HiveFactoryDashboard.tsx
@@ -197,24 +197,6 @@ interface Velocity {
   closed: number;
 }
 
-interface GitHubSearchResponse<T> {
-  total_count?: number;
-  items?: T[];
-}
-
-interface GitHubSearchIssueItem {
-  number: number;
-  title: string;
-  repository_url?: string;
-  pull_request?: { url?: string };
-  user?: { login?: string; type?: string };
-  updated_at: string;
-  html_url: string;
-  labels?: Array<{ name: string; color: string }>;
-  comments?: number;
-  draft?: boolean;
-}
-
 interface CommunityDiscussion {
   number: number;
   title: string;
@@ -253,6 +235,42 @@ interface RepoPRs {
   total: number;
   agentPRs: number;
   label: string;
+}
+
+// ── Build-time hive live data (from static/data/hive-live-data.json) ────────
+interface HiveLiveItem {
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url?: string;
+  updated_at: string;
+  created_at?: string;
+  labels?: Array<{ name: string; color: string }>;
+  comments?: number;
+  user?: { login?: string; avatar_url?: string };
+  draft?: boolean;
+  pull_request?: { merged_at?: string | null };
+}
+
+interface HiveLiveData {
+  fetchedAt: string;
+  mergedPRs: HiveLiveItem[];
+  discussions: HiveLiveItem[];
+  hivePRs: HiveLiveItem[];
+  copilotPRs: HiveLiveItem[];
+  velocity: { opened: number; closed: number };
+  testBuilds: number;
+  tapPromotions: number;
+  agentMergedCount: number;
+  orgStats: {
+    totalRepos: number;
+    openIssues: number;
+    openPRs: number;
+    mergedThisWeek: number;
+    agentReadyIssues: number;
+    agentOpenPRs: number;
+    sourceAgentOpen: number;
+  };
 }
 
 // ── Hive history types ─────────────────────────────────────────────────────
@@ -760,31 +778,6 @@ function governorModeClass(mode?: string): string {
     case "quiet": return styles.govModeQuiet;
     default: return styles.govModeIdle;
   }
-}
-
-async function parseSearchCount(
-  result: PromiseSettledResult<Response>,
-): Promise<number> {
-  if (result.status !== "fulfilled" || !result.value.ok) return 0;
-  const data = (await result.value.json()) as GitHubSearchResponse<unknown>;
-  return data.total_count ?? 0;
-}
-
-async function parseMergedPRs(
-  result: PromiseSettledResult<Response>,
-): Promise<MergedPR[]> {
-  if (result.status !== "fulfilled" || !result.value.ok) return [];
-  const data = (await result.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
-  const items = Array.isArray(data.items) ? data.items : [];
-  return items.map((item) => ({
-    number: item.number,
-    title: item.title,
-    repo: parseRepoName(item.repository_url),
-    author: item.user?.login ?? "unknown",
-    isBot: item.user?.type === "Bot" || isBotLogin(item.user?.login ?? ""),
-    updatedAt: item.updated_at,
-    url: item.html_url,
-  }));
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────
@@ -2704,48 +2697,20 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
 
   const fetchAll = useCallback(async () => {
     try {
-      const weekAgoISO = new Date(Date.now() - 7 * 24 * 3600 * 1000)
-        .toISOString()
-        .slice(0, 10);
-
+      // Only fetch live/private data that can't be baked at build time:
+      // snapshot (auth-gated), queue (public, changes every 10m), dakota CI (REST not search)
+      // All GitHub Search API calls are in hive-live-data.json (build-time, authenticated).
       const [
         htmlRes,
         queueRes,
         repoRes,
         ciRes,
-        mergedRes,
-        openedRes,
-        closedRes,
-        discussRes,
-        hivePRRes,
-        copilotPRRes,
       ] = await Promise.allSettled([
         fetchTimeout(SNAPSHOT_API_URL, 12000, { credentials: "include" }),
         fetchQueueData(),
         fetchTimeout(`${GH_API}/repos/${DAKOTA}`),
         fetchTimeout(
           `${GH_API}/repos/${DAKOTA}/actions/workflows/${BUILD_WORKFLOW}/runs?per_page=1&status=completed`,
-        ),
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged&sort=updated&per_page=30`,
-        ),
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:issue+created:>${weekAgoISO}&per_page=1`,
-        ),
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:issue+closed:>${weekAgoISO}&per_page=1`,
-        ),
-        // Guardians: open community issues, sorted by latest activity
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:issue+is:open+-label:queue%2Fagent-ready+-label:source%3Aagent&sort=updated&order=desc&per_page=25`,
-        ),
-        // Ghosts: PRs authored by the hive bot
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:open+author:kubestellar-hive%5Bbot%5D&sort=updated&order=desc&per_page=25`,
-        ),
-        // Ghosts: PRs labeled source:agent (Copilot-assisted)
-        fetchTimeout(
-          `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:open+label:source%3Aagent&sort=updated&order=desc&per_page=25`,
         ),
       ]);
 
@@ -2773,72 +2738,7 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
         setQueue({ ready: agentReady, claimed: 0, p0: p0Count });
       }
 
-      setMergedPRs(await parseMergedPRs(mergedRes));
-      const opened = await parseSearchCount(openedRes);
-      const closed = await parseSearchCount(closedRes);
-      setVelocity({ opened, closed });
-
-      // Guardians: community discussions (from main batch — guaranteed before rate limit)
-      let localHivePRs: AgentAssistedPR[] = [];
-      let localCopilotPRs: AgentAssistedPR[] = [];
-
-      if (discussRes.status === "fulfilled" && discussRes.value.ok) {
-        const d = (await discussRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
-        setCommunityDiscussions(
-          (d.items ?? []).map((i) => ({
-            number: i.number,
-            title: i.title,
-            html_url: i.html_url,
-            repository_url: i.repository_url,
-            updated_at: i.updated_at,
-            labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
-            comments: i.comments,
-            user: i.user ? { login: i.user.login } : undefined,
-          })),
-        );
-      } else {
-        setCommunityDiscussions([]); // show empty state rather than loading spinner
-      }
-
-      // Ghosts: hive-bot PRs (from main batch)
-      if (hivePRRes.status === "fulfilled" && hivePRRes.value.ok) {
-        const d = (await hivePRRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
-        localHivePRs = (d.items ?? []).map((i) => ({
-          number: i.number,
-          title: i.title,
-          html_url: i.html_url,
-          repository_url: i.repository_url,
-          updated_at: i.updated_at,
-          labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
-          user: i.user ? { login: i.user.login } : undefined,
-          draft: i.draft,
-          agentType: "hive" as const,
-        }));
-        setHivePRsList(localHivePRs);
-      } else {
-        setHivePRsList([]);
-      }
-
-      // Ghosts: source:agent PRs (from main batch)
-      if (copilotPRRes.status === "fulfilled" && copilotPRRes.value.ok) {
-        const d = (await copilotPRRes.value.json()) as GitHubSearchResponse<GitHubSearchIssueItem>;
-        localCopilotPRs = (d.items ?? []).map((i) => ({
-          number: i.number,
-          title: i.title,
-          html_url: i.html_url,
-          repository_url: i.repository_url,
-          updated_at: i.updated_at,
-          labels: (i.labels ?? []).map((l) => ({ name: l.name, color: l.color })),
-          user: i.user ? { login: i.user.login } : undefined,
-          draft: i.draft,
-          agentType: "copilot" as const,
-        }));
-        setCopilotPRsList(localCopilotPRs);
-      } else {
-        setCopilotPRsList([]);
-      }
-
-      // Repo stats + CI
+      // Repo stats + CI — uses REST API (not search), generous rate limit
       if (repoRes.status === "fulfilled" && repoRes.value.ok) {
         const repo = (await repoRes.value.json()) as {
           stargazers_count: number;
@@ -2860,79 +2760,13 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
                   : "pending";
           }
         }
-        let openPRs = 0;
-        try {
-          const prRes = await fetchTimeout(
-            `${GH_API}/search/issues?q=repo:${DAKOTA}+type:pr+state:open`,
-          );
-          if (prRes.ok) {
-            const prData =
-              (await prRes.json()) as GitHubSearchResponse<unknown>;
-            openPRs = prData.total_count ?? 0;
-          }
-        } catch {
-          /* non-fatal */
-        }
         setDakotaStats({
           stars: repo.stargazers_count,
           forks: repo.forks_count,
           openIssues: repo.open_issues_count,
-          openPRs,
+          openPRs: 0,
           ciStatus,
         });
-      }
-
-      // Org-wide stats — derived from already-fetched data (no extra API calls)
-      // Avoids burning the 10 req/min unauthenticated search rate limit
-      try {
-        const orgRepoRes = await fetchTimeout(`${GH_API}/orgs/projectbluefin`);
-        const orgRepo = orgRepoRes.ok ? ((await orgRepoRes.json()) as { public_repos?: number }) : {};
-        setOrgStats({
-          totalRepos: orgRepo.public_repos ?? 0,
-          openIssues: 0,   // not fetched to preserve rate limit
-          openPRs: 0,      // not fetched to preserve rate limit
-          mergedThisWeek: closed,
-          agentReadyIssues: 0, // not fetched to preserve rate limit
-          agentOpenPRs: localHivePRs.length,
-          sourceAgentOpen: localCopilotPRs.length,
-        });
-      } catch {
-        /* non-fatal */
-      }
-
-      // Supplementary production stats (non-blocking, best-effort — 3 search calls)
-      try {
-        const monthAgoISO = new Date(Date.now() - 30 * 24 * 3600 * 1000)
-          .toISOString()
-          .slice(0, 10);
-        const [testRes, promosRes, agentMergedRes] = await Promise.allSettled([
-          // Successful CI runs in the hardware test suite this week
-          fetchTimeout(
-            `${GH_API}/repos/projectbluefin/testsuite/actions/runs?status=success&per_page=1`,
-          ),
-          // PRs merged to the production homebrew tap this month (promotions)
-          fetchTimeout(
-            `${GH_API}/search/issues?q=repo:ublue-os/homebrew-tap+type:pr+is:merged+merged:>${monthAgoISO}&per_page=1`,
-          ),
-          // PRs merged by the hive agent this week (agent output rate)
-          fetchTimeout(
-            `${GH_API}/search/issues?q=org:projectbluefin+type:pr+is:merged+author:kubestellar-hive%5Bbot%5D+merged:>${weekAgoISO}&per_page=1`,
-          ),
-        ]);
-        if (testRes.status === "fulfilled" && testRes.value.ok) {
-          const d = (await testRes.value.json()) as { total_count?: number };
-          setTestBuilds(d.total_count ?? 0);
-        }
-        if (promosRes.status === "fulfilled" && promosRes.value.ok) {
-          const d = (await promosRes.value.json()) as GitHubSearchResponse<unknown>;
-          setTapPromotions(d.total_count ?? 0);
-        }
-        if (agentMergedRes.status === "fulfilled" && agentMergedRes.value.ok) {
-          const d = (await agentMergedRes.value.json()) as GitHubSearchResponse<unknown>;
-          setAgentMergedCount(d.total_count ?? 0);
-        }
-      } catch {
-        /* non-fatal */
       }
     } finally {
       setLoading(false);
@@ -2955,6 +2789,70 @@ export default function HiveFactoryDashboard(): React.JSX.Element {
       .then((r) => r.ok ? r.json() as Promise<RegistryEntry | null> : null)
       .then((data) => { if (data) setRegistryData(data); })
       .catch(() => {/* non-fatal */});
+  }, []);
+
+  // Fetch hive live data (GitHub Search API data baked at build time using GITHUB_TOKEN)
+  useEffect(() => {
+    fetch("/data/hive-live-data.json")
+      .then((r) => r.ok ? r.json() as Promise<HiveLiveData> : null)
+      .then((data) => {
+        if (!data) return;
+        setMergedPRs(
+          (data.mergedPRs ?? []).map((i) => ({
+            number: i.number,
+            title: i.title,
+            repo: parseRepoName(i.repository_url ?? ""),
+            author: i.user?.login ?? "unknown",
+            isBot: isBotLogin(i.user?.login ?? ""),
+            updatedAt: i.updated_at,
+            url: i.html_url,
+          })),
+        );
+        setCommunityDiscussions(
+          (data.discussions ?? []).map((i) => ({
+            number: i.number,
+            title: i.title,
+            html_url: i.html_url,
+            repository_url: i.repository_url,
+            updated_at: i.updated_at,
+            labels: i.labels,
+            comments: i.comments,
+            user: i.user ? { login: i.user.login } : undefined,
+          })),
+        );
+        setHivePRsList(
+          (data.hivePRs ?? []).map((i) => ({
+            number: i.number,
+            title: i.title,
+            html_url: i.html_url,
+            repository_url: i.repository_url,
+            updated_at: i.updated_at,
+            labels: i.labels,
+            user: i.user ? { login: i.user.login } : undefined,
+            draft: i.draft,
+            agentType: "hive" as const,
+          })),
+        );
+        setCopilotPRsList(
+          (data.copilotPRs ?? []).map((i) => ({
+            number: i.number,
+            title: i.title,
+            html_url: i.html_url,
+            repository_url: i.repository_url,
+            updated_at: i.updated_at,
+            labels: i.labels,
+            user: i.user ? { login: i.user.login } : undefined,
+            draft: i.draft,
+            agentType: "copilot" as const,
+          })),
+        );
+        if (data.velocity) setVelocity(data.velocity);
+        if (data.testBuilds != null) setTestBuilds(data.testBuilds);
+        if (data.tapPromotions != null) setTapPromotions(data.tapPromotions);
+        if (data.agentMergedCount != null) setAgentMergedCount(data.agentMergedCount);
+        if (data.orgStats) setOrgStats(data.orgStats);
+      })
+      .catch(() => {/* non-fatal — dashboard degrades gracefully */});
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Moves all GitHub Search API calls from browser-side (unauthenticated, 10 req/min) to build time (authenticated via GITHUB_TOKEN, 5000 req/hr).

## Changes

- New script: scripts/fetch-hive-live-data.js
  - Fetches: merged PRs (30), community discussions (25), hive-bot PRs (25), source:agent PRs (25), velocity, test builds, tap promotions, agent merged count, org stats
  - Cache TTL: 15 minutes (HIVE_LIVE_CACHE_HOURS env var)
  - Output: static/data/hive-live-data.json

- Dashboard: removes all GitHub Search API browser calls from fetchAll
  - fetchAll now only handles: snapshot (auth-gated), queue (public), dakota CI (REST)
  - New useEffect loads /data/hive-live-data.json at mount (same pattern as hive-history.json and registry-data.json)
  - Removes unused parseMergedPRs, parseSearchCount helpers and GitHubSearchResponse, GitHubSearchIssueItem interfaces

- pages.yml: adds hive-live-data.json and registry-data.json to github-data-* cache, adds HIVE_LIVE_CACHE_HOURS=0 to always re-fetch in CI

## Result

Guardians column (community discussions), Ghosts column (agent PRs), Recently Merged feed, velocity, and org stats all now come from the static JSON baked at build time. No more rate-limit failures on these panels.