### PR TITLE
chore: remove GTS announcement banner

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -131,14 +131,6 @@ const config: Config = {
         hideable: false,
       },
     },
-    announcementBar: {
-      id: "announcement",
-      content:
-        'Reminder: Bluefin GTS has been merged into mainline Bluefin. Check the <a href="https://docs.projectbluefin.io/blog/bluefin-2025/">State of the Raptor</a> for more information.',
-      backgroundColor: "#fafbfc",
-      textColor: "#091E42",
-      isCloseable: true,
-    },
     metadata: [
       {
         name: "keywords",


### PR DESCRIPTION
Removes the stale GTS announcement bar. The announcementBar slot in docusaurus.config.ts is reserved for future use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the site-wide announcement banner from the documentation site, so the page now loads without that message or its close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->