### PR TITLE
feat(sparklines): shared Sparkline component + version trend sparklines on driver versions page

### DIFF
--- a/src/components/DriverVersionsCatalog.module.css
+++ b/src/components/DriverVersionsCatalog.module.css
@@ -817,6 +817,33 @@
   border-color: color-mix(in srgb, #4a9eff 30%, transparent);
 }
 
+/* ── Version trend sparklines in stream header ───────────────────────────── */
+.versionTrends {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.trendChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.trendLabel {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-600);
+  white-space: nowrap;
+}
+
 /* ── Userspace marker center upgrade badge ──────────────────────────────── */
 .userspaceMarkerCenter {
   flex-shrink: 0;

--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -4,6 +4,7 @@ import Heading from "@theme/Heading";
 import CodeBlock from "@theme/CodeBlock";
 import driverVersionsData from "@site/static/data/driver-versions.json";
 import streamPinsData from "@site/static/data/stream-pins.json";
+import Sparkline from "@site/src/components/Sparkline";
 import styles from "./DriverVersionsCatalog.module.css";
 
 interface StreamPins {
@@ -106,6 +107,18 @@ function majorMinor(value: string | null | undefined) {
     major: Number.parseInt(match[1], 10),
     minor: Number.parseInt(match[2], 10),
   };
+}
+
+/** Extracts a sortable version number (major*1000+minor) for each history row,
+ *  oldest-first, suitable for feeding into a Sparkline. */
+function versionSparkData(history: DriverRow[], field: keyof VersionSet): number[] {
+  return [...history]
+    .reverse()
+    .map((r) => {
+      const { major, minor } = majorMinor(r.versions[field] as string | null);
+      return major !== null && minor !== null ? major * 1000 + minor : null;
+    })
+    .filter((v): v is number => v !== null);
 }
 
 interface UserspaceInfo {
@@ -421,6 +434,41 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
                   {currentUserspace.label}
                 </span>
               )}
+              {(() => {
+                const kernelSpark = versionSparkData(stream.history, "kernel");
+                const hweSpark = versionSparkData(stream.history, "hweKernel");
+                const mesaSpark = versionSparkData(stream.history, "mesa");
+                const gnomeSpark = versionSparkData(stream.history, "gnome");
+                if (kernelSpark.length < 2 && mesaSpark.length < 2) return null;
+                return (
+                  <div className={styles.versionTrends}>
+                    {kernelSpark.length >= 2 && (
+                      <span className={styles.trendChip} title="Kernel version trend across last releases">
+                        <span className={styles.trendLabel}>Kernel</span>
+                        <Sparkline data={kernelSpark} width={72} height={20} color="#3fb950" areaColor="rgba(63,185,80,0.10)" />
+                      </span>
+                    )}
+                    {hweSpark.length >= 2 && (
+                      <span className={styles.trendChip} title="HWE kernel version trend">
+                        <span className={styles.trendLabel}>HWE</span>
+                        <Sparkline data={hweSpark} width={72} height={20} color="#a371f7" areaColor="rgba(163,113,247,0.10)" />
+                      </span>
+                    )}
+                    {mesaSpark.length >= 2 && (
+                      <span className={styles.trendChip} title="Mesa version trend across last releases">
+                        <span className={styles.trendLabel}>Mesa</span>
+                        <Sparkline data={mesaSpark} width={72} height={20} color="#58a6ff" areaColor="rgba(88,166,255,0.10)" />
+                      </span>
+                    )}
+                    {gnomeSpark.length >= 2 && (
+                      <span className={styles.trendChip} title="GNOME version trend across last releases">
+                        <span className={styles.trendLabel}>GNOME</span>
+                        <Sparkline data={gnomeSpark} width={72} height={20} color="#d97706" areaColor="rgba(217,119,6,0.10)" />
+                      </span>
+                    )}
+                  </div>
+                );
+              })()}
             </header>
 
             {latest ? (

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  /** Stroke color — use named CSS colors or hex; CSS custom properties not supported in inline SVG */
+  color?: string;
+  /** Fill color for the area under the line. Defaults to 10% opacity of stroke color. Pass "none" to disable. */
+  areaColor?: string;
+}
+
+/**
+ * Zero-dependency inline SVG sparkline. Works in SSR/SSG contexts.
+ * Normalizes data to fill the available height range.
+ */
+export default function Sparkline({
+  data,
+  width = 120,
+  height = 28,
+  color = "#58a6ff",
+  areaColor,
+}: SparklineProps) {
+  if (!data || data.length < 2) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const pad = 2;
+
+  const pts = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - pad - ((v - min) / range) * (height - pad * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const linePts = pts.join(" ");
+  const fill =
+    areaColor === "none"
+      ? "none"
+      : (areaColor ?? "rgba(88, 166, 255, 0.10)");
+  const area = `M ${pts[0]} L ${pts.slice(1).join(" L ")} L ${width},${height} L 0,${height} Z`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      aria-hidden="true"
+      style={{ display: "inline-block", verticalAlign: "middle", overflow: "visible" }}
+    >
+      {fill !== "none" && <path d={area} fill={fill} />}
+      <polyline
+        points={linePts}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Adds a reusable zero-dependency inline SVG sparkline and wires it into the Driver Versions catalog stream headers.

## Changes

- New src/components/Sparkline.tsx — pure SVG polyline + area fill, SSR-safe, zero new deps. Props: data, width, height, color, areaColor.
- DriverVersionsCatalog.tsx — new versionSparkData() helper converts version strings (e.g. 6.19.12-200.fc43) to sortable numerics (major*1000+minor), oldest-first. Stream headers now show Kernel/HWE/Mesa/GNOME sparkline chips when >=2 data points exist.
- DriverVersionsCatalog.module.css — .versionTrends/.trendChip/.trendLabel for sparkline cluster layout.

## What it shows

Each stream header gets an at-a-glance velocity signal: flat line = version pinned/stable, upward slope = actively tracking upstream. Color coded: Kernel=green, HWE=purple, Mesa=blue, GNOME=amber.

The shared Sparkline component is available for reuse anywhere on the site — analytics page, ImagesCatalog download trends, future dashboards, MDX pages.