### PR TITLE
chore(docs): brutal audit — fix ublue-os refs, update outdated commands

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -75,7 +75,7 @@ The major difference between `latest` and `stable` is the kernel cadence and whe
 
 The `stable` tag features a gated kernel. This kernel follows the same version as the [Fedora CoreOS stable stream](https://fedoraproject.org/coreos/release-notes?arch=x86_64&stream=stable), which is a slower cadence than default Fedora Silverblue. The Universal Blue team may temporarily pin to a specific kernel in order to avoid regressions that may affect users.
 
-Adding and editing kernel boot arguments is currently handled by `rpm-ostree`, check the [upstream documentation](https://docs.fedoraproject.org/en-US/fedora-coreos/kernel-args/#_modifying_kernel_arguments_on_existing_systems) for more information.
+Adding and editing kernel boot arguments is handled by `bootc kargs`. Check the [upstream documentation](https://bootc-dev.github.io/bootc/bootc-kargs.html) for more information.
 
 :::info[It's all just Bluefin]
 
@@ -318,7 +318,7 @@ This feature is incomplete and needs contributors to make it a reality
 
 :::
 
-Bluefin and Aurora include Cockpit for machine management. We're hoping to include more out-of-the-box management templates, please [check this issue](https://github.com/ublue-os/bluefin/issues/271) if you're interested in volunteering.
+Bluefin and Aurora include Cockpit for machine management. We're hoping to include more out-of-the-box management templates, please [check this issue](https://github.com/projectbluefin/bluefin/issues) if you're interested in volunteering.
 
 ## Verification
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,9 +79,9 @@ Bluefin is a combination of a set of configuration OCI containers which are then
 
 ### Images 
 
-- Bluefin stable: [@ublue-os/bluefin](https://github.com/projectbluefin/bluefin) - generates Fedora-based Bluefin OCI container
-- Bluefin LTS [@ublue-os/bluefin-lts](https://github.com/projectbluefin/bluefin-lts) - generates a CentOS-based Bluefin OCI container
-- Bluefin distroless prototype (aka Dakotaraptor) [@ublue-os/dakota](https://github.com/projectbluefin/dakota) - generates a GNOME OS based Bluefin OCI container
+- Bluefin stable: [@projectbluefin/bluefin](https://github.com/projectbluefin/bluefin) - generates Fedora-based Bluefin OCI container
+- Bluefin LTS [@projectbluefin/bluefin-lts](https://github.com/projectbluefin/bluefin-lts) - generates a CentOS-based Bluefin OCI container
+- Bluefin distroless prototype (aka Dakotaraptor) [@projectbluefin/dakota](https://github.com/projectbluefin/dakota) - generates a GNOME OS based Bluefin OCI container
 
 :::info Distroless
 This is opposite of the traditional Linux distribution model, the value is in the other OCI layers, not the base image. This is what we mean by "distributions don't matter", since you can use any base image it's just another choice in the long list of decisions we have to make. It's still _important_, it just doesn't matter. And since you can source software from anywhere, the idea of "who gets you the same software better" doesn't make much sense when you can just automate that.
@@ -918,7 +918,7 @@ git push origin your-branch --force-with-lease
 
 ### Code of Conduct
 
-All contributors must follow the [Universal Blue Code of Conduct](https://github.com/ublue-os/main?tab=coc-ov-file#readme).
+All contributors must follow the [Bluefin Code of Conduct](/code-of-conduct).
 
 **Key Points:**
 - Be respectful and inclusive

--- a/docs/local.md
+++ b/docs/local.md
@@ -5,7 +5,7 @@ slug: /local
 
 # Using the devcontainer
 
-Follow the [ublue-os/devcontainer](https://github.com/ublue-os/devcontainer) documentation.
+Follow the [projectbluefin/bluefin](https://github.com/projectbluefin/bluefin) documentation.
 
 # Building Bluefin
 
@@ -14,20 +14,6 @@ Bluefin is cloud native, so all the tooling can be run locally or on any server.
 First clone the repo:
 
 `git clone https://github.com/projectbluefin/bluefin.git`
-
-:::warning
-`origin` in this repo points to `ublue-os/bluefin` (the upstream source). Always push to `projectbluefin` explicitly:
-
-```bash
-git push projectbluefin your-branch-name
-```
-
-Or install the push guard hook after cloning:
-
-```bash
-bash .github/scripts/install-hooks.sh
-```
-:::
 
 The `Justfile` at the root of the repo is used to build the images. The general pattern is:
 

--- a/docs/lts.mdx
+++ b/docs/lts.mdx
@@ -38,7 +38,7 @@ Bluefin LTS ships with Linux 6.12.0, which is the kernel for the lifetime of rel
 
 ### Differences from Bluefin
 
-- There may be instances when something from Bluefin is not implemented in Bluefin LTS. Please [file an issue](https://github.com/ublue-os/bluefin-lts/issues) and tag it with `parity` and the team will investigate. They'll never match _exactly_ but we can get the important ones done
+- There may be instances when something from Bluefin is not implemented in Bluefin LTS. Please [file an issue](https://github.com/projectbluefin/bluefin-lts/issues) and tag it with `parity` and the team will investigate. They'll never match _exactly_ but we can get the important ones done
 - Appimages are hard unsupported (those fuse packages aren't even in CentOS)
 - Local Layering is not supported
 
@@ -60,7 +60,7 @@ Do NOT rebase to this image from an existing Bluefin, Aurora, Bazzite, or Fedora
 
 ### Images
 
-- [Repository](https://github.com/ublue-os/bluefin-lts)
+- [Repository](https://github.com/projectbluefin/bluefin-lts)
 
 The following images and tags are available:
 
@@ -105,17 +105,17 @@ If there are other ways to set this up on MacOS please considering sending a pul
 To build locally and then spit out a VM:
 
 ```bash
-git clone https://github.com/ublue-os/bluefin-lts
+git clone https://github.com/projectbluefin/bluefin-lts
 cd bluefin-lts
 just build
-just build-qcow2 ghcr.io/ublue-os/bluefin:lts # if you want to build an ISO just change qcow2 to iso instead
+just build-qcow2 ghcr.io/projectbluefin/bluefin:lts # if you want to build an ISO just change qcow2 to iso instead
 ```
 
 The [qcow2](https://qemu-project.gitlab.io/qemu/system/images.html) file will be written to the `output/` directory. Default username and password are `centos`/`centos`
 
 #### Hibernation Enabled by Default
 
-Hibernation is on by default in a suspend-then-hibernate configuration. Here is the [exact config](https://github.com/ublue-os/bluefin-lts/blob/c0c8e2166cb5d0c4dd511ab3f677450c2cf8de0c/build_scripts/40-services.sh#L6). The device will suspend then go into hibernation after two hours. See the [systemd-sleep.conf](https://www.freedesktop.org/software/systemd/man/latest/systemd-sleep.conf.html) documentation.
+Hibernation is on by default in a suspend-then-hibernate configuration. Here is the [exact config](https://github.com/projectbluefin/bluefin-lts/blob/c0c8e2166cb5d0c4dd511ab3f677450c2cf8de0c/build_scripts/40-services.sh#L6). The device will suspend then go into hibernation after two hours. See the [systemd-sleep.conf](https://www.freedesktop.org/software/systemd/man/latest/systemd-sleep.conf.html) documentation.
 
 Note that secureboot and hibernation are mutually exclusive. We do not yet offer secureboot enabled images of Bluefin LTS, if you need that functionality now we recommend the normal Bluefin images.
 

--- a/docs/press-kit.md
+++ b/docs/press-kit.md
@@ -13,7 +13,7 @@ Thanks for generating content about Bluefin and Universal Blue! This document wi
 
 # Bluefin Terminology
 
-The name of the project is `Project Bluefin` but usually shortened to just `Bluefin`. It is built with [Universal Blue](https://universal-blue.org), which publishes base images that Bluefin uses. These in turn are derived from Fedora's Silverblue images. Universal Blue is the parent organization of [Bluefin](https://projectbluefin.io), [Bazzite](https://bazzite.gg), [Aurora](https://getaurora.dev), and [uCore](https://github.com/ublue-os/ucore). It also acts as the GitHub organization.
+The name of the project is `Project Bluefin` but usually shortened to just `Bluefin`. Bluefin is published under the [projectbluefin](https://github.com/projectbluefin) GitHub organization and is built using shared infrastructure from [Universal Blue](https://universal-blue.org). Universal Blue is the community umbrella that also hosts [Bazzite](https://bazzite.gg), [Aurora](https://getaurora.dev), and [uCore](https://github.com/ublue-os/ucore).
 
 ## Proper Usage
 
@@ -48,11 +48,11 @@ Also when dealing with communicating to end users, we want the word Universal to
 
 # Governance
 
-All Universal Blue images share governance structures and are modelled after cloud native projects such as Kubernetes:
+Bluefin is modelled after cloud native projects such as Kubernetes:
 
-- [Mission](https://universal-blue.org/mission.html)
-- [Values](https://universal-blue.org/values.html)
-- [Membership](https://universal-blue.org/membership.html)
+- [Mission](/mission)
+- [Values](/values)
+- [Code of Conduct](/code-of-conduct)
 
 # Contacts
 

--- a/docs/t2-mac.md
+++ b/docs/t2-mac.md
@@ -4,9 +4,9 @@ author: Chris Lauretano
 slug: /t2-mac
 ---
 
-This is an addendum to the [Bluefin installation runbook](/introduction.md) for T2 Macs, supporting the project's goal of sustainability by enabling Bluefin installation on the final generation of Intel Macs (2018-2020). Apple ends support for them after 2024.
+This is an addendum to the [Bluefin installation runbook](/installation) for T2 Macs, supporting the project's goal of sustainability by enabling Bluefin installation on the final generation of Intel Macs (2018-2020). Apple ends support for them after 2024.
 
-Please read the original [Bluefin installation runbook](/introduction.md) as the contents of it are not reproduced here. Section Headings match up where possible.
+Please read the original [Bluefin installation runbook](/installation) as the contents of it are not reproduced here. Section Headings match up where possible.
 
 ## Day 0 - Planning
 
@@ -120,13 +120,13 @@ In a terminal, you'll install several packages and enable some daemons needed to
 3. After a reboot, ensure t2fanrd is running with `systemctl status t2fanrd`. Fan speed curves can be managed by editing `/etc/t2fanrd.conf`. See [T2FanRD](https://github.com/GnomedDev/T2FanRD) for details.
 
 4. Enable T2-appropriate kernel arguments.
-   In a terminal, run: `rpm-ostree kargs --append-if-missing=intel_iommu=on --append-if-missing=iommu=pt --append-if-missing=mem_sleep_default=s2idle` and reboot when prompted.
+   In a terminal, run: `sudo bootc kargs --append intel_iommu=on --append iommu=pt --append mem_sleep_default=s2idle` and reboot when prompted.
 
 ### Day 2-3 Post-Install Refinement for T2
 
 #### Allow internal keyboard during early boot (LUKS encryption unlock)
 
-Enable initramfs regeneration. This will enable dracut to run during upgrades, allowing us to configure the apple-bce module to load during early boot. `rpm-ostree initramfs enable` --Note that initramfs generation adds a fair bit of local CPU time after normal rpm-ostree upgrade processing happens.
+Enable initramfs regeneration. This will enable dracut to run during upgrades, allowing us to configure the apple-bce module to load during early boot. `sudo bootc initramfs --enable` --Note that initramfs generation adds a fair bit of local CPU time after normal rpm-ostree upgrade processing happens.
 
 - If layering T2 packages, create a config file that loads the apple-bce module: `echo "force_drivers+=\" apple-bce \"" | sudo tee /etc/dracut.conf.d/t2linux-modules.conf`
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -30,10 +30,10 @@ In the menu select "Ask Bluefin" to use the chat agent.
 
 <Tabs groupId="operating-systems">
   <TabItem value="linux" label="Linux" default>
-    ```brew install ublue-os/tap/linux-mcp-server ```
+    ```brew install rhel-lightspeed/tap/linux-mcp-server ```
   </TabItem>
   <TabItem value="macos" label="macOS">
-    ```brew install ublue-os/tap/linux-mcp-server ```
+    ```brew install rhel-lightspeed/tap/linux-mcp-server ```
   </TabItem>
 </Tabs>
 
@@ -56,7 +56,7 @@ Provides system diagnostics and monitoring tools:
 - Network diagnostics
 - File system inspection
 
-**Repository**: [ublue-os/linux-mcp-server](https://github.com/rhel-lightspeed/linux-mcp-server)
+**Repository**: [rhel-lightspeed/linux-mcp-server](https://github.com/rhel-lightspeed/linux-mcp-server)
 
 ### MCP Configuration
 
@@ -67,7 +67,7 @@ The configuration process differs depending on which AI client you're using:
 **Step 1: Install linux-mcp-server**
 
 ```bash
-brew install ublue-os/tap/linux-mcp-server
+brew install rhel-lightspeed/tap/linux-mcp-server
 ```
 
 **Step 2: Configure Goose**
@@ -111,7 +111,7 @@ ramalama serve qwen3:8b
 
 Then run `goose configure`, select **Ollama**, and set `OLLAMA_HOST` to `http://localhost:8080`.
 
-[LM Studio](https://lmstudio.ai/) (`brew install ublue-os/tap/lm-studio-linux`) is a graphical alternative — launch it, load a model, enable the local server, then select **LM Studio** in `goose configure`.
+[LM Studio](https://lmstudio.ai/) (`brew install lm-studio`) is a graphical alternative — launch it, load a model, enable the local server, then select **LM Studio** in `goose configure`.
 
 :::tip[On the local network? Use Ghost.]
 


### PR DESCRIPTION
## Summary

Brutal docs audit pass fixing stale references and outdated commands across the documentation site.

### Changes

| File | Action | Details |
|------|--------|---------|
| `lts.mdx` | UPDATE | Fix `ublue-os/bluefin-lts` → `projectbluefin/bluefin-lts` (issue link, repo, clone URL, ghcr.io image tag, hibernation config link) |
| `contributing.md` | UPDATE | Fix image labels `@ublue-os/*` → `@projectbluefin/*`; update CoC link to internal `/code-of-conduct` |
| `local.md` | UPDATE | Fix stale `ublue-os/devcontainer` ref; remove incorrect 'origin points to ublue-os' warning |
| `administration.md` | UPDATE | Update `rpm-ostree kargs` → `bootc kargs` with correct upstream doc link |
| `t2-mac.md` | UPDATE | Fix `/introduction.md` links → `/installation`; update `rpm-ostree kargs` → `bootc kargs`; `rpm-ostree initramfs` → `bootc initramfs` |
| `troubleshooting.mdx` | UPDATE | Fix `ublue-os/tap/linux-mcp-server` → `rhel-lightspeed/tap`; fix LM Studio tap ref; fix Repository label |
| `press-kit.md` | UPDATE | Update Universal Blue parent org description to reflect projectbluefin org migration; update governance links to internal docs pages |

### Verdict for all audited files

- **DELETE**: None — no page is completely useless  
- **analytics.mdx**: Already updated by previous agent (LFX widgets replaced Repobeats) ✅  
- **agentic-contributing.md**: KEEP — comprehensive and correct  
- **ai.md**: KEEP — up to date  
- **artwork.mdx**: KEEP — `ublue-os/artwork` is still the correct repo  
- **bluefin-dx.md**: KEEP — accurate  
- **bluefin-gdx.mdx**: KEEP — accurate  
- **code-of-conduct.md**: KEEP  
- **command-line.md**: KEEP  
- **devcontainers.md**: KEEP — useful devcontainer guide  
- **dinosaurs.md**: KEEP — brand character page, intentional  
- **donations/**: KEEP  
- **downloads.mdx / downloads-testing.mdx**: KEEP  
- **driver-versions.mdx**: KEEP  
- **FAQ.md**: KEEP  
- **gaming.md**: KEEP (thin but correct)  
- **images.md**: KEEP  
- **index.md + introduction.md**: KEEP — serve different purposes (home vs features)  
- **installation.md**: KEEP  
- **knuckle.md**: KEEP — real product, pre-alpha  
- **mission.md + values.md**: KEEP — both needed, not duplicates  
- **music.md**: KEEP  
- **reports.md**: KEEP  
- **tips.mdx**: KEEP  
- **lore.md**: NOT TOUCHED — unlisted, stays hidden  

### Sidebar
No files deleted, sidebar structure unchanged. `images` and `driver-versions` are already in "Using Bluefin" section (visible by default).

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot