### PR TITLE
fix(sparklines): fix trend guard and Sparkline default fill

### DIFF
--- a/src/components/DriverVersionsCatalog.tsx
+++ b/src/components/DriverVersionsCatalog.tsx
@@ -439,7 +439,7 @@ export default function DriverVersionsCatalog({ streamId }: DriverVersionsCatalo
                 const hweSpark = versionSparkData(stream.history, "hweKernel");
                 const mesaSpark = versionSparkData(stream.history, "mesa");
                 const gnomeSpark = versionSparkData(stream.history, "gnome");
-                if (kernelSpark.length < 2 && mesaSpark.length < 2) return null;
+                if (kernelSpark.length < 2 && hweSpark.length < 2 && mesaSpark.length < 2 && gnomeSpark.length < 2) return null;
                 return (
                   <div className={styles.versionTrends}>
                     {kernelSpark.length >= 2 && (

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -35,10 +35,8 @@ export default function Sparkline({
   });
 
   const linePts = pts.join(" ");
-  const fill =
-    areaColor === "none"
-      ? "none"
-      : (areaColor ?? "rgba(88, 166, 255, 0.10)");
+  // ponytail: callers pass explicit areaColor; default "transparent" avoids color mismatch
+  const fill = areaColor === "none" || areaColor === undefined ? "transparent" : areaColor;
   const area = `M ${pts[0]} L ${pts.slice(1).join(" L ")} L ${width},${height} L 0,${height} Z`;
 
   return (
@@ -49,7 +47,7 @@ export default function Sparkline({
       aria-hidden="true"
       style={{ display: "inline-block", verticalAlign: "middle", overflow: "visible" }}
     >
-      {fill !== "none" && <path d={area} fill={fill} />}
+      {fill !== "transparent" && <path d={area} fill={fill} />}
       <polyline
         points={linePts}
         fill="none"


### PR DESCRIPTION
Two fixes from rubber duck review of PR #969.

1. DriverVersionsCatalog trend guard only checked kernel+mesa length, hiding the whole sparkline cluster if those had <2 data points even when hweKernel or gnome had valid trend data. Guard now checks all four series.

2. Sparkline.tsx default areaColor was hardcoded blue rgba(88,166,255,0.10) regardless of the color prop. Default is now transparent — callers control the fill. All current call sites pass explicit areaColor so behavior is unchanged.