### PR TITLE
revert: remove SBOM seed commit step (branch protection blocks push)

### DIFF
--- a/.github/workflows/update-sbom-cache.yml
+++ b/.github/workflows/update-sbom-cache.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
-  contents: write
+  contents: read
   packages: read
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -85,15 +86,3 @@ jobs:
             static/data/sbom-attestations.json
             static/data/sbom-attestations-frontend.json
           key: github-data-sbom-${{ github.run_id }}
-
-      - name: Commit updated SBOM seed files
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet static/data/sbom-attestations.json static/data/sbom-attestations-frontend.json; then
-            echo "No changes to SBOM seed files — skipping commit."
-          else
-            git add static/data/sbom-attestations.json static/data/sbom-attestations-frontend.json
-            git commit -m "chore(sbom): update SBOM attestation seed files [skip ci]"
-            git push origin HEAD:main
-          fi


### PR DESCRIPTION
PR #987 added a commit step to update-sbom-cache.yml to auto-commit the SBOM seed files. However, main has branch protection requiring PRs, so the direct git push fails and the workflow is left in a failed state.

Reverts to the original read-only design. The GHA cache mechanism is the correct data path:
- update-sbom-cache.yml runs nightly → saves fresh SBOM data to GHA cache
- pages.yml restores from cache before building → always builds with current data
- The committed seed files are last-resort fallbacks, not the primary path