### PR TITLE
feat(docs): show last-update timestamps, hide edit on data pages, fix stale content

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -75,7 +75,7 @@ The major difference between `latest` and `stable` is the kernel cadence and whe
 
 The `stable` tag features a gated kernel. This kernel follows the same version as the [Fedora CoreOS stable stream](https://fedoraproject.org/coreos/release-notes?arch=x86_64&stream=stable), which is a slower cadence than default Fedora Silverblue. The Universal Blue team may temporarily pin to a specific kernel in order to avoid regressions that may affect users.
 
-Adding and editing kernel boot arguments is currently handled by `rpm-ostree`, check the [upstream documentation](https://docs.fedoraproject.org/en-US/fedora-coreos/kernel-args/#_modifying_kernel_arguments_on_existing_systems) for more information.
+Adding and editing kernel boot arguments is handled by `bootc kargs`. Check the [upstream documentation](https://bootc-dev.github.io/bootc/bootc-kargs.html) for more information.
 
 :::info[It's all just Bluefin]
 

--- a/docs/artwork.mdx
+++ b/docs/artwork.mdx
@@ -2,6 +2,7 @@
 title: Artwork
 description: Browse and download Bluefin, Aurora, and Bazzite wallpapers and artwork assets.
 slug: artwork
+custom_edit_url: null
 ---
 
 import ArtworkGallery from '@site/src/components/ArtworkGallery';

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,9 +79,9 @@ Bluefin is a combination of a set of configuration OCI containers which are then
 
 ### Images 
 
-- Bluefin stable: [@ublue-os/bluefin](https://github.com/projectbluefin/bluefin) - generates Fedora-based Bluefin OCI container
-- Bluefin LTS [@ublue-os/bluefin-lts](https://github.com/projectbluefin/bluefin-lts) - generates a CentOS-based Bluefin OCI container
-- Bluefin distroless prototype (aka Dakotaraptor) [@ublue-os/dakota](https://github.com/projectbluefin/dakota) - generates a GNOME OS based Bluefin OCI container
+- Bluefin stable: [@projectbluefin/bluefin](https://github.com/projectbluefin/bluefin) - generates Fedora-based Bluefin OCI container
+- Bluefin LTS [@projectbluefin/bluefin-lts](https://github.com/projectbluefin/bluefin-lts) - generates a CentOS-based Bluefin OCI container
+- Bluefin distroless prototype (aka Dakotaraptor) [@projectbluefin/dakota](https://github.com/projectbluefin/dakota) - generates a GNOME OS based Bluefin OCI container
 
 :::info Distroless
 This is opposite of the traditional Linux distribution model, the value is in the other OCI layers, not the base image. This is what we mean by "distributions don't matter", since you can use any base image it's just another choice in the long list of decisions we have to make. It's still _important_, it just doesn't matter. And since you can source software from anywhere, the idea of "who gets you the same software better" doesn't make much sense when you can just automate that.

--- a/docs/driver-versions.mdx
+++ b/docs/driver-versions.mdx
@@ -1,6 +1,7 @@
 ---
 tags:
   - drivers
+custom_edit_url: null
 ---
 
 import DriverVersionsCatalog from "@site/src/components/DriverVersionsCatalog";

--- a/docs/images.md
+++ b/docs/images.md
@@ -3,6 +3,7 @@ id: images
 title: Images
 sidebar_position: 6
 hide_table_of_contents: true
+custom_edit_url: null
 pagination_next: null
 pagination_prev: null
 ---

--- a/docs/lts.mdx
+++ b/docs/lts.mdx
@@ -38,7 +38,7 @@ Bluefin LTS ships with Linux 6.12.0, which is the kernel for the lifetime of rel
 
 ### Differences from Bluefin
 
-- There may be instances when something from Bluefin is not implemented in Bluefin LTS. Please [file an issue](https://github.com/ublue-os/bluefin-lts/issues) and tag it with `parity` and the team will investigate. They'll never match _exactly_ but we can get the important ones done
+- There may be instances when something from Bluefin is not implemented in Bluefin LTS. Please [file an issue](https://github.com/projectbluefin/bluefin-lts/issues) and tag it with `parity` and the team will investigate. They'll never match _exactly_ but we can get the important ones done
 - Appimages are hard unsupported (those fuse packages aren't even in CentOS)
 - Local Layering is not supported
 
@@ -60,7 +60,7 @@ Do NOT rebase to this image from an existing Bluefin, Aurora, Bazzite, or Fedora
 
 ### Images
 
-- [Repository](https://github.com/ublue-os/bluefin-lts)
+- [Repository](https://github.com/projectbluefin/bluefin-lts)
 
 The following images and tags are available:
 
@@ -105,17 +105,17 @@ If there are other ways to set this up on MacOS please considering sending a pul
 To build locally and then spit out a VM:
 
 ```bash
-git clone https://github.com/ublue-os/bluefin-lts
+git clone https://github.com/projectbluefin/bluefin-lts
 cd bluefin-lts
 just build
-just build-qcow2 ghcr.io/ublue-os/bluefin:lts # if you want to build an ISO just change qcow2 to iso instead
+just build-qcow2 ghcr.io/projectbluefin/bluefin:lts # if you want to build an ISO just change qcow2 to iso instead
 ```
 
 The [qcow2](https://qemu-project.gitlab.io/qemu/system/images.html) file will be written to the `output/` directory. Default username and password are `centos`/`centos`
 
 #### Hibernation Enabled by Default
 
-Hibernation is on by default in a suspend-then-hibernate configuration. Here is the [exact config](https://github.com/ublue-os/bluefin-lts/blob/c0c8e2166cb5d0c4dd511ab3f677450c2cf8de0c/build_scripts/40-services.sh#L6). The device will suspend then go into hibernation after two hours. See the [systemd-sleep.conf](https://www.freedesktop.org/software/systemd/man/latest/systemd-sleep.conf.html) documentation.
+Hibernation is on by default in a suspend-then-hibernate configuration. Here is the [exact config](https://github.com/projectbluefin/bluefin-lts/blob/c0c8e2166cb5d0c4dd511ab3f677450c2cf8de0c/build_scripts/40-services.sh#L6). The device will suspend then go into hibernation after two hours. See the [systemd-sleep.conf](https://www.freedesktop.org/software/systemd/man/latest/systemd-sleep.conf.html) documentation.
 
 Note that secureboot and hibernation are mutually exclusive. We do not yet offer secureboot enabled images of Bluefin LTS, if you need that functionality now we recommend the normal Bluefin images.
 

--- a/docs/press-kit.md
+++ b/docs/press-kit.md
@@ -13,7 +13,7 @@ Thanks for generating content about Bluefin and Universal Blue! This document wi
 
 # Bluefin Terminology
 
-The name of the project is `Project Bluefin` but usually shortened to just `Bluefin`. It is built with [Universal Blue](https://universal-blue.org), which publishes base images that Bluefin uses. These in turn are derived from Fedora's Silverblue images. Universal Blue is the parent organization of [Bluefin](https://projectbluefin.io), [Bazzite](https://bazzite.gg), [Aurora](https://getaurora.dev), and [uCore](https://github.com/ublue-os/ucore). It also acts as the GitHub organization.
+The name of the project is `Project Bluefin` but usually shortened to just `Bluefin`. Bluefin is published under the [projectbluefin](https://github.com/projectbluefin) GitHub organization and is built using shared infrastructure from [Universal Blue](https://universal-blue.org). Universal Blue is the community umbrella that also hosts [Bazzite](https://bazzite.gg), [Aurora](https://getaurora.dev), and [uCore](https://github.com/ublue-os/ucore).
 
 ## Proper Usage
 
@@ -48,11 +48,11 @@ Also when dealing with communicating to end users, we want the word Universal to
 
 # Governance
 
-All Universal Blue images share governance structures and are modelled after cloud native projects such as Kubernetes:
+Bluefin is modelled after cloud native projects such as Kubernetes:
 
-- [Mission](https://universal-blue.org/mission.html)
-- [Values](https://universal-blue.org/values.html)
-- [Membership](https://universal-blue.org/membership.html)
+- [Mission](/mission)
+- [Values](/values)
+- [Code of Conduct](/code-of-conduct)
 
 # Contacts
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -102,7 +102,8 @@ const config: Config = {
           copyright: `Copyright © ${new Date().getFullYear()} Project Bluefin`,
         },
         // Enable table of contents in right sidebar
-        showLastUpdateTime: false,
+        showLastUpdateTime: true,
+        showLastUpdateAuthor: false,
       },
     ],
   ],


### PR DESCRIPTION
Three improvements from Context7 Docusaurus audit:

1. Enable showLastUpdateTime in docusaurus.config.ts — CI already uses fetch-depth: 0 so git timestamps are available. Every doc page now shows when it was last modified.

2. Add custom_edit_url: null to data-driven pages (images, driver-versions, artwork) — users can't meaningfully edit these component pages.

3. Fix stale content:
   - administration.md: rpm-ostree kargs → bootc kargs with correct upstream docs URL
   - press-kit.md: fix org description (projectbluefin, not 'Universal Blue is parent org'), fix governance links to use local /mission, /values, /code-of-conduct