### PR TITLE
fix: add search-insights as explicit dep to sync package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.6.0",
+        "search-insights": "^2.17.3",
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
@@ -20477,6 +20478,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
       "license": "MIT"
     },
     "node_modules/section-matter": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.6.0",
+    "search-insights": "^2.17.3",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
search-insights@2.17.3 was missing from the lockfile, causing `npm ci` to fail in CI with Node 24. This was blocking the SBOM workflow and pages.yml builds.

Fix: add search-insights as an explicit dependency so the lockfile includes it consistently across Node versions (22 vs 24).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new runtime dependency to support analytics-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->