### PR TITLE
docs(music): update top section title and playlist order

### DIFF
--- a/docs/music.md
+++ b/docs/music.md
@@ -8,21 +8,33 @@ import styles from '@site/src/components/ExtensionsGrid.module.css';
 
 The Bluefin team releases music playlists regularly. Each song and album has a theme and reason for being included. How do the songs speak to you?
 
-## The Tomorrow Exile
+## Seven Days to the Wolves
 
 The people are out of time, the end is coming. Bluefin and her friends go to war ... 
 
 <div className={styles.extensionsGrid}>
 
 <MusicPlaylist 
-  title="Bluefin: Harbringer"
+  title="Seven Days to the Wolves"
+  playlistId="PLA78oiE-RGAE"
+  variant="card"
+/>
+
+<MusicPlaylist 
+  title="Harbringer: All Shall Burn"
   playlistId="PLDrClbL5OBKY"
   variant="card"
 />
 
 <MusicPlaylist 
-  title="Bluefin: Seven Days to the Wolves"
-  playlistId="PLA78oiE-RGAE"
+  title="Harbringer: Requiem"
+  playlistId="PLhiPP9M5fgWE-xZ4l6hF_-3ESen1x-FNY"
+  variant="card"
+/>
+
+<MusicPlaylist 
+  title="The Forbidden Factory"
+  playlistId="PLbORkyQL0Pe8"
   variant="card"
 />
 

--- a/scripts/fetch-playlist-metadata.js
+++ b/scripts/fetch-playlist-metadata.js
@@ -9,11 +9,19 @@ const YOUTUBE_REQUEST_DELAY_MS = 1500; // Delay between requests to be respectfu
 const PLAYLISTS = [
   {
     id: "PLDrClbL5OBKY",
-    title: "Bluefin: Harbringer",
+    title: "Harbringer: All Shall Burn",
   },
   {
     id: "PLA78oiE-RGAE",
-    title: "Bluefin: Seven Days to the Wolves",
+    title: "Seven Days to the Wolves",
+  },
+  {
+    id: "PLhiPP9M5fgWE-xZ4l6hF_-3ESen1x-FNY",
+    title: "Harbringer: Requiem",
+  },
+  {
+    id: "PLbORkyQL0Pe8",
+    title: "The Forbidden Factory",
   },
   {
     id: "PLhiPP9M5fgWHFlG3TS27gyOCQl4Dg115W",


### PR DESCRIPTION
## Summary
- retitle top music section to Seven Days to the Wolves
- remove Bluefin prefix from that album title
- add Harbringer: Requiem and The Forbidden Factory to the top section
- reorder top section cards to requested left-to-right order
