### PR TITLE
feat(nav+analytics): add Hive to navbar, replace analytics page with LFX widgets

### DIFF
--- a/docs/analytics.mdx
+++ b/docs/analytics.mdx
@@ -3,11 +3,13 @@ title: Analytics
 slug: /analytics
 ---
 
-Bluefin is a high performance predator, the team believes in the importance of instrumentation and telemetry as a means to improve software. However that information must be privacy respecting via an open process so that we can verify what information is being donated.
+[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=ublue-os-bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin)
+
+Bluefin is a high-performance predator. The team believes in instrumentation and telemetry as a means to improve software — but that information must be privacy-respecting via an open process so we can verify what is being shared.
 
 > Data, for me, is the foundation of F1. There's no human judgment involved. You've got to get your foundation right in data.
 >
-> -- [James Vowles](https://www.youtube.com/watch?v=nYzwvTSffiY&t=1025s)
+> — [James Vowles](https://www.youtube.com/watch?v=nYzwvTSffiY&t=1025s)
 
 ## Countme Statistics
 
@@ -20,43 +22,35 @@ Bluefin is a high performance predator, the team believes in the importance of i
   height="720"
 />
 
-The Fedora countme service is on by default in Fedora, and we inherit that behavior:
+The Fedora countme service is on by default in Fedora, and Bluefin inherits that behavior:
 
 - [countme](https://github.com/wgwoods/fedora-countme-data)
 - [How to turn it off](https://coreos.github.io/rpm-ostree/countme/)
 
 ## Homebrew
 
-Homebrew's analytics are on by default. To turn them off:
+Homebrew analytics are on by default. To turn them off:
 
 ```
 brew analytics off
 ```
 
-Check the [homebrew documentation](https://docs.brew.sh/Analytics) for more information. You can also checkout the [operating system rankings](https://formulae.brew.sh/analytics/os-version/30d/) as a fun competition.
+See the [Homebrew documentation](https://docs.brew.sh/Analytics) for more information. You can also check the [operating system rankings](https://formulae.brew.sh/analytics/os-version/30d/).
 
 ## Contributor Metrics
 
-Since Bluefin is an [Universal Blue](https://universal-blue.org) image, it leverages the shared maintenance of a larger community. Note that builds are automated, long periods of inactivity are normal.
+The charts below are sourced from [Linux Foundation Insights](https://insights.linuxfoundation.org/project/ublue-os-bluefin) and track the `ublue-os/bluefin` repository. For org-wide metrics across all 15 factory repos, see the [Hive dashboard](/hive).
 
-### Bluefin
+<div className="lfx-chart" style={{overflow:'hidden', borderRadius:'8px', height:'488px'}}>
+  <iframe src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=active-contributors" style={{transform:'scale(0.75)', transformOrigin:'top left', width:'133%', height:'800px', border:'none'}} />
+</div>
 
-![Alt](https://repobeats.axiom.co/api/embed/40b85b252bf6ea25eb90539d1adcea013ccae69a.svg "Repobeats analytics image")
+<div className="lfx-chart" style={{overflow:'hidden', borderRadius:'8px', height:'503px'}}>
+  <iframe src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=commit-activities" style={{transform:'scale(0.75)', transformOrigin:'top left', width:'133%', height:'820px', border:'none'}} />
+</div>
 
-### Bluefin LTS
+<div className="lfx-chart" style={{overflow:'hidden', borderRadius:'8px', height:'645px'}}>
+  <iframe src="https://insights.linuxfoundation.org/embed/project/ublue-os-bluefin?widget=pull-requests" style={{transform:'scale(0.75)', transformOrigin:'top left', width:'133%', height:'1010px', border:'none'}} />
+</div>
 
-![Alt](https://repobeats.axiom.co/api/embed/3e29c59ccd003fe1939ce0bdfccdee2b14203541.svg "Repobeats analytics image")
-
-### Bluefin Common
-
-Shared config and customization that's shared across all images
-
-![Alt](https://repobeats.axiom.co/api/embed/45dffc43196101fdeb340b462af3f7babe39eee3.svg "Repobeats analytics image")
-
-### Homebrew Packages
-
-![Alt](https://repobeats.axiom.co/api/embed/c4eb0b1a3a2baeb3cdb87b3a463a98e21e78eafc.svg "Repobeats analytics image")
-
-### Documentation
-
-![Alt](https://repobeats.axiom.co/api/embed/81441c406e02b3f796f1ac8b8977efcf6f08acd4.svg "Repobeats analytics image")
+For the full picture across all factory repositories, visit the [Hive Factory Dashboard](/hive).

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -177,6 +177,11 @@ const config: Config = {
           position: "right",
         },
         {
+          to: "/hive",
+          label: "Hive",
+          position: "right",
+        },
+        {
           href: "https://github.com/ublue-os/bluefin/discussions",
           label: "Discussions",
           position: "right",


### PR DESCRIPTION
## Changes

### Task 1: Add Hive to navbar (closes #970)
- Added 'Hive' navbar item on the right side (after Reports) linking to `/hive`
- The local `/hive` page hosts the full Hive Factory Dashboard component

### Task 2: Restructure analytics.mdx with LFX iframes (closes #971)
- Replaced 5 broken Repobeats SVGs (old `ublue-os/` paths) with 3 LFX iframe widgets
- Widgets: `active-contributors`, `commit-activities`, `pull-requests`
- Added LFX Health Score badge at the top
- Added scope note: LFX tracks `ublue-os/bluefin` (one repo); links to `/hive` for org-wide metrics
- Kept Countme and Homebrew analytics sections

## Decisions
- **Internal link for Hive**: Used `to: '/hive'` (local page) rather than the external hive URL — the local page serves the full HiveFactoryDashboard component and is the right discoverability target
- **3 widgets, not 6**: active-contributors + commit-activities + pull-requests tell the story; less is more per ponytail